### PR TITLE
feat: forward incoming emails to configurable webhooks

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -38,6 +38,7 @@ OwlMail ist ein SMTP-Server und Web-Interface für Entwicklungs- und Testumgebun
 - ✅ **E-Mail-Persistenz** - E-Mails werden als `.eml`-Dateien gespeichert, unterstützt Laden aus Verzeichnis
 - ✅ **E-Mail-Weiterleitung** - Unterstützt Weiterleitung von E-Mails an echte SMTP-Server
 - ✅ **Auto-Relay** - Unterstützt automatische Weiterleitung aller E-Mails mit Regel-Filterung
+- ✅ **Webhook-Weiterleitung** - Sendet passende neue E-Mails mit benutzerdefinierten Nachrichtenvorlagen an HTTP-Webhooks
 - ✅ **SMTP-Authentifizierung** - Unterstützt PLAIN/LOGIN-Authentifizierung
 - ✅ **TLS/STARTTLS** - Unterstützt verschlüsselte Verbindungen
 - ✅ **SMTPS** - Unterstützt direkte TLS-Verbindung auf Port 465 (OwlMail exklusiv)
@@ -205,6 +206,7 @@ docker buildx build \
 | `-auto-relay` | `MAILDEV_AUTO_RELAY` / `OWLMAIL_AUTO_RELAY` | false | Auto-Relay aktivieren |
 | `-auto-relay-addr` | `MAILDEV_AUTO_RELAY_ADDR` / `OWLMAIL_AUTO_RELAY_ADDR` | - | Auto-Relay-Adresse |
 | `-auto-relay-rules` | `MAILDEV_AUTO_RELAY_RULES` / `OWLMAIL_AUTO_RELAY_RULES` | - | Auto-Relay-Regeldatei |
+| `-webhook-config` | `OWLMAIL_WEBHOOK_CONFIG` | - | JSON-Konfigurationsdatei für Webhook-Weiterleitung |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | SMTP-Authentifizierungsbenutzername |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | SMTP-Authentifizierungspasswort |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | SMTP TLS aktivieren |

--- a/README.fr.md
+++ b/README.fr.md
@@ -38,6 +38,7 @@ OwlMail is an SMTP server and web interface for development and testing environm
 - ✅ **Email Persistence** - Emails saved as `.eml` files, supports loading from directory
 - ✅ **Email Relay** - Supports forwarding emails to real SMTP servers
 - ✅ **Auto Relay** - Supports automatically forwarding all emails with rule filtering
+- ✅ **Webhook Forwarding** - Sends matching new emails to HTTP webhooks with custom message templates
 - ✅ **SMTP Authentication** - Supports PLAIN/LOGIN authentication
 - ✅ **TLS/STARTTLS** - Supports encrypted connections
 - ✅ **SMTPS** - Supports direct TLS connection on port 465 (OwlMail exclusive)
@@ -205,6 +206,7 @@ docker buildx build \
 | `-auto-relay` | `MAILDEV_AUTO_RELAY` / `OWLMAIL_AUTO_RELAY` | false | Enable auto relay |
 | `-auto-relay-addr` | `MAILDEV_AUTO_RELAY_ADDR` / `OWLMAIL_AUTO_RELAY_ADDR` | - | Auto relay address |
 | `-auto-relay-rules` | `MAILDEV_AUTO_RELAY_RULES` / `OWLMAIL_AUTO_RELAY_RULES` | - | Auto relay rules file |
+| `-webhook-config` | `OWLMAIL_WEBHOOK_CONFIG` | - | JSON webhook forwarding configuration file |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | SMTP authentication username |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | SMTP authentication password |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | Enable SMTP TLS |

--- a/README.it.md
+++ b/README.it.md
@@ -38,6 +38,7 @@ OwlMail è un server SMTP e un'interfaccia web per ambienti di sviluppo e test c
 - ✅ **Persistenza Email** - Le email vengono salvate come file `.eml`, supporta il caricamento da directory
 - ✅ **Inoltro Email** - Supporta l'inoltro di email a server SMTP reali
 - ✅ **Inoltro Automatico** - Supporta l'inoltro automatico di tutte le email con filtri basati su regole
+- ✅ **Inoltro Webhook** - Invia le nuove email corrispondenti a webhook HTTP con modelli di messaggio personalizzati
 - ✅ **Autenticazione SMTP** - Supporta autenticazione PLAIN/LOGIN
 - ✅ **TLS/STARTTLS** - Supporta connessioni crittografate
 - ✅ **SMTPS** - Supporta connessione TLS diretta sulla porta 465 (esclusivo OwlMail)
@@ -205,6 +206,7 @@ docker buildx build \
 | `-auto-relay` | `MAILDEV_AUTO_RELAY` / `OWLMAIL_AUTO_RELAY` | false | Abilita inoltro automatico |
 | `-auto-relay-addr` | `MAILDEV_AUTO_RELAY_ADDR` / `OWLMAIL_AUTO_RELAY_ADDR` | - | Indirizzo inoltro automatico |
 | `-auto-relay-rules` | `MAILDEV_AUTO_RELAY_RULES` / `OWLMAIL_AUTO_RELAY_RULES` | - | File regole inoltro automatico |
+| `-webhook-config` | `OWLMAIL_WEBHOOK_CONFIG` | - | File JSON di configurazione dell'inoltro webhook |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | Nome utente autenticazione SMTP |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | Password autenticazione SMTP |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | Abilita TLS SMTP |

--- a/README.ja.md
+++ b/README.ja.md
@@ -38,6 +38,7 @@ OwlMail is an SMTP server and web interface for development and testing environm
 - ✅ **Email Persistence** - Emails saved as `.eml` files, supports loading from directory
 - ✅ **Email Relay** - Supports forwarding emails to real SMTP servers
 - ✅ **Auto Relay** - Supports automatically forwarding all emails with rule filtering
+- ✅ **Webhook Forwarding** - Sends matching new emails to HTTP webhooks with custom message templates
 - ✅ **SMTP Authentication** - Supports PLAIN/LOGIN authentication
 - ✅ **TLS/STARTTLS** - Supports encrypted connections
 - ✅ **SMTPS** - Supports direct TLS connection on port 465 (OwlMail exclusive)
@@ -205,6 +206,7 @@ docker buildx build \
 | `-auto-relay` | `MAILDEV_AUTO_RELAY` / `OWLMAIL_AUTO_RELAY` | false | Enable auto relay |
 | `-auto-relay-addr` | `MAILDEV_AUTO_RELAY_ADDR` / `OWLMAIL_AUTO_RELAY_ADDR` | - | Auto relay address |
 | `-auto-relay-rules` | `MAILDEV_AUTO_RELAY_RULES` / `OWLMAIL_AUTO_RELAY_RULES` | - | Auto relay rules file |
+| `-webhook-config` | `OWLMAIL_WEBHOOK_CONFIG` | - | JSON webhook forwarding configuration file |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | SMTP authentication username |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | SMTP authentication password |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | Enable SMTP TLS |

--- a/README.ko.md
+++ b/README.ko.md
@@ -38,6 +38,7 @@ OwlMail is an SMTP server and web interface for development and testing environm
 - ✅ **Email Persistence** - Emails saved as `.eml` files, supports loading from directory
 - ✅ **Email Relay** - Supports forwarding emails to real SMTP servers
 - ✅ **Auto Relay** - Supports automatically forwarding all emails with rule filtering
+- ✅ **Webhook Forwarding** - Sends matching new emails to HTTP webhooks with custom message templates
 - ✅ **SMTP Authentication** - Supports PLAIN/LOGIN authentication
 - ✅ **TLS/STARTTLS** - Supports encrypted connections
 - ✅ **SMTPS** - Supports direct TLS connection on port 465 (OwlMail exclusive)
@@ -205,6 +206,7 @@ docker buildx build \
 | `-auto-relay` | `MAILDEV_AUTO_RELAY` / `OWLMAIL_AUTO_RELAY` | false | Enable auto relay |
 | `-auto-relay-addr` | `MAILDEV_AUTO_RELAY_ADDR` / `OWLMAIL_AUTO_RELAY_ADDR` | - | Auto relay address |
 | `-auto-relay-rules` | `MAILDEV_AUTO_RELAY_RULES` / `OWLMAIL_AUTO_RELAY_RULES` | - | Auto relay rules file |
+| `-webhook-config` | `OWLMAIL_WEBHOOK_CONFIG` | - | JSON webhook forwarding configuration file |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | SMTP authentication username |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | SMTP authentication password |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | Enable SMTP TLS |

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ OwlMail is an SMTP server and web interface for development and testing environm
 - ✅ **Email Persistence** - Emails saved as `.eml` files, supports loading from directory
 - ✅ **Email Relay** - Supports forwarding emails to real SMTP servers
 - ✅ **Auto Relay** - Supports automatically forwarding all emails with rule filtering
+- ✅ **Webhook Forwarding** - Sends matching new emails to generic HTTP webhooks with custom payload templates
 - ✅ **SMTP Authentication** - Supports PLAIN/LOGIN authentication
 - ✅ **TLS/STARTTLS** - Supports encrypted connections
 - ✅ **SMTPS** - Supports direct TLS connection on port 465 (OwlMail exclusive)
@@ -202,6 +203,7 @@ docker buildx build \
 | `-auto-relay` | `MAILDEV_AUTO_RELAY` / `OWLMAIL_AUTO_RELAY` | false | Enable auto relay |
 | `-auto-relay-addr` | `MAILDEV_AUTO_RELAY_ADDR` / `OWLMAIL_AUTO_RELAY_ADDR` | - | Auto relay address |
 | `-auto-relay-rules` | `MAILDEV_AUTO_RELAY_RULES` / `OWLMAIL_AUTO_RELAY_RULES` | - | Auto relay rules file |
+| `-webhook-config` | `OWLMAIL_WEBHOOK_CONFIG` | - | JSON webhook forwarding configuration file |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | SMTP authentication username |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | SMTP authentication password |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | Enable SMTP TLS |
@@ -404,6 +406,15 @@ EOF
   -auto-relay \
   -auto-relay-rules relay-rules.json
 ```
+
+### Webhook Forwarding
+
+```bash
+export OWLMAIL_WEBHOOK_SECRET='replace-with-a-random-secret'
+./owlmail -webhook-config ./examples/webhooks.json
+```
+
+Webhook targets support case-insensitive wildcard rules, custom JSON-safe body templates, environment-backed secrets, HMAC-SHA256 signatures, timeouts, and bounded retries. See the [Webhook forwarding guide](./docs/en/Webhook-Forwarding.md), including a ready-to-use `soulteary/webhook` example.
 
 ### Using HTTPS
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,6 +35,7 @@ OwlMail 是一个用于开发和测试环境的 SMTP 服务器和 Web 界面，�
 - ✅ **邮件持久化** - 邮件保存为 `.eml` 文件，支持从目录加载
 - ✅ **邮件转发** - 支持将邮件转发到真实的 SMTP 服务器
 - ✅ **自动中继** - 支持自动转发所有邮件，带规则过滤
+- ✅ **Webhook 消息转发** - 按规则把新邮件转换为自定义消息并发送到通用 HTTP Webhook
 - ✅ **SMTP 认证** - 支持 PLAIN/LOGIN 认证
 - ✅ **TLS/STARTTLS** - 支持加密连接
 - ✅ **SMTPS** - 支持端口 465 的直接 TLS 连接（OwlMail 独有）
@@ -202,6 +203,7 @@ docker buildx build \
 | `-auto-relay` | `MAILDEV_AUTO_RELAY` / `OWLMAIL_AUTO_RELAY` | false | 启用自动中继 |
 | `-auto-relay-addr` | `MAILDEV_AUTO_RELAY_ADDR` / `OWLMAIL_AUTO_RELAY_ADDR` | - | 自动中继地址 |
 | `-auto-relay-rules` | `MAILDEV_AUTO_RELAY_RULES` / `OWLMAIL_AUTO_RELAY_RULES` | - | 自动中继规则文件 |
+| `-webhook-config` | `OWLMAIL_WEBHOOK_CONFIG` | - | Webhook 消息转发 JSON 配置文件 |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | SMTP 认证用户名 |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | SMTP 认证密码 |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | 启用 SMTP TLS |
@@ -404,6 +406,15 @@ EOF
   -auto-relay \
   -auto-relay-rules relay-rules.json
 ```
+
+### Webhook 消息转发
+
+```bash
+export OWLMAIL_WEBHOOK_SECRET='请替换为随机密钥'
+./owlmail -webhook-config ./examples/webhooks.json
+```
+
+Webhook 目标支持不区分大小写的通配规则、JSON 安全的自定义请求体模板、环境变量密钥、HMAC-SHA256 签名、超时和有限重试。完整配置和 `soulteary/webhook` 对接方式见 [Webhook 消息转发指南](./docs/zh-CN/Webhook-Forwarding.md)。
 
 ### 使用 HTTPS
 

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"github.com/soulteary/owlmail/internal/config"
 	"github.com/soulteary/owlmail/internal/mailserver"
 	"github.com/soulteary/owlmail/internal/outgoing"
+	webhooknotify "github.com/soulteary/owlmail/internal/webhook"
 )
 
 // parseLogLevel parses log level string and returns LogLevel
@@ -119,6 +121,38 @@ func registerEventHandlers(server *mailserver.MailServer) {
 	})
 }
 
+func setupWebhookDispatcher(cfg *config.Config) (*webhooknotify.Dispatcher, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config is nil")
+	}
+	if cfg.WebhookConfig == "" {
+		return nil, nil
+	}
+
+	dispatcher, err := webhooknotify.Load(cfg.WebhookConfig, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load webhook forwarding config: %w", err)
+	}
+	return dispatcher, nil
+}
+
+func registerWebhookHandler(server *mailserver.MailServer, dispatcher *webhooknotify.Dispatcher) {
+	if server == nil || dispatcher == nil {
+		return
+	}
+
+	server.On("new", func(email *mailserver.Email) {
+		for _, result := range dispatcher.Dispatch(context.Background(), email) {
+			if result.Err != nil {
+				common.Error("Webhook delivery to %q failed after %d attempt(s): %v", result.Target, result.Attempts, result.Err)
+				continue
+			}
+			common.Verbose("Webhook delivery to %q succeeded with HTTP %d", result.Target, result.StatusCode)
+		}
+	})
+	common.Log("Webhook forwarding enabled with %d target(s)", dispatcher.TargetCount())
+}
+
 // startAPIServer creates and starts the API server
 func startAPIServer(server *mailserver.MailServer, cfg *config.Config) (*api.API, error) {
 	if server == nil {
@@ -189,6 +223,12 @@ func createMailServer(cfg *config.Config) (*mailserver.MailServer, error) {
 		return nil, fmt.Errorf("config is nil")
 	}
 
+	// Validate and compile webhook configuration before starting server resources.
+	webhookDispatcher, err := setupWebhookDispatcher(cfg)
+	if err != nil {
+		return nil, err
+	}
+
 	// Setup outgoing mail config if provided
 	outgoingConfig, err := setupOutgoingConfig(cfg)
 	if err != nil {
@@ -209,6 +249,7 @@ func createMailServer(cfg *config.Config) (*mailserver.MailServer, error) {
 
 	// Register event handlers
 	registerEventHandlers(server)
+	registerWebhookHandler(server, webhookDispatcher)
 
 	return server, nil
 }

--- a/cmd/owlmail/main_test.go
+++ b/cmd/owlmail/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"sync"
@@ -13,6 +15,7 @@ import (
 	"github.com/soulteary/owlmail/internal/common"
 	"github.com/soulteary/owlmail/internal/config"
 	"github.com/soulteary/owlmail/internal/mailserver"
+	webhooknotify "github.com/soulteary/owlmail/internal/webhook"
 )
 
 // loggerEventTestMu serializes tests that use common.InitLogger or registerEventHandlers,
@@ -262,6 +265,77 @@ func TestSetupOutgoingConfig(t *testing.T) {
 	if err == nil {
 		t.Error("setupOutgoingConfig() error = nil, want error")
 	}
+}
+
+func TestSetupWebhookDispatcher(t *testing.T) {
+	if _, err := setupWebhookDispatcher(nil); err == nil {
+		t.Fatal("setupWebhookDispatcher(nil) should fail")
+	}
+
+	dispatcher, err := setupWebhookDispatcher(&config.Config{})
+	if err != nil || dispatcher != nil {
+		t.Fatalf("empty setupWebhookDispatcher() = %v, %v", dispatcher, err)
+	}
+
+	filePath := filepath.Join(t.TempDir(), "webhooks.json")
+	if err := os.WriteFile(filePath, []byte(`{"version":1,"targets":[{"name":"test","url":"https://example.com/hook"}]}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	dispatcher, err = setupWebhookDispatcher(&config.Config{WebhookConfig: filePath})
+	if err != nil {
+		t.Fatalf("setupWebhookDispatcher() error = %v", err)
+	}
+	if dispatcher.TargetCount() != 1 {
+		t.Fatalf("TargetCount() = %d", dispatcher.TargetCount())
+	}
+
+	if _, err := setupWebhookDispatcher(&config.Config{WebhookConfig: filepath.Join(t.TempDir(), "missing.json")}); err == nil {
+		t.Fatal("missing webhook config should fail")
+	}
+}
+
+func TestRegisterWebhookHandlerDispatchesNewEmail(t *testing.T) {
+	received := make(chan struct{}, 1)
+	hookServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		received <- struct{}{}
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer hookServer.Close()
+
+	dispatcher, err := webhooknotify.NewDispatcher(webhooknotify.Config{Targets: []webhooknotify.Target{{
+		Name: "test",
+		URL:  hookServer.URL,
+	}}}, hookServer.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, err := mailserver.NewMailServer(1025, "localhost", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	registerWebhookHandler(server, dispatcher)
+
+	email := &mailserver.Email{Subject: "Webhook integration"}
+	envelope := &mailserver.Envelope{From: "sender@example.com", To: []string{"recipient@example.com"}}
+	if err := server.SaveEmailToStore("webhook-test", false, envelope, email); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-received:
+	case <-time.After(time.Second):
+		t.Fatal("webhook request was not received")
+	}
+}
+
+func TestRegisterWebhookHandlerHandlesNil(t *testing.T) {
+	registerWebhookHandler(nil, nil)
+	server, err := mailserver.NewMailServer(1025, "localhost", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	registerWebhookHandler(server, nil)
 }
 
 func TestSetupAuthConfig(t *testing.T) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Select your preferred language:
 
 - [OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper](./en/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [API Refactoring Record](./en/internal/API_Refactoring_Record.md)
+- [Webhook Forwarding](./en/Webhook-Forwarding.md)
 
 ---
 
@@ -37,6 +38,7 @@ Select your preferred language:
 
 - [OwlMail × MailDev - 功能与 API 完整对比与迁移白皮书](./zh-CN/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [API 重构记录](./zh-CN/internal/API_Refactoring_Record.md)
+- [Webhook 消息转发](./zh-CN/Webhook-Forwarding.md)
 
 ---
 

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -14,6 +14,9 @@ Willkommen im OwlMail-Dokumentationsverzeichnis. Dieses Verzeichnis enthält tec
 
 ### Hauptdokumente
 
+- **[Webhook-Weiterleitung](../en/Webhook-Forwarding.md)** (Englisch, [中文](../zh-CN/Webhook-Forwarding.md))
+  - Regeln, benutzerdefinierte Nachrichten, HMAC-Signaturen und die Integration mit `soulteary/webhook` konfigurieren.
+
 - **[OwlMail × MailDev - Vollständiger Funktions- und API-Vergleich sowie Migrations-Whitepaper](./OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)** (Englisch)
   - [中文版本](../zh-CN/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
   - Ein umfassender Vergleich zwischen OwlMail und MailDev, einschließlich API-Kompatibilität, Funktionsparität und Migrationsleitfaden.

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -20,6 +20,10 @@ Welcome to the OwlMail documentation directory. This directory contains technica
 
 ### Main Documents
 
+- **[Webhook Forwarding](./Webhook-Forwarding.md)**
+  - Configure filtering, custom payload templates, HMAC signatures, retries, and integration with `soulteary/webhook`.
+  - **Other languages**: [简体中文](../zh-CN/Webhook-Forwarding.md)
+
 - **[OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper](./OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)**
   - A comprehensive comparison between OwlMail and MailDev, including API compatibility, feature parity, and migration guide.
   - **Other languages**: [简体中文](../zh-CN/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md) | [Deutsch](../de/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md) | [Français](../fr/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md) | [Italiano](../it/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md) | [日本語](../ja/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md) | [한국어](../ko/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)

--- a/docs/en/Webhook-Forwarding.md
+++ b/docs/en/Webhook-Forwarding.md
@@ -1,0 +1,184 @@
+# Webhook forwarding
+
+OwlMail can send every matching new email to one or more HTTP endpoints. The feature is configured at startup, runs on the server even when no browser is open, and does not alter MailDev-compatible APIs.
+
+## Enable forwarding
+
+Create a JSON file and pass it to OwlMail:
+
+```bash
+export OWLMAIL_WEBHOOK_SECRET='replace-with-a-random-secret'
+./owlmail -webhook-config ./webhooks.json
+```
+
+The environment variable form is equivalent:
+
+```bash
+export OWLMAIL_WEBHOOK_CONFIG=./webhooks.json
+```
+
+See [`examples/webhooks.json`](../../examples/webhooks.json) for a complete configuration.
+
+## Configuration format
+
+```json
+{
+  "version": 1,
+  "targets": [
+    {
+      "name": "notifications",
+      "url": "https://notify.example.com/hooks/owlmail",
+      "method": "POST",
+      "headers": {
+        "Authorization": "Bearer ${OWLMAIL_WEBHOOK_TOKEN}"
+      },
+      "contentType": "application/json",
+      "secret": "${OWLMAIL_WEBHOOK_SECRET}",
+      "timeout": "5s",
+      "retries": 2,
+      "match": {
+        "from": ["*@example.com"],
+        "to": ["alerts@*"],
+        "subject": ["*alert*", "*verification*"],
+        "text": ["*code*"]
+      },
+      "bodyTemplate": "{\"title\":{{ json .Subject }},\"message\":{{ json .Text }}}"
+    }
+  ]
+}
+```
+
+| Field | Required | Behavior |
+|---|---:|---|
+| `version` | No | Configuration version. Omitted and `1` both mean version 1. |
+| `targets` | Yes | One to 32 destinations. Target names must be unique. |
+| `name` | Yes | Safe identifier used in logs; the full URL and configured secrets are never logged. |
+| `url` | Yes | Fixed `http` or `https` URL. Redirects are not followed. |
+| `method` | No | `POST` by default; `POST`, `PUT`, and `PATCH` are accepted. |
+| `headers` | No | Static request headers. `Host` and `Content-Length` cannot be overridden. |
+| `contentType` | No | `application/json` by default. An explicit `Content-Type` header takes precedence. |
+| `secret` | No | Generates `X-OwlMail-Signature: sha256=<hex>` over the exact request body. |
+| `timeout` | No | Per-attempt timeout; default `5s`, maximum `1m`. |
+| `retries` | No | Extra attempts from zero to five. Only network errors, 408, 425, 429, and 5xx responses are retried. |
+| `match` | No | Case-insensitive wildcard rules. See the rule semantics below. |
+| `bodyTemplate` | No | Go text template for a custom body. When omitted, OwlMail sends the default event payload. |
+
+`${VARIABLE}` placeholders are supported in `url`, header values, and `secret`. OwlMail fails at startup if a referenced variable is missing, rather than silently sending an unauthenticated request.
+
+## Matching rules
+
+The `from`, `to`, `subject`, and `text` fields accept arrays of shell-style patterns using `*` and `?`.
+
+- Patterns inside one field are ORed.
+- Different non-empty fields are ANDed.
+- Empty fields match every email.
+- Matching is case-insensitive.
+- `to` considers envelope recipients as well as To, Cc, and Bcc headers.
+
+For example, this rule forwards alerts from any `example.com` sender only when their text contains a verification code:
+
+```json
+{
+  "from": ["*@example.com"],
+  "subject": ["*alert*", "*verification*"],
+  "text": ["*code*"]
+}
+```
+
+## Custom body templates
+
+Templates receive these fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| `.ID`, `.Subject`, `.Text`, `.HTML` | string | Email identifier and content. |
+| `.Time` | time | Parsed or received timestamp. |
+| `.From`, `.To`, `.CC`, `.BCC` | string arrays | Parsed addresses without display names. |
+| `.EnvelopeFrom`, `.EnvelopeTo` | string / string array | SMTP envelope addresses. |
+| `.Size`, `.SizeHuman` | number / string | Stored message size. |
+| `.Attachments`, `.AttachmentCount` | array / number | Safe attachment metadata; attachment bodies and local paths are not exposed. |
+| `.Headers` | map | Parsed headers, available only to an explicit template. |
+
+Available helpers are:
+
+- `json VALUE`: JSON-encode a value so quotes and newlines cannot break the request body.
+- `join STRINGS SEPARATOR`: join an address array.
+- `truncate STRING LENGTH`: truncate by Unicode code points.
+
+Always use `json` when placing email-controlled text into JSON:
+
+```json
+"bodyTemplate": "{\"title\":{{ json .Subject }},\"message\":{{ json (truncate .Text 4000) }}}"
+```
+
+Without a template, OwlMail sends:
+
+```json
+{
+  "event": "email.received",
+  "message": "Subject followed by plain-text content",
+  "email": {
+    "id": "email-id",
+    "subject": "Example",
+    "from": ["sender@example.com"],
+    "to": ["recipient@example.com"],
+    "text": "Message body"
+  }
+}
+```
+
+The exact email ID is also sent as `X-OwlMail-Email-ID`, which receivers can use as an idempotency key when retries produce a duplicate request.
+
+## Send to `soulteary/webhook`
+
+Use the hook URL exposed by [`soulteary/webhook`](https://github.com/soulteary/webhook):
+
+```json
+{
+  "version": 1,
+  "targets": [
+    {
+      "name": "automation",
+      "url": "http://webhook:9000/hooks/owlmail",
+      "secret": "${OWLMAIL_WEBHOOK_SECRET}",
+      "bodyTemplate": "{\"message\":{{ json .Text }},\"title\":{{ json .Subject }},\"emailId\":{{ json .ID }}}"
+    }
+  ]
+}
+```
+
+One matching `soulteary/webhook` hook configuration is:
+
+```json
+[
+  {
+    "id": "owlmail",
+    "execute-command": "/app/notify.sh",
+    "incoming-payload-content-type": "application/json",
+    "http-methods": ["POST"],
+    "pass-environment-to-command": [
+      { "source": "payload", "name": "message", "envname": "OWLMAIL_MESSAGE" },
+      { "source": "payload", "name": "title", "envname": "OWLMAIL_TITLE" },
+      { "source": "payload", "name": "emailId", "envname": "OWLMAIL_EMAIL_ID" }
+    ],
+    "trigger-rule": {
+      "match": {
+        "type": "payload-hmac-sha256",
+        "secret": "{{ getenv \"OWLMAIL_WEBHOOK_SECRET\" | js }}",
+        "parameter": { "source": "header", "name": "X-OwlMail-Signature" }
+      }
+    }
+  }
+]
+```
+
+Start `soulteary/webhook` with its `-template` option when using `getenv` in the hook file. Give both containers the same `OWLMAIL_WEBHOOK_SECRET` value.
+
+## Operational and security notes
+
+- Webhook targets receive email content. Only configure destinations you trust.
+- Prefer HTTPS outside a private container network and HMAC-sign every request.
+- Keep the configuration file private (for example, mode `0600`) and put tokens in environment variables.
+- A successful response is any 2xx status. Redirects and other non-2xx responses are failures.
+- Delivery is asynchronous relative to SMTP storage. A failed webhook does not reject or delete the received email.
+- Retries can duplicate a request. Deduplicate with `email.id` or `X-OwlMail-Email-ID` before performing non-idempotent actions.

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -14,6 +14,9 @@ Bienvenue dans le répertoire de documentation OwlMail. Ce répertoire contient 
 
 ### Documents principaux
 
+- **[Transfert Webhook](../en/Webhook-Forwarding.md)** (Anglais, [中文](../zh-CN/Webhook-Forwarding.md))
+  - Configurer les règles, les messages personnalisés, les signatures HMAC et l'intégration avec `soulteary/webhook`.
+
 - **[OwlMail × MailDev - Livre blanc complet sur les fonctionnalités, l'API et la migration](./OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)** (Anglais)
   - [中文版本](../zh-CN/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
   - Une comparaison complète entre OwlMail et MailDev, incluant la compatibilité API, la parité des fonctionnalités et le guide de migration.

--- a/docs/it/README.md
+++ b/docs/it/README.md
@@ -14,6 +14,9 @@ Benvenuto nella directory della documentazione OwlMail. Questa directory contien
 
 ### Documenti principali
 
+- **[Inoltro Webhook](../en/Webhook-Forwarding.md)** (Inglese, [中文](../zh-CN/Webhook-Forwarding.md))
+  - Configurazione di regole, messaggi personalizzati, firme HMAC e integrazione con `soulteary/webhook`.
+
 - **[OwlMail × MailDev - Libro bianco completo su funzionalità, API e migrazione](./OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)** (Inglese)
   - [中文版本](../zh-CN/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
   - Un confronto completo tra OwlMail e MailDev, inclusa la compatibilità API, la parità delle funzionalità e la guida alla migrazione.

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -14,6 +14,9 @@ OwlMail ドキュメントディレクトリへようこそ。このディレク
 
 ### メインドキュメント
 
+- **[Webhook 転送](../en/Webhook-Forwarding.md)** (英語、[中文](../zh-CN/Webhook-Forwarding.md))
+  - ルール、カスタムメッセージ、HMAC 署名、`soulteary/webhook` 連携の設定方法。
+
 - **[OwlMail × MailDev - 機能と API の完全比較および移行ホワイトペーパー](./OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)** (英語)
   - [中文版本](../zh-CN/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
   - OwlMail と MailDev の包括的な比較。API 互換性、機能パリティ、移行ガイドを含みます。

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -14,6 +14,9 @@ OwlMail 문서 디렉토리에 오신 것을 환영합니다. 이 디렉토리�
 
 ### 주요 문서
 
+- **[Webhook 전달](../en/Webhook-Forwarding.md)** (영어, [中文](../zh-CN/Webhook-Forwarding.md))
+  - 규칙, 사용자 지정 메시지, HMAC 서명 및 `soulteary/webhook` 연동 구성 방법.
+
 - **[OwlMail × MailDev - 전체 기능 및 API 비교 및 마이그레이션 백서](./OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)** (영어)
   - [中文版本](../zh-CN/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
   - OwlMail과 MailDev 간의 포괄적인 비교, API 호환성, 기능 패리티 및 마이그레이션 가이드를 포함합니다.

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -20,6 +20,10 @@
 
 ### 主要文档
 
+- **[Webhook 消息转发](./Webhook-Forwarding.md)**
+  - 配置邮件过滤、自定义消息模板、HMAC 签名、失败重试，以及与 `soulteary/webhook` 的对接。
+  - **其他语言**：[English](../en/Webhook-Forwarding.md)
+
 - **[OwlMail × MailDev - 功能与 API 完整对比与迁移白皮书](./OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)**
   - OwlMail 与 MailDev 的全面对比，包括 API 兼容性、功能对等性和迁移指南。
   - **其他语言**: [English](../en/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md) | [Deutsch](../de/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md) | [Français](../fr/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md) | [Italiano](../it/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md) | [日本語](../ja/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md) | [한국어](../ko/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)

--- a/docs/zh-CN/Webhook-Forwarding.md
+++ b/docs/zh-CN/Webhook-Forwarding.md
@@ -1,0 +1,184 @@
+# Webhook 消息转发
+
+OwlMail 可以把符合规则的新邮件发送到一个或多个 HTTP 端点。该能力在服务端运行，不要求浏览器保持打开，也不会改变 MailDev 兼容 API。
+
+## 开启转发
+
+创建 JSON 配置文件，并在启动时传给 OwlMail：
+
+```bash
+export OWLMAIL_WEBHOOK_SECRET='请替换为随机密钥'
+./owlmail -webhook-config ./webhooks.json
+```
+
+也可以使用等价的环境变量：
+
+```bash
+export OWLMAIL_WEBHOOK_CONFIG=./webhooks.json
+```
+
+完整示例见 [`examples/webhooks.json`](../../examples/webhooks.json)。
+
+## 配置格式
+
+```json
+{
+  "version": 1,
+  "targets": [
+    {
+      "name": "notifications",
+      "url": "https://notify.example.com/hooks/owlmail",
+      "method": "POST",
+      "headers": {
+        "Authorization": "Bearer ${OWLMAIL_WEBHOOK_TOKEN}"
+      },
+      "contentType": "application/json",
+      "secret": "${OWLMAIL_WEBHOOK_SECRET}",
+      "timeout": "5s",
+      "retries": 2,
+      "match": {
+        "from": ["*@example.com"],
+        "to": ["alerts@*"],
+        "subject": ["*alert*", "*验证码*"],
+        "text": ["*code*", "*验证码*"]
+      },
+      "bodyTemplate": "{\"title\":{{ json .Subject }},\"message\":{{ json .Text }}}"
+    }
+  ]
+}
+```
+
+| 字段 | 必需 | 行为 |
+|---|---:|---|
+| `version` | 否 | 配置版本；省略或设置为 `1` 都表示版本 1。 |
+| `targets` | 是 | 1～32 个目标，目标名称必须唯一。 |
+| `name` | 是 | 仅用于日志的安全标识；完整 URL 和配置密钥不会写入日志。 |
+| `url` | 是 | 固定的 `http` 或 `https` 地址；不会跟随重定向。 |
+| `method` | 否 | 默认 `POST`，支持 `POST`、`PUT`、`PATCH`。 |
+| `headers` | 否 | 静态请求头；不能覆盖 `Host` 和 `Content-Length`。 |
+| `contentType` | 否 | 默认 `application/json`；显式 `Content-Type` 请求头优先。 |
+| `secret` | 否 | 对最终请求体生成 `X-OwlMail-Signature: sha256=<hex>`。 |
+| `timeout` | 否 | 每次请求的超时，默认 `5s`，最大 `1m`。 |
+| `retries` | 否 | 0～5 次额外尝试；仅网络错误、408、425、429 和 5xx 会重试。 |
+| `match` | 否 | 不区分大小写的通配符规则，语义见下文。 |
+| `bodyTemplate` | 否 | 自定义请求体的 Go 文本模板；省略时发送默认事件结构。 |
+
+`url`、请求头值和 `secret` 支持 `${VARIABLE}` 占位符。如果变量不存在，OwlMail 会在启动阶段报错，不会静默发送缺少鉴权信息的请求。
+
+## 匹配规则
+
+`from`、`to`、`subject`、`text` 支持含 `*`、`?` 的通配符数组：
+
+- 同一个字段内的多个规则是“或”关系；
+- 多个非空字段之间是“且”关系；
+- 空字段匹配所有邮件；
+- 匹配不区分大小写；
+- `to` 同时检查 SMTP 信封收件人，以及 To、Cc、Bcc 邮件头。
+
+例如，下面的规则只转发来自 `example.com`、主题为告警或验证码、正文包含验证码的邮件：
+
+```json
+{
+  "from": ["*@example.com"],
+  "subject": ["*alert*", "*验证码*"],
+  "text": ["*code*", "*验证码*"]
+}
+```
+
+## 自定义请求体
+
+模板可使用以下字段：
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `.ID`、`.Subject`、`.Text`、`.HTML` | 字符串 | 邮件标识和内容。 |
+| `.Time` | 时间 | 邮件头时间或接收时间。 |
+| `.From`、`.To`、`.CC`、`.BCC` | 字符串数组 | 不带显示名称的解析后地址。 |
+| `.EnvelopeFrom`、`.EnvelopeTo` | 字符串 / 字符串数组 | SMTP 信封地址。 |
+| `.Size`、`.SizeHuman` | 数值 / 字符串 | 已保存邮件的大小。 |
+| `.Attachments`、`.AttachmentCount` | 数组 / 数值 | 安全的附件元数据；不暴露附件正文和本地路径。 |
+| `.Headers` | 映射 | 解析后的邮件头，仅在显式模板中可用。 |
+
+模板函数：
+
+- `json VALUE`：把值安全编码为 JSON，避免引号或换行破坏请求结构；
+- `join STRINGS SEPARATOR`：连接地址数组；
+- `truncate STRING LENGTH`：按 Unicode 字符数截断文本。
+
+把邮件内容写进 JSON 时，应始终使用 `json`：
+
+```json
+"bodyTemplate": "{\"title\":{{ json .Subject }},\"message\":{{ json (truncate .Text 4000) }}}"
+```
+
+未配置模板时，默认发送：
+
+```json
+{
+  "event": "email.received",
+  "message": "主题和纯文本正文",
+  "email": {
+    "id": "email-id",
+    "subject": "示例",
+    "from": ["sender@example.com"],
+    "to": ["recipient@example.com"],
+    "text": "邮件正文"
+  }
+}
+```
+
+请求头还会包含 `X-OwlMail-Email-ID`。接收端可用它作为幂等键，处理重试造成的重复请求。
+
+## 发送到 `soulteary/webhook`
+
+把目标地址设置为 [`soulteary/webhook`](https://github.com/soulteary/webhook) 提供的 Hook 地址：
+
+```json
+{
+  "version": 1,
+  "targets": [
+    {
+      "name": "automation",
+      "url": "http://webhook:9000/hooks/owlmail",
+      "secret": "${OWLMAIL_WEBHOOK_SECRET}",
+      "bodyTemplate": "{\"message\":{{ json .Text }},\"title\":{{ json .Subject }},\"emailId\":{{ json .ID }}}"
+    }
+  ]
+}
+```
+
+对应的 `soulteary/webhook` Hook 配置示例：
+
+```json
+[
+  {
+    "id": "owlmail",
+    "execute-command": "/app/notify.sh",
+    "incoming-payload-content-type": "application/json",
+    "http-methods": ["POST"],
+    "pass-environment-to-command": [
+      { "source": "payload", "name": "message", "envname": "OWLMAIL_MESSAGE" },
+      { "source": "payload", "name": "title", "envname": "OWLMAIL_TITLE" },
+      { "source": "payload", "name": "emailId", "envname": "OWLMAIL_EMAIL_ID" }
+    ],
+    "trigger-rule": {
+      "match": {
+        "type": "payload-hmac-sha256",
+        "secret": "{{ getenv \"OWLMAIL_WEBHOOK_SECRET\" | js }}",
+        "parameter": { "source": "header", "name": "X-OwlMail-Signature" }
+      }
+    }
+  }
+]
+```
+
+Hook 文件使用 `getenv` 时，需要用 `-template` 参数启动 `soulteary/webhook`。两个容器应配置相同的 `OWLMAIL_WEBHOOK_SECRET`。
+
+## 运行与安全边界
+
+- Webhook 目标会收到邮件内容，只能配置可信目的地；
+- 容器私网之外优先使用 HTTPS，并使用 HMAC 签名；
+- 配置文件建议设置为 `0600`，Token 和密钥通过环境变量传入；
+- 任意 2xx 都视为成功；重定向和其他非 2xx 响应视为失败；
+- Webhook 发送相对于 SMTP 存储是异步的，发送失败不会拒收或删除邮件；
+- 重试可能造成重复请求，执行非幂等动作前应使用 `email.id` 或 `X-OwlMail-Email-ID` 去重。

--- a/examples/webhooks.json
+++ b/examples/webhooks.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "targets": [
+    {
+      "name": "soulteary-webhook",
+      "url": "http://webhook:9000/hooks/owlmail",
+      "method": "POST",
+      "contentType": "application/json",
+      "secret": "${OWLMAIL_WEBHOOK_SECRET}",
+      "timeout": "5s",
+      "retries": 2,
+      "match": {
+        "subject": ["*alert*", "*verification*", "*验证码*"],
+        "to": ["*"]
+      },
+      "bodyTemplate": "{\"event\":\"email.received\",\"emailId\":{{ json .ID }},\"title\":{{ json .Subject }},\"message\":{{ json .Text }},\"from\":{{ json .From }},\"to\":{{ json .To }},\"receivedAt\":{{ json .Time }}}"
+    }
+  ]
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -224,6 +224,9 @@ type Config struct {
 
 	// Email ID configuration
 	UseUUIDForEmailID bool
+
+	// Webhook forwarding configuration
+	WebhookConfig string
 }
 
 // DefaultConfig returns a Config with default values
@@ -254,6 +257,7 @@ func DefaultConfig() *Config {
 		TLSKeyFile:        "",
 		LogLevel:          "normal",
 		UseUUIDForEmailID: false,
+		WebhookConfig:     "",
 	}
 }
 
@@ -284,6 +288,7 @@ type FlagRefs struct {
 	TLSKeyFile        *string
 	LogLevel          *string
 	UseUUIDForEmailID *bool
+	WebhookConfig     *string
 }
 
 // DefineFlags defines all configuration flags on the given FlagSet.
@@ -316,6 +321,7 @@ func DefineFlags(fs *flag.FlagSet) *FlagRefs {
 		TLSKeyFile:        fs.String("tls-key", cfg.TLSKeyFile, "TLS private key file path"),
 		LogLevel:          fs.String("log-level", cfg.LogLevel, "Log level: silent, normal, or verbose"),
 		UseUUIDForEmailID: fs.Bool("use-uuid-for-email-id", cfg.UseUUIDForEmailID, "Use UUID instead of random string for email IDs"),
+		WebhookConfig:     fs.String("webhook-config", cfg.WebhookConfig, "JSON file path for webhook forwarding targets"),
 	}
 }
 
@@ -356,6 +362,7 @@ func ResolveConfig(fs *flag.FlagSet, refs *FlagRefs) *Config {
 		LogLevel: resolveLogLevelWithFlag(fs, "log-level", *refs.LogLevel),
 
 		UseUUIDForEmailID: resolveBoolWithFlag(fs, "use-uuid-for-email-id", "OWLMAIL_USE_UUID_FOR_EMAIL_ID", *refs.UseUUIDForEmailID),
+		WebhookConfig:     resolveStringWithFlag(fs, "webhook-config", "OWLMAIL_WEBHOOK_CONFIG", *refs.WebhookConfig),
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -274,6 +274,9 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.UseUUIDForEmailID != false {
 		t.Errorf("DefaultConfig().UseUUIDForEmailID = %v, want %v", cfg.UseUUIDForEmailID, false)
 	}
+	if cfg.WebhookConfig != "" {
+		t.Errorf("DefaultConfig().WebhookConfig = %q, want empty", cfg.WebhookConfig)
+	}
 }
 
 func TestDefineAndResolveConfig(t *testing.T) {
@@ -304,7 +307,7 @@ func TestDefineAndResolveConfig(t *testing.T) {
 	t.Run("CLI flags override defaults", func(t *testing.T) {
 		fs := flag.NewFlagSet("test-cli", flag.ContinueOnError)
 		refs := DefineFlags(fs)
-		_ = fs.Parse([]string{"-smtp", "2025", "-ip", "0.0.0.0", "-web", "8080"})
+		_ = fs.Parse([]string{"-smtp", "2025", "-ip", "0.0.0.0", "-web", "8080", "-webhook-config", "cli-webhooks.json"})
 		cfg := ResolveConfig(fs, refs)
 
 		if cfg.SMTPPort != 2025 {
@@ -316,11 +319,15 @@ func TestDefineAndResolveConfig(t *testing.T) {
 		if cfg.WebPort != 8080 {
 			t.Errorf("ResolveConfig().WebPort = %d, want %d", cfg.WebPort, 8080)
 		}
+		if cfg.WebhookConfig != "cli-webhooks.json" {
+			t.Errorf("ResolveConfig().WebhookConfig = %q", cfg.WebhookConfig)
+		}
 	})
 
 	t.Run("environment variables work", func(t *testing.T) {
 		_ = envMgr.Set("OWLMAIL_SMTP_PORT", "3025")
 		_ = envMgr.Set("OWLMAIL_SMTP_HOST", "192.168.1.1")
+		_ = envMgr.Set("OWLMAIL_WEBHOOK_CONFIG", "env-webhooks.json")
 		defer envMgr.Cleanup()
 
 		fs := flag.NewFlagSet("test-env", flag.ContinueOnError)
@@ -333,6 +340,9 @@ func TestDefineAndResolveConfig(t *testing.T) {
 		}
 		if cfg.SMTPHost != "192.168.1.1" {
 			t.Errorf("ResolveConfig().SMTPHost = %q, want %q", cfg.SMTPHost, "192.168.1.1")
+		}
+		if cfg.WebhookConfig != "env-webhooks.json" {
+			t.Errorf("ResolveConfig().WebhookConfig = %q", cfg.WebhookConfig)
 		}
 	})
 

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -59,6 +59,11 @@ func ValidateConfig(cfg *Config) error {
 			return fmt.Errorf("auto relay rules file: %w", err)
 		}
 	}
+	if cfg.WebhookConfig != "" {
+		if _, err := ValidatePath(cfg.WebhookConfig); err != nil {
+			return fmt.Errorf("webhook config file: %w", err)
+		}
+	}
 
 	return nil
 }

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -209,6 +209,15 @@ func TestValidateConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("webhook config with path traversal", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.WebhookConfig = "../../../etc/passwd"
+		err := ValidateConfig(cfg)
+		if err == nil {
+			t.Error("ValidateConfig with path traversal in webhook config should return error")
+		}
+	})
+
 	t.Run("valid full config", func(t *testing.T) {
 		cfg := DefaultConfig()
 		cfg.SMTPPort = 2525

--- a/internal/webhook/config.go
+++ b/internal/webhook/config.go
@@ -1,0 +1,315 @@
+// Package webhook delivers newly received emails to configurable HTTP endpoints.
+package webhook
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+	"text/template"
+	"time"
+)
+
+const (
+	configVersion        = 1
+	maxConfigBytes       = 1 << 20
+	maxTargets           = 32
+	maxRetries           = 5
+	defaultTargetTimeout = 5 * time.Second
+	maxTargetTimeout     = time.Minute
+)
+
+var environmentVariablePattern = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
+
+// Config is the top-level webhook forwarding configuration.
+type Config struct {
+	Version int      `json:"version,omitempty"`
+	Targets []Target `json:"targets"`
+}
+
+// Target describes one HTTP destination and the emails it should receive.
+type Target struct {
+	Name         string            `json:"name"`
+	URL          string            `json:"url"`
+	Method       string            `json:"method,omitempty"`
+	Headers      map[string]string `json:"headers,omitempty"`
+	ContentType  string            `json:"contentType,omitempty"`
+	BodyTemplate string            `json:"bodyTemplate,omitempty"`
+	Secret       string            `json:"secret,omitempty"`
+	Timeout      string            `json:"timeout,omitempty"`
+	Retries      int               `json:"retries,omitempty"`
+	Match        Match             `json:"match,omitempty"`
+}
+
+// Match filters a target. Non-empty fields are ANDed, while patterns inside a
+// field are ORed. Patterns use shell-style '*' and '?' wildcards and are
+// matched case-insensitively.
+type Match struct {
+	From    []string `json:"from,omitempty"`
+	To      []string `json:"to,omitempty"`
+	Subject []string `json:"subject,omitempty"`
+	Text    []string `json:"text,omitempty"`
+}
+
+type compiledTarget struct {
+	name        string
+	url         string
+	method      string
+	headers     http.Header
+	contentType string
+	secret      string
+	timeout     time.Duration
+	retries     int
+	match       Match
+	template    *template.Template
+}
+
+// LoadConfig reads a strict JSON webhook configuration. Unknown fields and
+// trailing JSON values are rejected so configuration mistakes fail at startup.
+func LoadConfig(filePath string) (Config, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return Config{}, fmt.Errorf("open webhook config: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	data, err := io.ReadAll(io.LimitReader(file, maxConfigBytes+1))
+	if err != nil {
+		return Config{}, fmt.Errorf("read webhook config: %w", err)
+	}
+	if len(data) > maxConfigBytes {
+		return Config{}, fmt.Errorf("webhook config exceeds %d bytes", maxConfigBytes)
+	}
+
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+
+	var config Config
+	if err := decoder.Decode(&config); err != nil {
+		return Config{}, fmt.Errorf("decode webhook config: %w", err)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return Config{}, err
+	}
+
+	return config, nil
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("decode webhook config: multiple JSON values are not allowed")
+		}
+		return fmt.Errorf("decode webhook config: trailing data: %w", err)
+	}
+	return nil
+}
+
+func compileConfig(config Config) ([]compiledTarget, error) {
+	if config.Version != 0 && config.Version != configVersion {
+		return nil, fmt.Errorf("unsupported webhook config version %d", config.Version)
+	}
+	if len(config.Targets) == 0 {
+		return nil, fmt.Errorf("webhook config must contain at least one target")
+	}
+	if len(config.Targets) > maxTargets {
+		return nil, fmt.Errorf("webhook config contains %d targets; maximum is %d", len(config.Targets), maxTargets)
+	}
+
+	compiled := make([]compiledTarget, 0, len(config.Targets))
+	names := make(map[string]struct{}, len(config.Targets))
+	for index, target := range config.Targets {
+		item, err := compileTarget(target)
+		if err != nil {
+			return nil, fmt.Errorf("target %d: %w", index+1, err)
+		}
+		if _, exists := names[item.name]; exists {
+			return nil, fmt.Errorf("target %d: duplicate name %q", index+1, item.name)
+		}
+		names[item.name] = struct{}{}
+		compiled = append(compiled, item)
+	}
+
+	return compiled, nil
+}
+
+func compileTarget(target Target) (compiledTarget, error) {
+	name := strings.TrimSpace(target.Name)
+	if name == "" {
+		return compiledTarget{}, fmt.Errorf("name is required")
+	}
+	if len(name) > 100 || strings.ContainsAny(name, "\r\n") {
+		return compiledTarget{}, fmt.Errorf("name must be at most 100 characters and contain no newlines")
+	}
+
+	resolvedURL, err := expandEnvironmentVariables(target.URL)
+	if err != nil {
+		return compiledTarget{}, fmt.Errorf("url: %w", err)
+	}
+	parsedURL, err := url.Parse(resolvedURL)
+	if err != nil {
+		return compiledTarget{}, fmt.Errorf("url is invalid")
+	}
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return compiledTarget{}, fmt.Errorf("url scheme must be http or https")
+	}
+	if parsedURL.Hostname() == "" {
+		return compiledTarget{}, fmt.Errorf("url host is required")
+	}
+	if parsedURL.User != nil {
+		return compiledTarget{}, fmt.Errorf("url user information is not allowed; use headers for authentication")
+	}
+	if parsedURL.Fragment != "" {
+		return compiledTarget{}, fmt.Errorf("url fragments are not allowed")
+	}
+
+	method := strings.ToUpper(strings.TrimSpace(target.Method))
+	if method == "" {
+		method = http.MethodPost
+	}
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch:
+	default:
+		return compiledTarget{}, fmt.Errorf("method %q is not supported", method)
+	}
+
+	timeout := defaultTargetTimeout
+	if target.Timeout != "" {
+		timeout, err = time.ParseDuration(target.Timeout)
+		if err != nil {
+			return compiledTarget{}, fmt.Errorf("invalid timeout: %w", err)
+		}
+	}
+	if timeout <= 0 || timeout > maxTargetTimeout {
+		return compiledTarget{}, fmt.Errorf("timeout must be greater than zero and no more than %s", maxTargetTimeout)
+	}
+	if target.Retries < 0 || target.Retries > maxRetries {
+		return compiledTarget{}, fmt.Errorf("retries must be between 0 and %d", maxRetries)
+	}
+
+	contentType := strings.TrimSpace(target.ContentType)
+	if contentType == "" {
+		contentType = "application/json"
+	}
+	if strings.ContainsAny(contentType, "\r\n") {
+		return compiledTarget{}, fmt.Errorf("contentType contains a newline")
+	}
+
+	headers := make(http.Header, len(target.Headers))
+	for headerName, headerValue := range target.Headers {
+		canonicalName := http.CanonicalHeaderKey(strings.TrimSpace(headerName))
+		if canonicalName == "" || !validHeaderName(headerName) {
+			return compiledTarget{}, fmt.Errorf("invalid header name %q", headerName)
+		}
+		if canonicalName == "Host" || canonicalName == "Content-Length" {
+			return compiledTarget{}, fmt.Errorf("header %q is managed by the HTTP client", canonicalName)
+		}
+		resolvedValue, expandErr := expandEnvironmentVariables(headerValue)
+		if expandErr != nil {
+			return compiledTarget{}, fmt.Errorf("header %q: %w", canonicalName, expandErr)
+		}
+		if strings.ContainsAny(resolvedValue, "\r\n") {
+			return compiledTarget{}, fmt.Errorf("header %q contains a newline", canonicalName)
+		}
+		headers.Set(canonicalName, resolvedValue)
+	}
+
+	secret, err := expandEnvironmentVariables(target.Secret)
+	if err != nil {
+		return compiledTarget{}, fmt.Errorf("secret: %w", err)
+	}
+
+	if err := validateMatch(target.Match); err != nil {
+		return compiledTarget{}, err
+	}
+
+	var bodyTemplate *template.Template
+	if target.BodyTemplate != "" {
+		bodyTemplate, err = template.New(name).
+			Option("missingkey=error").
+			Funcs(templateFunctions()).
+			Parse(target.BodyTemplate)
+		if err != nil {
+			return compiledTarget{}, fmt.Errorf("invalid bodyTemplate: %w", err)
+		}
+	}
+
+	return compiledTarget{
+		name:        name,
+		url:         parsedURL.String(),
+		method:      method,
+		headers:     headers,
+		contentType: contentType,
+		secret:      secret,
+		timeout:     timeout,
+		retries:     target.Retries,
+		match:       target.Match,
+		template:    bodyTemplate,
+	}, nil
+}
+
+func validHeaderName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for index := 0; index < len(name); index++ {
+		character := name[index]
+		if (character >= 'a' && character <= 'z') ||
+			(character >= 'A' && character <= 'Z') ||
+			(character >= '0' && character <= '9') {
+			continue
+		}
+		switch character {
+		case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func validateMatch(match Match) error {
+	fields := []struct {
+		name     string
+		patterns []string
+	}{
+		{name: "from", patterns: match.From},
+		{name: "to", patterns: match.To},
+		{name: "subject", patterns: match.Subject},
+		{name: "text", patterns: match.Text},
+	}
+	for _, field := range fields {
+		for _, pattern := range field.patterns {
+			if strings.TrimSpace(pattern) == "" {
+				return fmt.Errorf("match.%s contains an empty pattern", field.name)
+			}
+			if _, err := path.Match(strings.ToLower(pattern), ""); err != nil {
+				return fmt.Errorf("match.%s contains invalid pattern %q: %w", field.name, pattern, err)
+			}
+		}
+	}
+	return nil
+}
+
+func expandEnvironmentVariables(value string) (string, error) {
+	var missing string
+	expanded := environmentVariablePattern.ReplaceAllStringFunc(value, func(token string) string {
+		name := environmentVariablePattern.FindStringSubmatch(token)[1]
+		resolved, exists := os.LookupEnv(name)
+		if !exists && missing == "" {
+			missing = name
+		}
+		return resolved
+	})
+	if missing != "" {
+		return "", fmt.Errorf("environment variable %s is not set", missing)
+	}
+	return expanded, nil
+}

--- a/internal/webhook/config_test.go
+++ b/internal/webhook/config_test.go
@@ -1,0 +1,161 @@
+package webhook
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLoadConfigStrictJSON(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantError string
+	}{
+		{
+			name:    "valid",
+			content: `{"version":1,"targets":[{"name":"test","url":"https://example.com/hook"}]}`,
+		},
+		{
+			name:      "unknown field",
+			content:   `{"targets":[],"targetz":[]}`,
+			wantError: "unknown field",
+		},
+		{
+			name:      "trailing value",
+			content:   `{"targets":[]} {"targets":[]}`,
+			wantError: "multiple JSON values",
+		},
+		{
+			name:      "invalid json",
+			content:   `{"targets":`,
+			wantError: "decode webhook config",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			filePath := filepath.Join(t.TempDir(), "webhooks.json")
+			if err := os.WriteFile(filePath, []byte(test.content), 0600); err != nil {
+				t.Fatal(err)
+			}
+			config, err := LoadConfig(filePath)
+			if test.wantError == "" {
+				if err != nil {
+					t.Fatalf("LoadConfig() error = %v", err)
+				}
+				if config.Version != 1 || len(config.Targets) != 1 {
+					t.Fatalf("LoadConfig() = %#v", config)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("LoadConfig() error = %v, want substring %q", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestLoadConfigLimitsSize(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "webhooks.json")
+	if err := os.WriteFile(filePath, bytes.Repeat([]byte{'x'}, maxConfigBytes+1), 0600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadConfig(filePath)
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("LoadConfig() error = %v, want size error", err)
+	}
+}
+
+func TestCompileConfigValidation(t *testing.T) {
+	validTarget := func() Target {
+		return Target{Name: "primary", URL: "https://example.com/hooks/owlmail"}
+	}
+
+	tests := []struct {
+		name      string
+		config    Config
+		wantError string
+	}{
+		{name: "unsupported version", config: Config{Version: 2, Targets: []Target{validTarget()}}, wantError: "unsupported"},
+		{name: "no targets", config: Config{Version: 1}, wantError: "at least one"},
+		{name: "duplicate names", config: Config{Targets: []Target{validTarget(), validTarget()}}, wantError: "duplicate name"},
+		{name: "missing name", config: Config{Targets: []Target{{URL: "https://example.com"}}}, wantError: "name is required"},
+		{name: "name newline", config: Config{Targets: []Target{{Name: "bad\nname", URL: "https://example.com"}}}, wantError: "no newlines"},
+		{name: "bad scheme", config: Config{Targets: []Target{{Name: "bad", URL: "file:///tmp/hook"}}}, wantError: "scheme"},
+		{name: "missing host", config: Config{Targets: []Target{{Name: "bad", URL: "http:///hook"}}}, wantError: "host"},
+		{name: "url credentials", config: Config{Targets: []Target{{Name: "bad", URL: "https://user:pass@example.com"}}}, wantError: "user information"},
+		{name: "url fragment", config: Config{Targets: []Target{{Name: "bad", URL: "https://example.com/#secret"}}}, wantError: "fragments"},
+		{name: "unsupported method", config: Config{Targets: []Target{{Name: "bad", URL: "https://example.com", Method: "GET"}}}, wantError: "not supported"},
+		{name: "invalid timeout", config: Config{Targets: []Target{{Name: "bad", URL: "https://example.com", Timeout: "soon"}}}, wantError: "invalid timeout"},
+		{name: "excessive timeout", config: Config{Targets: []Target{{Name: "bad", URL: "https://example.com", Timeout: "61s"}}}, wantError: "no more than"},
+		{name: "too many retries", config: Config{Targets: []Target{{Name: "bad", URL: "https://example.com", Retries: 6}}}, wantError: "retries"},
+		{name: "content type newline", config: Config{Targets: []Target{{Name: "bad", URL: "https://example.com", ContentType: "text/plain\r\nX-Test: yes"}}}, wantError: "contentType"},
+		{name: "invalid header name", config: Config{Targets: []Target{{Name: "bad", URL: "https://example.com", Headers: map[string]string{"Bad Header": "x"}}}}, wantError: "invalid header"},
+		{name: "managed header", config: Config{Targets: []Target{{Name: "bad", URL: "https://example.com", Headers: map[string]string{"Content-Length": "10"}}}}, wantError: "managed"},
+		{name: "header newline", config: Config{Targets: []Target{{Name: "bad", URL: "https://example.com", Headers: map[string]string{"X-Test": "x\ny"}}}}, wantError: "newline"},
+		{name: "empty pattern", config: Config{Targets: []Target{{Name: "bad", URL: "https://example.com", Match: Match{Subject: []string{""}}}}}, wantError: "empty pattern"},
+		{name: "invalid pattern", config: Config{Targets: []Target{{Name: "bad", URL: "https://example.com", Match: Match{Subject: []string{"["}}}}}, wantError: "invalid pattern"},
+		{name: "invalid template", config: Config{Targets: []Target{{Name: "bad", URL: "https://example.com", BodyTemplate: "{{"}}}, wantError: "bodyTemplate"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := NewDispatcher(test.config, nil)
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("NewDispatcher() error = %v, want substring %q", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestCompileConfigExpandsEnvironmentAndDefaults(t *testing.T) {
+	t.Setenv("OWLMAIL_TEST_HOOK_HOST", "example.com")
+	t.Setenv("OWLMAIL_TEST_HOOK_TOKEN", "token-value")
+
+	dispatcher, err := NewDispatcher(Config{Targets: []Target{{
+		Name:    "primary",
+		URL:     "https://${OWLMAIL_TEST_HOOK_HOST}/hooks/owlmail",
+		Secret:  "${OWLMAIL_TEST_HOOK_TOKEN}",
+		Headers: map[string]string{"Authorization": "Bearer ${OWLMAIL_TEST_HOOK_TOKEN}"},
+	}}}, nil)
+	if err != nil {
+		t.Fatalf("NewDispatcher() error = %v", err)
+	}
+	target := dispatcher.targets[0]
+	if target.url != "https://example.com/hooks/owlmail" {
+		t.Errorf("url = %q", target.url)
+	}
+	if target.method != "POST" || target.timeout != 5*time.Second || target.contentType != "application/json" {
+		t.Errorf("defaults not applied: %#v", target)
+	}
+	if target.secret != "token-value" || target.headers.Get("Authorization") != "Bearer token-value" {
+		t.Errorf("environment variables not expanded")
+	}
+}
+
+func TestCompileConfigRejectsMissingEnvironment(t *testing.T) {
+	const variable = "OWLMAIL_TEST_MISSING_VARIABLE_7D896"
+	_ = os.Unsetenv(variable)
+	_, err := NewDispatcher(Config{Targets: []Target{{
+		Name: "primary",
+		URL:  "https://example.com/${" + variable + "}",
+	}}}, nil)
+	if err == nil || !strings.Contains(err.Error(), variable) {
+		t.Fatalf("NewDispatcher() error = %v, want missing environment variable", err)
+	}
+}
+
+func TestCompileConfigLimitsTargets(t *testing.T) {
+	targets := make([]Target, maxTargets+1)
+	for index := range targets {
+		targets[index] = Target{Name: "target", URL: "https://example.com"}
+	}
+	_, err := NewDispatcher(Config{Targets: targets}, nil)
+	if err == nil || !strings.Contains(err.Error(), "maximum") {
+		t.Fatalf("NewDispatcher() error = %v, want maximum target error", err)
+	}
+}

--- a/internal/webhook/dispatcher.go
+++ b/internal/webhook/dispatcher.go
@@ -1,0 +1,224 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/soulteary/owlmail/internal/types"
+)
+
+const (
+	maxPayloadBytes = 2 << 20
+	maxDrainBytes   = 64 << 10
+)
+
+// Dispatcher sends matching email events to configured targets.
+type Dispatcher struct {
+	targets []compiledTarget
+	client  *http.Client
+}
+
+// Result describes one target delivery attempt.
+type Result struct {
+	Target     string
+	StatusCode int
+	Attempts   int
+	Err        error
+}
+
+// Load creates a dispatcher from a JSON configuration file.
+func Load(filePath string, client *http.Client) (*Dispatcher, error) {
+	config, err := LoadConfig(filePath)
+	if err != nil {
+		return nil, err
+	}
+	return NewDispatcher(config, client)
+}
+
+// NewDispatcher validates configuration and creates a dispatcher. Redirects
+// are intentionally not followed so a configured target cannot redirect a
+// payload or credentials to another host.
+func NewDispatcher(config Config, client *http.Client) (*Dispatcher, error) {
+	targets, err := compileConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	if client == nil {
+		transport := http.DefaultTransport
+		if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
+			clonedTransport := defaultTransport.Clone()
+			clonedTransport.MaxIdleConnsPerHost = 4
+			transport = clonedTransport
+		}
+		client = &http.Client{Transport: transport}
+	} else {
+		copy := *client
+		client = &copy
+	}
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	return &Dispatcher{targets: targets, client: client}, nil
+}
+
+// TargetCount returns the number of configured destinations.
+func (dispatcher *Dispatcher) TargetCount() int {
+	if dispatcher == nil {
+		return 0
+	}
+	return len(dispatcher.targets)
+}
+
+// Dispatch synchronously sends an email to every matching target. MailServer
+// invokes event listeners asynchronously, so this never blocks SMTP storage.
+func (dispatcher *Dispatcher) Dispatch(ctx context.Context, email *types.Email) []Result {
+	if dispatcher == nil {
+		return nil
+	}
+	if email == nil {
+		return []Result{{Err: fmt.Errorf("email is nil")}}
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	payload := newEmailPayload(email)
+	results := make([]Result, 0, len(dispatcher.targets))
+	for _, target := range dispatcher.targets {
+		if !target.matches(payload) {
+			continue
+		}
+		results = append(results, dispatcher.deliver(ctx, target, payload))
+	}
+	return results
+}
+
+func (dispatcher *Dispatcher) deliver(ctx context.Context, target compiledTarget, payload EmailPayload) Result {
+	result := Result{Target: target.name}
+	body, err := renderBody(target, payload)
+	if err != nil {
+		result.Err = err
+		return result
+	}
+	if len(body) > maxPayloadBytes {
+		result.Err = fmt.Errorf("rendered payload exceeds %d bytes", maxPayloadBytes)
+		return result
+	}
+
+	for attempt := 0; attempt <= target.retries; attempt++ {
+		result.Attempts = attempt + 1
+		statusCode, retry, requestErr := dispatcher.sendAttempt(ctx, target, payload.ID, body)
+		result.StatusCode = statusCode
+		if requestErr == nil {
+			result.Err = nil
+			return result
+		}
+		result.Err = requestErr
+		if !retry || attempt == target.retries || ctx.Err() != nil {
+			return result
+		}
+		if !waitForRetry(ctx, attempt) {
+			result.Err = ctx.Err()
+			return result
+		}
+	}
+	return result
+}
+
+func renderBody(target compiledTarget, payload EmailPayload) ([]byte, error) {
+	if target.template == nil {
+		body, err := json.Marshal(eventPayload{
+			Event:   "email.received",
+			Message: defaultMessage(payload),
+			Email:   payload,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("encode default payload: %w", err)
+		}
+		return body, nil
+	}
+
+	var body bytes.Buffer
+	if err := target.template.Execute(&body, payload); err != nil {
+		return nil, fmt.Errorf("render body template: %w", err)
+	}
+	return body.Bytes(), nil
+}
+
+func (dispatcher *Dispatcher) sendAttempt(ctx context.Context, target compiledTarget, emailID string, body []byte) (int, bool, error) {
+	attemptContext, cancel := context.WithTimeout(ctx, target.timeout)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(attemptContext, target.method, target.url, bytes.NewReader(body))
+	if err != nil {
+		return 0, false, fmt.Errorf("create request: %w", err)
+	}
+	request.Header = target.headers.Clone()
+	if request.Header.Get("Content-Type") == "" {
+		request.Header.Set("Content-Type", target.contentType)
+	}
+	if request.Header.Get("User-Agent") == "" {
+		request.Header.Set("User-Agent", "OwlMail-Webhook/1")
+	}
+	request.Header.Set("X-OwlMail-Event", "email.received")
+	request.Header.Set("X-OwlMail-Email-ID", emailID)
+	if target.secret != "" {
+		request.Header.Set("X-OwlMail-Signature", signPayload(target.secret, body))
+	}
+
+	response, err := dispatcher.client.Do(request)
+	if err != nil {
+		return 0, !errors.Is(err, context.Canceled), sanitizeRequestError(err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, maxDrainBytes))
+
+	if response.StatusCode >= http.StatusOK && response.StatusCode < http.StatusMultipleChoices {
+		return response.StatusCode, false, nil
+	}
+	retry := response.StatusCode == http.StatusRequestTimeout ||
+		response.StatusCode == http.StatusTooEarly ||
+		response.StatusCode == http.StatusTooManyRequests ||
+		response.StatusCode >= http.StatusInternalServerError
+	return response.StatusCode, retry, fmt.Errorf("target returned HTTP %d", response.StatusCode)
+}
+
+func sanitizeRequestError(err error) error {
+	for {
+		var urlError *url.Error
+		if !errors.As(err, &urlError) || urlError.Err == nil || urlError.Err == err {
+			break
+		}
+		err = urlError.Err
+	}
+	return fmt.Errorf("request failed: %v", err)
+}
+
+func signPayload(secret string, payload []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(payload)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func waitForRetry(ctx context.Context, attempt int) bool {
+	delay := 100 * time.Millisecond * time.Duration(1<<attempt)
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}

--- a/internal/webhook/dispatcher_test.go
+++ b/internal/webhook/dispatcher_test.go
@@ -1,0 +1,297 @@
+package webhook
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/mail"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/soulteary/owlmail/internal/types"
+)
+
+func testEmail() *types.Email {
+	return &types.Email{
+		ID:        "email-123",
+		Time:      time.Date(2026, 8, 29, 12, 30, 0, 0, time.UTC),
+		Subject:   "System Alert",
+		From:      []*mail.Address{{Name: "Monitor", Address: "monitor@example.com"}},
+		To:        []*mail.Address{{Address: "ops@example.net"}},
+		CC:        []*mail.Address{{Address: "audit@example.net"}},
+		Text:      "Verification code: 123456",
+		HTML:      "<p>Verification code: 123456</p>",
+		Size:      512,
+		SizeHuman: "512 B",
+		Envelope: &types.Envelope{
+			From: "monitor@example.com",
+			To:   []string{"ops@example.net"},
+		},
+		Source: "/private/mail/email-123.eml",
+		Attachments: []*types.Attachment{{
+			FileName:    "report.txt",
+			ContentType: "text/plain",
+			Size:        42,
+		}},
+	}
+}
+
+func TestDispatchDefaultPayload(t *testing.T) {
+	var received eventPayload
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost {
+			t.Errorf("method = %s", request.Method)
+		}
+		if request.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Content-Type = %q", request.Header.Get("Content-Type"))
+		}
+		if request.Header.Get("X-OwlMail-Event") != "email.received" || request.Header.Get("X-OwlMail-Email-ID") != "email-123" {
+			t.Errorf("missing OwlMail headers")
+		}
+		if err := json.NewDecoder(request.Body).Decode(&received); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	dispatcher, err := NewDispatcher(Config{Targets: []Target{{Name: "primary", URL: server.URL}}}, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := dispatcher.Dispatch(context.Background(), testEmail())
+	if len(results) != 1 || results[0].Err != nil || results[0].StatusCode != http.StatusNoContent || results[0].Attempts != 1 {
+		t.Fatalf("Dispatch() = %#v", results)
+	}
+	if received.Event != "email.received" || received.Email.Subject != "System Alert" {
+		t.Errorf("payload = %#v", received)
+	}
+	if strings.Contains(received.Message, "/private/mail") {
+		t.Error("payload leaked local source path")
+	}
+	encoded, _ := json.Marshal(received)
+	if strings.Contains(string(encoded), "/private/mail") {
+		t.Error("payload JSON leaked local source path")
+	}
+}
+
+func TestDispatchCustomTemplateHeadersAndSignature(t *testing.T) {
+	const secret = "shared-secret"
+	var receivedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		receivedBody, _ = io.ReadAll(request.Body)
+		if request.Header.Get("X-Custom") != "owlmail" {
+			t.Errorf("X-Custom = %q", request.Header.Get("X-Custom"))
+		}
+		mac := hmac.New(sha256.New, []byte(secret))
+		_, _ = mac.Write(receivedBody)
+		wantSignature := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+		if request.Header.Get("X-OwlMail-Signature") != wantSignature {
+			t.Errorf("signature = %q, want %q", request.Header.Get("X-OwlMail-Signature"), wantSignature)
+		}
+		writer.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	dispatcher, err := NewDispatcher(Config{Targets: []Target{{
+		Name:         "custom",
+		URL:          server.URL,
+		Method:       "put",
+		ContentType:  "application/vnd.owlmail+json",
+		Headers:      map[string]string{"X-Custom": "owlmail"},
+		Secret:       secret,
+		BodyTemplate: `{"title":{{ json .Subject }},"message":{{ json (truncate .Text 17) }},"to":{{ json .To }}}`,
+	}}}, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := dispatcher.Dispatch(context.Background(), testEmail())
+	if len(results) != 1 || results[0].Err != nil {
+		t.Fatalf("Dispatch() = %#v", results)
+	}
+	if string(receivedBody) != `{"title":"System Alert","message":"Verification code","to":["ops@example.net"]}` {
+		t.Errorf("body = %s", receivedBody)
+	}
+}
+
+func TestDispatchAppliesMatchRules(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	dispatcher, err := NewDispatcher(Config{Targets: []Target{{
+		Name: "filtered",
+		URL:  server.URL,
+		Match: Match{
+			From:    []string{"*@EXAMPLE.COM"},
+			To:      []string{"ops@*"},
+			Subject: []string{"*alert*"},
+			Text:    []string{"*123456*"},
+		},
+	}}}, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results := dispatcher.Dispatch(context.Background(), testEmail()); len(results) != 1 || results[0].Err != nil {
+		t.Fatalf("matching Dispatch() = %#v", results)
+	}
+
+	email := testEmail()
+	email.Subject = "Routine report"
+	if results := dispatcher.Dispatch(context.Background(), email); len(results) != 0 {
+		t.Fatalf("non-matching Dispatch() = %#v", results)
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("requests = %d, want 1", requests.Load())
+	}
+}
+
+func TestDispatchRetriesTransientFailure(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		if requests.Add(1) == 1 {
+			writer.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	dispatcher, err := NewDispatcher(Config{Targets: []Target{{Name: "retry", URL: server.URL, Retries: 1}}}, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := dispatcher.Dispatch(context.Background(), testEmail())
+	if len(results) != 1 || results[0].Err != nil || results[0].Attempts != 2 || requests.Load() != 2 {
+		t.Fatalf("Dispatch() = %#v, requests = %d", results, requests.Load())
+	}
+}
+
+func TestDispatchDoesNotRetryPermanentFailure(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		writer.WriteHeader(http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	dispatcher, err := NewDispatcher(Config{Targets: []Target{{Name: "bad", URL: server.URL, Retries: 3}}}, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := dispatcher.Dispatch(context.Background(), testEmail())
+	if len(results) != 1 || results[0].Err == nil || results[0].Attempts != 1 || requests.Load() != 1 {
+		t.Fatalf("Dispatch() = %#v, requests = %d", results, requests.Load())
+	}
+}
+
+func TestDispatchDoesNotFollowRedirects(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	destination := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		redirectedRequests.Add(1)
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer destination.Close()
+	redirect := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		http.Redirect(writer, request, destination.URL, http.StatusTemporaryRedirect)
+	}))
+	defer redirect.Close()
+
+	dispatcher, err := NewDispatcher(Config{Targets: []Target{{Name: "redirect", URL: redirect.URL}}}, redirect.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := dispatcher.Dispatch(context.Background(), testEmail())
+	if len(results) != 1 || results[0].Err == nil || results[0].StatusCode != http.StatusTemporaryRedirect {
+		t.Fatalf("Dispatch() = %#v", results)
+	}
+	if redirectedRequests.Load() != 0 {
+		t.Fatalf("followed redirect %d time(s)", redirectedRequests.Load())
+	}
+}
+
+func TestDispatchHonorsTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	dispatcher, err := NewDispatcher(Config{Targets: []Target{{Name: "slow", URL: server.URL, Timeout: "10ms"}}}, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := dispatcher.Dispatch(context.Background(), testEmail())
+	if len(results) != 1 || results[0].Err == nil || !strings.Contains(results[0].Err.Error(), "deadline") {
+		t.Fatalf("Dispatch() = %#v", results)
+	}
+}
+
+func TestDispatchDoesNotLeakTargetURLInErrors(t *testing.T) {
+	client := &http.Client{Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		return nil, &url.Error{Op: "Post", URL: request.URL.String(), Err: errors.New("connection failed")}
+	})}
+	dispatcher, err := NewDispatcher(Config{Targets: []Target{{
+		Name: "secret-url",
+		URL:  "https://example.com/hooks/test?token=do-not-log",
+	}}}, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := dispatcher.Dispatch(context.Background(), testEmail())
+	if len(results) != 1 || results[0].Err == nil {
+		t.Fatalf("Dispatch() = %#v", results)
+	}
+	if strings.Contains(results[0].Err.Error(), "do-not-log") || strings.Contains(results[0].Err.Error(), "example.com") {
+		t.Fatalf("error leaked target URL: %v", results[0].Err)
+	}
+}
+
+func TestDispatchRejectsOversizedAndNilEmail(t *testing.T) {
+	dispatcher, err := NewDispatcher(Config{Targets: []Target{{
+		Name:         "large",
+		URL:          "https://example.com",
+		BodyTemplate: "{{ .Text }}",
+	}}}, &http.Client{Transport: roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		t.Fatal("HTTP request should not be attempted")
+		return nil, nil
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	email := testEmail()
+	email.Text = strings.Repeat("x", maxPayloadBytes+1)
+	results := dispatcher.Dispatch(context.Background(), email)
+	if len(results) != 1 || results[0].Err == nil || results[0].Attempts != 0 {
+		t.Fatalf("oversized Dispatch() = %#v", results)
+	}
+	results = dispatcher.Dispatch(context.Background(), nil)
+	if len(results) != 1 || results[0].Err == nil {
+		t.Fatalf("nil Dispatch() = %#v", results)
+	}
+}
+
+func TestTargetCountHandlesNilDispatcher(t *testing.T) {
+	var dispatcher *Dispatcher
+	if dispatcher.TargetCount() != 0 {
+		t.Fatal("nil dispatcher should have zero targets")
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (function roundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}

--- a/internal/webhook/payload.go
+++ b/internal/webhook/payload.go
@@ -1,0 +1,168 @@
+package webhook
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/mail"
+	"path"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/soulteary/owlmail/internal/types"
+)
+
+// Attachment is the safe attachment metadata exposed to webhook templates.
+type Attachment struct {
+	FileName    string `json:"fileName"`
+	ContentType string `json:"contentType"`
+	Size        int64  `json:"size"`
+}
+
+// EmailPayload is the stable email representation used by default payloads and
+// custom body templates. It intentionally omits local file-system paths.
+type EmailPayload struct {
+	ID              string                 `json:"id"`
+	Time            time.Time              `json:"time"`
+	Subject         string                 `json:"subject"`
+	From            []string               `json:"from"`
+	To              []string               `json:"to"`
+	CC              []string               `json:"cc,omitempty"`
+	BCC             []string               `json:"bcc,omitempty"`
+	EnvelopeFrom    string                 `json:"envelopeFrom,omitempty"`
+	EnvelopeTo      []string               `json:"envelopeTo,omitempty"`
+	Text            string                 `json:"text"`
+	HTML            string                 `json:"html,omitempty"`
+	Size            int64                  `json:"size"`
+	SizeHuman       string                 `json:"sizeHuman"`
+	Attachments     []Attachment           `json:"attachments,omitempty"`
+	Headers         map[string]interface{} `json:"-"`
+	AttachmentCount int                    `json:"attachmentCount"`
+}
+
+type eventPayload struct {
+	Event   string       `json:"event"`
+	Message string       `json:"message"`
+	Email   EmailPayload `json:"email"`
+}
+
+func newEmailPayload(email *types.Email) EmailPayload {
+	payload := EmailPayload{
+		ID:              email.ID,
+		Time:            email.Time,
+		Subject:         email.Subject,
+		From:            addressStrings(email.From),
+		To:              addressStrings(email.To),
+		CC:              addressStrings(email.CC),
+		BCC:             addressStrings(email.BCC),
+		Text:            email.Text,
+		HTML:            email.HTML,
+		Size:            email.Size,
+		SizeHuman:       email.SizeHuman,
+		Headers:         email.Headers,
+		AttachmentCount: len(email.Attachments),
+	}
+	if email.Envelope != nil {
+		payload.EnvelopeFrom = email.Envelope.From
+		payload.EnvelopeTo = append([]string(nil), email.Envelope.To...)
+	}
+	if len(email.Attachments) > 0 {
+		payload.Attachments = make([]Attachment, 0, len(email.Attachments))
+		for _, attachment := range email.Attachments {
+			if attachment == nil {
+				continue
+			}
+			payload.Attachments = append(payload.Attachments, Attachment{
+				FileName:    attachment.FileName,
+				ContentType: attachment.ContentType,
+				Size:        attachment.Size,
+			})
+		}
+	}
+	return payload
+}
+
+func addressStrings(addresses []*mail.Address) []string {
+	if len(addresses) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(addresses))
+	for _, address := range addresses {
+		if address != nil && address.Address != "" {
+			result = append(result, address.Address)
+		}
+	}
+	return result
+}
+
+func defaultMessage(payload EmailPayload) string {
+	subject := strings.TrimSpace(payload.Subject)
+	text := strings.TrimSpace(payload.Text)
+	switch {
+	case subject != "" && text != "":
+		return subject + "\n" + text
+	case subject != "":
+		return subject
+	case text != "":
+		return text
+	default:
+		return "New email received"
+	}
+}
+
+func templateFunctions() template.FuncMap {
+	return template.FuncMap{
+		"json": func(value any) (string, error) {
+			encoded, err := json.Marshal(value)
+			if err != nil {
+				return "", fmt.Errorf("encode template value as JSON: %w", err)
+			}
+			return string(encoded), nil
+		},
+		"join": strings.Join,
+		"truncate": func(value string, length int) string {
+			if length <= 0 {
+				return ""
+			}
+			runes := []rune(value)
+			if len(runes) <= length {
+				return value
+			}
+			return string(runes[:length])
+		},
+	}
+}
+
+func (target compiledTarget) matches(payload EmailPayload) bool {
+	fromValues := append(append([]string(nil), payload.From...), payload.EnvelopeFrom)
+	toValues := append(append([]string(nil), payload.To...), payload.EnvelopeTo...)
+	toValues = append(toValues, payload.CC...)
+	toValues = append(toValues, payload.BCC...)
+
+	return matchesField(target.match.From, fromValues) &&
+		matchesField(target.match.To, toValues) &&
+		matchesField(target.match.Subject, []string{payload.Subject}) &&
+		matchesField(target.match.Text, []string{payload.Text})
+}
+
+func matchesField(patterns, values []string) bool {
+	if len(patterns) == 0 {
+		return true
+	}
+	for _, pattern := range patterns {
+		lowerPattern := strings.ToLower(pattern)
+		for _, value := range values {
+			matched, _ := pathMatch(lowerPattern, strings.ToLower(value))
+			if matched {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// pathMatch is a variable to keep the wildcard matcher easy to exercise in
+// tests without exposing it as part of the public package API.
+var pathMatch = func(pattern, value string) (bool, error) {
+	return path.Match(pattern, value)
+}


### PR DESCRIPTION
## Summary

- add configurable webhook forwarding for incoming emails
- support match rules, per-target templates, custom headers, timeouts and bounded retries
- add HMAC-SHA256 signatures compatible with `soulteary/webhook`
- document configuration in English and Chinese and include a ready-to-use example

## Safety

- rejects non-HTTP(S) targets and invalid configuration at startup
- caps rendered payload size and request timeout
- prevents redirect-based destination changes
- omits raw message storage paths from webhook payloads

## Verification

- `go test -race ./...`
- `go vet ./...`
- `go build -trimpath`
- end-to-end SMTP delivery into OwlMail and signed delivery into a real `soulteary/webhook` process

Closes #8