### PR TITLE
fix: Dockerfile healthcheck does not use HTTP basic auth causing container to show up as unhealthy.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ ENV OWLMAIL_MAIL_DIR=/app/mail
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --quiet --tries=1 -O /dev/null --http-user=$OWLMAIL_WEB_USER --http-password=$OWLMAIL_WEB_PASSWORD http://localhost:1080/healthz || exit 1
+  CMD wget --quiet --tries=1 -O /dev/null http://localhost:1080/healthz || exit 1
 
 # Start application
 ENTRYPOINT ["/app/owlmail"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ ENV OWLMAIL_MAIL_DIR=/app/mail
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:1080/healthz || exit 1
+  CMD wget --quiet --tries=1 -O /dev/null --http-user=$OWLMAIL_WEB_USER --http-password=$OWLMAIL_WEB_PASSWORD http://localhost:1080/healthz || exit 1
 
 # Start application
 ENTRYPOINT ["/app/owlmail"]

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -73,7 +73,7 @@ func (api *API) setupRoutes() {
 
 	// HTTP Basic Auth middleware if configured
 	if api.authUser != "" && api.authPassword != "" {
-		router.Use(basicAuthMiddleware(api.authUser, api.authPassword))
+		router.Use(basicAuthMiddleware(api.authUser, api.authPassword, "/healthz", "/api/v1/health"))
 	}
 
 	// Static files (web UI)

--- a/internal/api/api_middleware.go
+++ b/internal/api/api_middleware.go
@@ -26,8 +26,15 @@ func corsMiddleware() gin.HandlerFunc {
 }
 
 // basicAuthMiddleware creates HTTP Basic Auth middleware
-func basicAuthMiddleware(username, password string) gin.HandlerFunc {
+func basicAuthMiddleware(username, password string, skippedPaths ...string) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		for _, path := range skippedPaths {
+			if c.Request.URL.Path == path {
+				c.Next()
+				return
+			}
+		}
+
 		auth := c.GetHeader("Authorization")
 		if auth == "" {
 			c.Header("WWW-Authenticate", `Basic realm="OwlMail"`)


### PR DESCRIPTION
## Pull Request Description

OwlMail allows setting HTTP basic auth with `OWLMAIL_HTTP_USER` and `OWLMAIL_HTTP_PASSWORD`.
The healthcheck APIs are also protected by HTTP basic auth.
This causes trouble for docker healthcheck command as well as external monitoring systems.

This PR excludes healthcheck APIs from HTTP basic auth (namely `GET /healthz` and `GET /api/v1/health`). The healthcheck command in `Dockerfile` is also adjusted to use `GET` instead of `HEAD` (as implied by `--spider` option) to avoid 404 error.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue without breaking existing functionality)
- [ ] ✨ New feature (adds functionality without breaking existing functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (documentation changes only)
- [ ] 🎨 Code style (formatting, missing semicolons, etc., no code change)
- [ ] ♻️ Code refactoring (code changes that neither fix a bug nor add a feature)
- [ ] ⚡ Performance improvement (code changes that improve performance)
- [x] ✅ Tests (adding or correcting tests)
- [ ] 🔧 Build/tool changes (changes that affect the build system or external dependencies)
- [ ] 🔄 Other (please describe)

## Related Issue

None.

## Change Details

### New Features

None.

### Bug Fixes
- Docker container shows up as `healthy` now.

### Breaking Changes
- `GET /healthz` and `GET /api/v1/health` now requires no authentication.

## Testing

- [x] I have run all existing tests
- [x] I have added new tests to cover my changes
- [x] All tests pass

### Test Commands
```bash
# Please provide commands to run tests
go test ./...
```

### Test Results

```
ok  	github.com/soulteary/owlmail/cmd/owlmail	0.013s
ok  	github.com/soulteary/owlmail/internal/api	1.341s
ok  	github.com/soulteary/owlmail/internal/common	0.006s
ok  	github.com/soulteary/owlmail/internal/maildev	0.008s
ok  	github.com/soulteary/owlmail/internal/mailserver	9.039s
ok  	github.com/soulteary/owlmail/internal/outgoing	9.064s
ok  	github.com/soulteary/owlmail/internal/types	0.007s
```

## Checklist

<!-- Please ensure all items are completed -->

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the relevant documentation
  - There does not seem to be any documentation to update, as the original doc does not describe whether the healthcheck APIs require authentication.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally
- [x] Any dependent changes have been committed and pushed to the respective modules

## Screenshots (if applicable)

None.

## Additional Information

None.