### PR TITLE
feat: add an embedded local help page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,6 @@ WORKDIR /app
 # Copy binary from builder stage
 COPY --from=builder /build/owlmail /app/owlmail
 
-# Copy web static files
-COPY --from=builder /build/web /app/web
-
 # Create mail storage directory
 RUN mkdir -p /app/mail && \
     chown -R owlmail:owlmail /app

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ OwlMail is an SMTP server and web interface for development and testing environm
 - 🆕 **Configuration Management API** - Complete configuration management (GET/PUT/PATCH)
 - 🆕 **Powerful Search** - Full-text search, date range filtering, sorting
 - 🆕 **Improved RESTful API** - More standardized API design (`/api/v1/*`)
+- 🆕 **Built-in Help** - Local bilingual guide available from the inbox or at `/help`
 
 ### Compatibility
 
@@ -101,6 +102,10 @@ export MAILDEV_SMTP_PORT=1025
 export MAILDEV_WEB_PORT=1080
 ./owlmail
 ```
+
+Open `http://localhost:1080` for the inbox. The **Help** button opens the local
+guide at `http://localhost:1080/help`. Both pages and their assets are embedded
+in the executable, so installed binaries do not need a separate `web` folder.
 
 ### Docker Usage
 
@@ -542,7 +547,7 @@ OwlMail/
 │   ├── mailserver/       # SMTP server implementation
 │   ├── outgoing/         # Email relay implementation
 │   └── types/            # Type definitions
-├── web/                  # Web frontend files
+├── web/                  # Embedded web frontend and local help assets
 ├── go.mod                # Go module definition
 └── README.md             # This document
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -48,6 +48,7 @@ OwlMail 是一个用于开发和测试环境的 SMTP 服务器和 Web 界面，�
 - 🆕 **配置管理 API** - 完整的配置管理（GET/PUT/PATCH）
 - 🆕 **强大的搜索** - 全文搜索、日期范围过滤、排序
 - 🆕 **改进的 RESTful API** - 更规范的 API 设计（`/api/v1/*`）
+- 🆕 **内置帮助** - 可从收件箱或 `/help` 打开本地中英文指南
 
 ### 兼容性
 
@@ -101,6 +102,10 @@ export MAILDEV_SMTP_PORT=1025
 export MAILDEV_WEB_PORT=1080
 ./owlmail
 ```
+
+打开 `http://localhost:1080` 访问收件箱。点击界面中的**帮助**按钮，可直接
+访问 `http://localhost:1080/help` 的本地说明页面。页面及静态资源均已嵌入
+可执行文件，安装后的二进制无需额外携带 `web` 目录。
 
 ### Docker 使用
 
@@ -542,7 +547,7 @@ OwlMail/
 │   ├── mailserver/       # SMTP 服务器实现
 │   ├── outgoing/         # 邮件转发实现
 │   └── types/            # 类型定义
-├── web/                  # Web 前端文件
+├── web/                  # 嵌入式 Web 前端和本地帮助资源
 ├── go.mod                # Go 模块定义
 └── README.md             # 本文档
 ```

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -14,6 +14,7 @@ import (
 	"github.com/soulteary/health-kit/v2"
 	"github.com/soulteary/owlmail/internal/mailserver"
 	"github.com/soulteary/owlmail/internal/types"
+	webassets "github.com/soulteary/owlmail/web"
 	"github.com/soulteary/version-kit/v2"
 )
 
@@ -86,9 +87,12 @@ func (api *API) setupRoutes() {
 		app.Use(basicAuthMiddleware(api.authUser, api.authPassword, "/healthz", "/api/v1/health"))
 	}
 
-	// Static files (web UI)
-	app.Get("/style.css", func(c fiber.Ctx) error { return c.SendFile("./web/style.css") })
-	app.Get("/app.js", func(c fiber.Ctx) error { return c.SendFile("./web/app.js") })
+	// Static files are embedded in the executable so the UI and help page work
+	// regardless of the process working directory.
+	app.Get("/style.css", serveWebAsset("style.css", "text/css; charset=utf-8"))
+	app.Get("/app.js", serveWebAsset("app.js", "text/javascript; charset=utf-8"))
+	app.Get("/help.css", serveWebAsset("help.css", "text/css; charset=utf-8"))
+	app.Get("/help.js", serveWebAsset("help.js", "text/javascript; charset=utf-8"))
 
 	// ============================================================================
 	// MailDev-compatible API routes (maintains backward compatibility)
@@ -100,10 +104,10 @@ func (api *API) setupRoutes() {
 	// ============================================================================
 	api.setupImprovedAPIRoutes(app)
 
-	// Root route - serve index.html
-	app.Get("/", func(c fiber.Ctx) error {
-		return c.SendFile("./web/index.html")
-	})
+	// Browser UI and local help.
+	app.Get("/", serveWebAsset("index.html", "text/html; charset=utf-8"))
+	app.Get("/help", serveWebAsset("help.html", "text/html; charset=utf-8"))
+	app.Get("/help/", serveWebAsset("help.html", "text/html; charset=utf-8"))
 
 	// Serve index.html for all non-API routes (NoRoute equivalent)
 	app.All("*", func(c fiber.Ctx) error {
@@ -114,13 +118,27 @@ func (api *API) setupRoutes() {
 			strings.HasPrefix(path, "/socket.io") ||
 			strings.HasPrefix(path, "/api/") ||
 			strings.HasPrefix(path, "/style.css") ||
-			strings.HasPrefix(path, "/app.js") {
+			strings.HasPrefix(path, "/app.js") ||
+			strings.HasPrefix(path, "/help.css") ||
+			strings.HasPrefix(path, "/help.js") {
 			return c.Next()
 		}
-		return c.SendFile("./web/index.html")
+		return serveWebAsset("index.html", "text/html; charset=utf-8")(c)
 	})
 
 	api.app = app
+}
+
+// serveWebAsset returns a handler for a build-time embedded browser asset.
+func serveWebAsset(name, contentType string) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		content, err := webassets.ReadFile(name)
+		if err != nil {
+			return c.Status(http.StatusInternalServerError).SendString("embedded web asset unavailable")
+		}
+		c.Set(fiber.HeaderContentType, contentType)
+		return c.Send(content)
+	}
 }
 
 // setupImprovedAPIRoutes sets up improved RESTful API routes

--- a/internal/api/api_middleware_test.go
+++ b/internal/api/api_middleware_test.go
@@ -61,6 +61,30 @@ func TestBasicAuthMiddleware(t *testing.T) {
 	}
 }
 
+func TestHelpPageRequiresBasicAuth(t *testing.T) {
+	tmpDir := t.TempDir()
+	server, err := mailserver.NewMailServer(1025, "localhost", tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create mail server: %v", err)
+	}
+	defer func() {
+		if err := server.Close(); err != nil {
+			t.Errorf("Failed to close server: %v", err)
+		}
+	}()
+
+	api := NewAPIWithAuth(server, 1080, "localhost", "user", "pass")
+	req, _ := http.NewRequest(http.MethodGet, "/help", nil)
+	resp, err := api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
+	if err != nil {
+		t.Fatalf("Test request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("Expected help page status 401, got %d", resp.StatusCode)
+	}
+}
+
 func TestBasicAuthMiddlewareSuccess(t *testing.T) {
 	tmpDir := t.TempDir()
 	server, err := mailserver.NewMailServer(1025, "localhost", tmpDir)

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -192,6 +193,61 @@ func TestAPISetupRoutes(t *testing.T) {
 	for _, path := range testCases {
 		req, _ := http.NewRequest("GET", path, nil)
 		_, _ = api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
+	}
+}
+
+func TestEmbeddedWebAssets(t *testing.T) {
+	api, server, _ := setupTestAPI(t)
+	defer func() {
+		if err := server.Close(); err != nil {
+			t.Errorf("Failed to close server: %v", err)
+		}
+	}()
+
+	// Embedded assets must not depend on the process being started from the
+	// repository root (for example, after `go install`).
+	t.Chdir(t.TempDir())
+
+	tests := []struct {
+		path        string
+		contentType string
+		contains    string
+	}{
+		{path: "/", contentType: "text/html", contains: `href="/help"`},
+		{path: "/some-page", contentType: "text/html", contains: "OwlMail"},
+		{path: "/help", contentType: "text/html", contains: "OwlMail Help"},
+		{path: "/help/", contentType: "text/html", contains: "快速上手 OwlMail"},
+		{path: "/style.css", contentType: "text/css", contains: ".header"},
+		{path: "/app.js", contentType: "text/javascript", contains: "connectWebSocket"},
+		{path: "/help.css", contentType: "text/css", contains: ".help-shell"},
+		{path: "/help.js", contentType: "text/javascript", contains: "applyLanguage"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, tt.path, nil)
+			if err != nil {
+				t.Fatalf("NewRequest(%q) error: %v", tt.path, err)
+			}
+			resp, err := api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
+			if err != nil {
+				t.Fatalf("GET %s failed: %v", tt.path, err)
+			}
+			body, readErr := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if readErr != nil {
+				t.Fatalf("reading %s response: %v", tt.path, readErr)
+			}
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("GET %s status = %d, want %d", tt.path, resp.StatusCode, http.StatusOK)
+			}
+			if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, tt.contentType) {
+				t.Errorf("GET %s Content-Type = %q, want prefix %q", tt.path, got, tt.contentType)
+			}
+			if !strings.Contains(string(body), tt.contains) {
+				t.Errorf("GET %s body does not contain %q", tt.path, tt.contains)
+			}
+		})
 	}
 }
 

--- a/web/app.js
+++ b/web/app.js
@@ -46,6 +46,7 @@ const i18n = {
         minutesAgo: '{minutes} 分钟前',
         hoursAgo: '{hours} 小时前',
         daysAgo: '{days} 天前',
+        help: '帮助',
         toggleTheme: '切换主题',
         switchLanguage: '切换语言',
         // API Error Codes
@@ -114,6 +115,7 @@ const i18n = {
         minutesAgo: '{minutes} minutes ago',
         hoursAgo: '{hours} hours ago',
         daysAgo: '{days} days ago',
+        help: 'Help',
         toggleTheme: 'Toggle Theme',
         switchLanguage: 'Switch Language',
         // API Error Codes
@@ -182,6 +184,7 @@ const i18n = {
         minutesAgo: 'vor {minutes} Minuten',
         hoursAgo: 'vor {hours} Stunden',
         daysAgo: 'vor {days} Tagen',
+        help: 'Hilfe',
         toggleTheme: 'Design umschalten',
         switchLanguage: 'Sprache wechseln',
         // API Error Codes
@@ -250,6 +253,7 @@ const i18n = {
         minutesAgo: '{minutes} minuti fa',
         hoursAgo: '{hours} ore fa',
         daysAgo: '{days} giorni fa',
+        help: 'Aiuto',
         toggleTheme: 'Cambia Tema',
         switchLanguage: 'Cambia Lingua',
         // API Error Codes
@@ -318,6 +322,7 @@ const i18n = {
         minutesAgo: 'il y a {minutes} minutes',
         hoursAgo: 'il y a {hours} heures',
         daysAgo: 'il y a {days} jours',
+        help: 'Aide',
         toggleTheme: 'Changer le Thème',
         switchLanguage: 'Changer la Langue',
         // API Error Codes
@@ -386,6 +391,7 @@ const i18n = {
         minutesAgo: '{minutes}분 전',
         hoursAgo: '{hours}시간 전',
         daysAgo: '{days}일 전',
+        help: '도움말',
         toggleTheme: '테마 전환',
         switchLanguage: '언어 전환',
         // API Error Codes
@@ -454,6 +460,7 @@ const i18n = {
         minutesAgo: '{minutes}分前',
         hoursAgo: '{hours}時間前',
         daysAgo: '{days}日前',
+        help: 'ヘルプ',
         toggleTheme: 'テーマを切り替え',
         switchLanguage: '言語を切り替え',
         // API Error Codes
@@ -778,6 +785,12 @@ function updateUI() {
     
     const deleteAllBtn = document.getElementById('deleteAllBtn');
     if (deleteAllBtn) deleteAllBtn.textContent = t('deleteAll');
+
+    const helpBtn = document.getElementById('helpBtn');
+    if (helpBtn) {
+        helpBtn.textContent = t('help');
+        helpBtn.title = t('help');
+    }
     
     // Update search
     const searchInput = document.getElementById('searchInput');
@@ -1301,4 +1314,3 @@ window.deleteEmail = deleteEmail;
 window.downloadEmail = downloadEmail;
 window.viewEmailSource = viewEmailSource;
 window.t = t; // Make translation function available globally
-

--- a/web/assets.go
+++ b/web/assets.go
@@ -1,0 +1,14 @@
+// Package webassets exposes OwlMail's browser UI as build-time embedded files.
+package webassets
+
+import "embed"
+
+// files contains every asset required by the inbox and local help pages.
+//
+//go:embed *.css *.html *.js
+var files embed.FS
+
+// ReadFile returns an embedded web asset by its base name.
+func ReadFile(name string) ([]byte, error) {
+	return files.ReadFile(name)
+}

--- a/web/assets_test.go
+++ b/web/assets_test.go
@@ -1,0 +1,42 @@
+package webassets
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestRequiredAssetsAreEmbedded(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		contains []byte
+	}{
+		{name: "index.html", contains: []byte("OwlMail")},
+		{name: "app.js", contains: []byte("connectWebSocket")},
+		{name: "style.css", contains: []byte(".header")},
+		{name: "help.html", contains: []byte("OwlMail Help")},
+		{name: "help.css", contains: []byte(".help-shell")},
+		{name: "help.js", contains: []byte("applyLanguage")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			asset, err := ReadFile(tt.name)
+			if err != nil {
+				t.Fatalf("ReadFile(%q) error: %v", tt.name, err)
+			}
+			if !bytes.Contains(asset, tt.contains) {
+				t.Fatalf("ReadFile(%q) does not contain %q", tt.name, tt.contains)
+			}
+		})
+	}
+}
+
+func TestMissingAsset(t *testing.T) {
+	t.Parallel()
+
+	if _, err := ReadFile("missing.txt"); err == nil {
+		t.Fatal("ReadFile(missing.txt) unexpectedly succeeded")
+	}
+}

--- a/web/help.css
+++ b/web/help.css
@@ -1,0 +1,263 @@
+:root {
+    color-scheme: light dark;
+    --bg: #f3f5f7;
+    --surface: #ffffff;
+    --surface-soft: #f7fafc;
+    --text: #1d2935;
+    --muted: #607080;
+    --line: #dce3e8;
+    --accent: #1677a8;
+    --accent-soft: #e5f4fb;
+    --code: #17222d;
+    --code-text: #e7f1f7;
+    --shadow: 0 14px 34px rgba(35, 55, 70, 0.09);
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+    margin: 0;
+    color: var(--text);
+    background:
+        radial-gradient(circle at 10% 0%, rgba(22, 119, 168, 0.11), transparent 27rem),
+        var(--bg);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    line-height: 1.65;
+}
+
+body.dark-theme {
+    --bg: #111820;
+    --surface: #1b252e;
+    --surface-soft: #202d37;
+    --text: #e7eef3;
+    --muted: #a9bac6;
+    --line: #344550;
+    --accent: #5fc3f0;
+    --accent-soft: #173b4e;
+    --code: #0c1218;
+    --code-text: #e7f1f7;
+    --shadow: 0 14px 34px rgba(0, 0, 0, 0.25);
+}
+
+a { color: var(--accent); }
+
+.help-shell {
+    width: min(1120px, calc(100% - 32px));
+    margin: 0 auto;
+}
+
+.help-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    padding: 22px 0;
+}
+
+.brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--text);
+    font-size: 1.25rem;
+    font-weight: 750;
+    text-decoration: none;
+}
+
+.help-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.control {
+    min-height: 40px;
+    padding: 8px 12px;
+    border: 1px solid var(--line);
+    border-radius: 9px;
+    color: var(--text);
+    background: var(--surface);
+    font: inherit;
+}
+
+.icon-button { min-width: 42px; cursor: pointer; }
+.back-link { display: inline-flex; align-items: center; text-decoration: none; }
+
+.hero {
+    padding: 72px clamp(24px, 6vw, 72px);
+    border: 1px solid var(--line);
+    border-radius: 24px;
+    background: linear-gradient(135deg, var(--surface), var(--accent-soft));
+    box-shadow: var(--shadow);
+}
+
+.eyebrow {
+    margin: 0 0 10px;
+    color: var(--accent);
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0.16em;
+}
+
+.hero h1 {
+    max-width: 780px;
+    margin: 0;
+    font-size: clamp(2.2rem, 6vw, 4.6rem);
+    line-height: 1.02;
+    letter-spacing: -0.045em;
+}
+
+.hero-copy {
+    max-width: 760px;
+    margin: 24px 0 0;
+    color: var(--muted);
+    font-size: 1.12rem;
+}
+
+.toc {
+    position: sticky;
+    top: 12px;
+    z-index: 5;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 22px 0;
+    padding: 10px;
+    border: 1px solid var(--line);
+    border-radius: 13px;
+    background: color-mix(in srgb, var(--surface) 90%, transparent);
+    backdrop-filter: blur(12px);
+}
+
+.toc a {
+    padding: 7px 11px;
+    border-radius: 7px;
+    color: var(--muted);
+    font-size: 0.9rem;
+    text-decoration: none;
+}
+
+.toc a:hover { color: var(--accent); background: var(--accent-soft); }
+
+.help-card {
+    margin: 18px 0;
+    padding: clamp(24px, 5vw, 48px);
+    scroll-margin-top: 94px;
+    border: 1px solid var(--line);
+    border-radius: 18px;
+    background: var(--surface);
+    box-shadow: var(--shadow);
+}
+
+.section-heading {
+    display: flex;
+    align-items: baseline;
+    gap: 13px;
+    margin-bottom: 22px;
+}
+
+.section-heading span { color: var(--accent); font-weight: 800; }
+.section-heading h2 { margin: 0; font-size: clamp(1.5rem, 3vw, 2.2rem); line-height: 1.2; }
+h3 { margin-top: 26px; margin-bottom: 8px; }
+p { margin-top: 0; }
+
+code {
+    padding: 0.12em 0.35em;
+    border-radius: 5px;
+    color: var(--text);
+    background: var(--accent-soft);
+    font-family: "SFMono-Regular", Consolas, monospace;
+    font-size: 0.9em;
+}
+
+pre {
+    max-width: 100%;
+    margin: 14px 0 0;
+    padding: 18px;
+    overflow-x: auto;
+    border-radius: 11px;
+    background: var(--code);
+}
+
+pre code { padding: 0; color: var(--code-text); background: transparent; }
+.steps { display: grid; gap: 23px; padding-left: 24px; }
+.steps li { padding-left: 6px; }
+
+.note {
+    margin-top: 24px;
+    padding: 16px 18px;
+    border-left: 4px solid var(--accent);
+    border-radius: 7px;
+    background: var(--accent-soft);
+}
+
+.feature-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 13px;
+}
+
+.feature-grid > div {
+    padding: 20px;
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    background: var(--surface-soft);
+}
+
+.feature-grid h3 { margin-top: 0; }
+.feature-grid p { margin-bottom: 0; color: var(--muted); }
+.table-wrap { overflow-x: auto; }
+
+table { width: 100%; border-collapse: collapse; font-size: 0.92rem; }
+th, td { padding: 13px 12px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+th { color: var(--muted); font-size: 0.78rem; letter-spacing: 0.04em; text-transform: uppercase; }
+
+.endpoint-list { display: grid; gap: 1px; overflow: hidden; border: 1px solid var(--line); border-radius: 11px; background: var(--line); }
+.endpoint-list div { display: grid; grid-template-columns: minmax(245px, 0.8fr) 1fr; gap: 20px; padding: 13px 16px; background: var(--surface-soft); }
+.endpoint-list span, .muted { color: var(--muted); }
+.muted { margin-top: 18px; }
+
+.checklist { display: grid; gap: 14px; padding-left: 23px; }
+.checklist li::marker { color: var(--accent); }
+
+details { padding: 15px 0; border-bottom: 1px solid var(--line); }
+details:last-child { border-bottom: 0; }
+summary { cursor: pointer; font-weight: 700; }
+details p { margin: 10px 0 0; color: var(--muted); }
+
+footer {
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+    padding: 38px 0 54px;
+    color: var(--muted);
+    text-align: center;
+}
+
+.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+.lang-zh { display: none; }
+html[data-language="zh-CN"] .lang-en { display: none; }
+html[data-language="zh-CN"] .lang-zh { display: initial; }
+
+@media (max-width: 720px) {
+    .help-shell { width: min(100% - 20px, 1120px); }
+    .help-header { align-items: flex-start; }
+    .help-actions { justify-content: flex-end; flex-wrap: wrap; }
+    .hero { padding: 44px 24px; }
+    .feature-grid { grid-template-columns: 1fr; }
+    .endpoint-list div { grid-template-columns: 1fr; gap: 7px; }
+    footer { flex-direction: column; }
+}
+
+@media (max-width: 480px) {
+    .help-header { flex-direction: column; }
+    .help-actions { justify-content: flex-start; }
+    .toc { position: static; }
+    .help-card { padding: 22px 17px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html { scroll-behavior: auto; }
+}

--- a/web/help.html
+++ b/web/help.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="en" data-language="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Local OwlMail setup, usage, API, security, and troubleshooting guide.">
+    <title>OwlMail Help</title>
+    <link rel="stylesheet" href="/help.css">
+</head>
+<body class="light-theme">
+    <div class="help-shell">
+        <header class="help-header">
+            <a class="brand" href="/" aria-label="OwlMail inbox">🦉 <span>OwlMail</span></a>
+            <nav class="help-actions" aria-label="Page controls">
+                <label class="sr-only" for="helpLanguage">Language</label>
+                <select id="helpLanguage" class="control" aria-label="Language">
+                    <option value="en">English</option>
+                    <option value="zh-CN">简体中文</option>
+                </select>
+                <button id="helpTheme" class="control icon-button" type="button" aria-label="Toggle theme">🌙</button>
+                <a class="control back-link" href="/">
+                    <span class="lang-copy lang-en">Back to inbox</span>
+                    <span class="lang-copy lang-zh">返回收件箱</span>
+                </a>
+            </nav>
+        </header>
+
+        <main>
+            <section class="hero">
+                <p class="eyebrow">LOCAL GUIDE · 本地指南</p>
+                <h1>
+                    <span class="lang-copy lang-en">Get productive with OwlMail</span>
+                    <span class="lang-copy lang-zh">快速上手 OwlMail</span>
+                </h1>
+                <p class="hero-copy lang-copy lang-en">Everything needed to receive, inspect, persist, and relay development email—served locally by this OwlMail instance.</p>
+                <p class="hero-copy lang-copy lang-zh">接收、检查、持久化和转发开发邮件所需的核心说明，由当前 OwlMail 实例在本地直接提供。</p>
+            </section>
+
+            <article class="language-panel" data-language="en">
+                <nav class="toc" aria-label="On this page">
+                    <a href="#en-quick-start">Quick start</a>
+                    <a href="#en-workflow">Inbox workflow</a>
+                    <a href="#en-config">Configuration</a>
+                    <a href="#en-api">API</a>
+                    <a href="#en-security">Security</a>
+                    <a href="#en-troubleshooting">Troubleshooting</a>
+                </nav>
+
+                <section id="en-quick-start" class="help-card">
+                    <div class="section-heading"><span>01</span><h2>Quick start</h2></div>
+                    <p>OwlMail listens for SMTP on <code>localhost:1025</code> and serves the inbox on <code>http://localhost:1080</code> by default.</p>
+                    <ol class="steps">
+                        <li>
+                            <strong>Point your application at OwlMail.</strong>
+                            <pre><code>SMTP_HOST=localhost
+SMTP_PORT=1025
+SMTP_SECURE=false</code></pre>
+                        </li>
+                        <li>
+                            <strong>Send a message from your application</strong>, or run this smoke test if your curl build supports SMTP:
+                            <pre><code>printf 'From: dev@example.test\r\nTo: inbox@example.test\r\nSubject: OwlMail test\r\n\r\nHello from OwlMail.\r\n' \
+  | curl --url smtp://localhost:1025 \
+      --mail-from dev@example.test \
+      --mail-rcpt inbox@example.test \
+      --upload-file -</code></pre>
+                        </li>
+                        <li><strong>Open the inbox.</strong> New messages appear live through WebSocket updates.</li>
+                    </ol>
+                    <aside class="note"><strong>Container networking:</strong> another container should use the OwlMail service name, not <code>localhost</code>. A host application connecting to Docker Desktop can continue to use the published port.</aside>
+                </section>
+
+                <section id="en-workflow" class="help-card">
+                    <div class="section-heading"><span>02</span><h2>Inbox workflow</h2></div>
+                    <div class="feature-grid">
+                        <div><h3>Inspect</h3><p>Search messages, view HTML or text bodies, inspect recipient metadata, and download attachments.</p></div>
+                        <div><h3>Debug</h3><p>Use <strong>View Source</strong> for raw headers and MIME structure, or download the original <code>.eml</code>.</p></div>
+                        <div><h3>Manage</h3><p>Mark all messages read, delete one message, or clear the inbox. Deletion is permanent.</p></div>
+                        <div><h3>Relay</h3><p>Configure an outgoing SMTP server before relaying captured messages to a real recipient.</p></div>
+                    </div>
+                </section>
+
+                <section id="en-config" class="help-card">
+                    <div class="section-heading"><span>03</span><h2>Essential configuration</h2></div>
+                    <p>CLI flags take precedence over <code>MAILDEV_*</code> variables, then <code>OWLMAIL_*</code> variables. Restart OwlMail after changing startup configuration.</p>
+                    <div class="table-wrap">
+                        <table>
+                            <thead><tr><th>Purpose</th><th>Flag</th><th>Environment</th><th>Default</th></tr></thead>
+                            <tbody>
+                                <tr><td>SMTP listener</td><td><code>-smtp</code>, <code>-ip</code></td><td><code>OWLMAIL_SMTP_PORT</code>, <code>OWLMAIL_SMTP_HOST</code></td><td><code>1025</code>, <code>localhost</code></td></tr>
+                                <tr><td>Web listener</td><td><code>-web</code>, <code>-web-ip</code></td><td><code>OWLMAIL_WEB_PORT</code>, <code>OWLMAIL_WEB_HOST</code></td><td><code>1080</code>, <code>localhost</code></td></tr>
+                                <tr><td>Persistent mail</td><td><code>-mail-directory</code></td><td><code>OWLMAIL_MAIL_DIR</code></td><td>Process-specific temporary directory</td></tr>
+                                <tr><td>Web authentication</td><td><code>-web-user</code>, <code>-web-password</code></td><td><code>OWLMAIL_WEB_USER</code>, <code>OWLMAIL_WEB_PASSWORD</code></td><td>Disabled</td></tr>
+                                <tr><td>SMTP authentication</td><td><code>-smtp-user</code>, <code>-smtp-password</code></td><td><code>OWLMAIL_SMTP_USER</code>, <code>OWLMAIL_SMTP_PASSWORD</code></td><td>Disabled</td></tr>
+                                <tr><td>SMTP TLS</td><td><code>-tls</code>, <code>-tls-cert</code>, <code>-tls-key</code></td><td><code>OWLMAIL_TLS_ENABLED</code>, certificate/key variables</td><td>Disabled</td></tr>
+                                <tr><td>Web HTTPS</td><td><code>-https</code>, <code>-https-cert</code>, <code>-https-key</code></td><td><code>OWLMAIL_HTTPS_ENABLED</code>, certificate/key variables</td><td>Disabled</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <h3>Persistent Docker example</h3>
+                    <pre><code>docker run -d --name owlmail \
+  -p 1025:1025 -p 1080:1080 \
+  -v owlmail-data:/app/mail \
+  ghcr.io/soulteary/owlmail:latest</code></pre>
+                </section>
+
+                <section id="en-api" class="help-card">
+                    <div class="section-heading"><span>04</span><h2>API essentials</h2></div>
+                    <div class="endpoint-list">
+                        <div><code>GET /api/v1/emails</code><span>List and search messages</span></div>
+                        <div><code>GET /api/v1/emails/:id</code><span>Read a message</span></div>
+                        <div><code>GET /api/v1/emails/:id/raw</code><span>Download the original message</span></div>
+                        <div><code>DELETE /api/v1/emails/:id</code><span>Delete a message</span></div>
+                        <div><code>GET /api/v1/health</code><span>Health check</span></div>
+                        <div><code>GET /api/v1/version</code><span>Build/version information</span></div>
+                        <div><code>GET /api/v1/ws</code><span>Live WebSocket events</span></div>
+                    </div>
+                    <p class="muted">MailDev-compatible endpoints under <code>/email</code>, <code>/config</code>, <code>/healthz</code>, and <code>/socket.io</code> remain available.</p>
+                </section>
+
+                <section id="en-security" class="help-card">
+                    <div class="section-heading"><span>05</span><h2>Security checklist</h2></div>
+                    <ul class="checklist">
+                        <li>Keep the default loopback binding for local-only development.</li>
+                        <li>If exposed to a network, set both web credentials and SMTP credentials; terminate TLS as appropriate.</li>
+                        <li>Captured messages can contain credentials, reset links, and personal data. Protect the storage directory and backups.</li>
+                        <li>Use development or test messages only. Review recipients carefully before enabling outgoing relay or auto-relay.</li>
+                    </ul>
+                </section>
+
+                <section id="en-troubleshooting" class="help-card">
+                    <div class="section-heading"><span>06</span><h2>Troubleshooting</h2></div>
+                    <details><summary>The application cannot connect to SMTP</summary><p>Confirm host and port, check whether OwlMail is bound to the expected interface, and verify Docker port publishing. TLS must match on both sides.</p></details>
+                    <details><summary>The inbox is empty after restart</summary><p>Set <code>-mail-directory</code> or <code>OWLMAIL_MAIL_DIR</code>. In Docker, mount a volume at <code>/app/mail</code>.</p></details>
+                    <details><summary>Live updates stopped</summary><p>Refresh the page and check that proxies allow WebSocket upgrade requests to <code>/api/v1/ws</code>.</p></details>
+                    <details><summary>HTML looks different from a real mailbox</summary><p>OwlMail previews captured HTML in an isolated frame. Email clients apply different CSS and security rules, so validate important templates in target clients too.</p></details>
+                </section>
+            </article>
+
+            <article class="language-panel" data-language="zh-CN" hidden>
+                <nav class="toc" aria-label="本页目录">
+                    <a href="#zh-quick-start">快速开始</a>
+                    <a href="#zh-workflow">收件箱操作</a>
+                    <a href="#zh-config">配置</a>
+                    <a href="#zh-api">API</a>
+                    <a href="#zh-security">安全</a>
+                    <a href="#zh-troubleshooting">问题排查</a>
+                </nav>
+
+                <section id="zh-quick-start" class="help-card">
+                    <div class="section-heading"><span>01</span><h2>快速开始</h2></div>
+                    <p>默认情况下，OwlMail 在 <code>localhost:1025</code> 接收 SMTP 邮件，并在 <code>http://localhost:1080</code> 提供收件箱界面。</p>
+                    <ol class="steps">
+                        <li>
+                            <strong>将应用的 SMTP 指向 OwlMail。</strong>
+                            <pre><code>SMTP_HOST=localhost
+SMTP_PORT=1025
+SMTP_SECURE=false</code></pre>
+                        </li>
+                        <li>
+                            <strong>从应用发送邮件</strong>；如果本机 curl 支持 SMTP，也可以运行以下冒烟测试：
+                            <pre><code>printf 'From: dev@example.test\r\nTo: inbox@example.test\r\nSubject: OwlMail test\r\n\r\nHello from OwlMail.\r\n' \
+  | curl --url smtp://localhost:1025 \
+      --mail-from dev@example.test \
+      --mail-rcpt inbox@example.test \
+      --upload-file -</code></pre>
+                        </li>
+                        <li><strong>打开收件箱。</strong>新邮件会通过 WebSocket 实时出现。</li>
+                    </ol>
+                    <aside class="note"><strong>容器网络：</strong>其他容器应使用 OwlMail 的服务名，而不是 <code>localhost</code>；宿主机应用可继续连接已映射的端口。</aside>
+                </section>
+
+                <section id="zh-workflow" class="help-card">
+                    <div class="section-heading"><span>02</span><h2>收件箱操作</h2></div>
+                    <div class="feature-grid">
+                        <div><h3>检查</h3><p>搜索邮件、查看 HTML 或纯文本正文、检查收件人信息并下载附件。</p></div>
+                        <div><h3>调试</h3><p>通过“查看源码”检查原始邮件头与 MIME 结构，或下载原始 <code>.eml</code>。</p></div>
+                        <div><h3>管理</h3><p>可全部标记为已读、删除单封邮件或清空收件箱。删除后不可恢复。</p></div>
+                        <div><h3>转发</h3><p>需要先配置外发 SMTP，才能把捕获的邮件转发给真实收件人。</p></div>
+                    </div>
+                </section>
+
+                <section id="zh-config" class="help-card">
+                    <div class="section-heading"><span>03</span><h2>核心配置</h2></div>
+                    <p>优先级依次为命令行参数、<code>MAILDEV_*</code> 环境变量、<code>OWLMAIL_*</code> 环境变量。修改启动配置后需要重启 OwlMail。</p>
+                    <div class="table-wrap">
+                        <table>
+                            <thead><tr><th>用途</th><th>参数</th><th>环境变量</th><th>默认值</th></tr></thead>
+                            <tbody>
+                                <tr><td>SMTP 监听</td><td><code>-smtp</code>、<code>-ip</code></td><td><code>OWLMAIL_SMTP_PORT</code>、<code>OWLMAIL_SMTP_HOST</code></td><td><code>1025</code>、<code>localhost</code></td></tr>
+                                <tr><td>Web 监听</td><td><code>-web</code>、<code>-web-ip</code></td><td><code>OWLMAIL_WEB_PORT</code>、<code>OWLMAIL_WEB_HOST</code></td><td><code>1080</code>、<code>localhost</code></td></tr>
+                                <tr><td>邮件持久化</td><td><code>-mail-directory</code></td><td><code>OWLMAIL_MAIL_DIR</code></td><td>当前进程专用临时目录</td></tr>
+                                <tr><td>Web 认证</td><td><code>-web-user</code>、<code>-web-password</code></td><td><code>OWLMAIL_WEB_USER</code>、<code>OWLMAIL_WEB_PASSWORD</code></td><td>关闭</td></tr>
+                                <tr><td>SMTP 认证</td><td><code>-smtp-user</code>、<code>-smtp-password</code></td><td><code>OWLMAIL_SMTP_USER</code>、<code>OWLMAIL_SMTP_PASSWORD</code></td><td>关闭</td></tr>
+                                <tr><td>SMTP TLS</td><td><code>-tls</code>、证书和私钥参数</td><td><code>OWLMAIL_TLS_ENABLED</code>、证书和私钥变量</td><td>关闭</td></tr>
+                                <tr><td>Web HTTPS</td><td><code>-https</code>、证书和私钥参数</td><td><code>OWLMAIL_HTTPS_ENABLED</code>、证书和私钥变量</td><td>关闭</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <h3>Docker 持久化示例</h3>
+                    <pre><code>docker run -d --name owlmail \
+  -p 1025:1025 -p 1080:1080 \
+  -v owlmail-data:/app/mail \
+  ghcr.io/soulteary/owlmail:latest</code></pre>
+                </section>
+
+                <section id="zh-api" class="help-card">
+                    <div class="section-heading"><span>04</span><h2>常用 API</h2></div>
+                    <div class="endpoint-list">
+                        <div><code>GET /api/v1/emails</code><span>列出和搜索邮件</span></div>
+                        <div><code>GET /api/v1/emails/:id</code><span>读取单封邮件</span></div>
+                        <div><code>GET /api/v1/emails/:id/raw</code><span>下载原始邮件</span></div>
+                        <div><code>DELETE /api/v1/emails/:id</code><span>删除单封邮件</span></div>
+                        <div><code>GET /api/v1/health</code><span>健康检查</span></div>
+                        <div><code>GET /api/v1/version</code><span>构建和版本信息</span></div>
+                        <div><code>GET /api/v1/ws</code><span>实时 WebSocket 事件</span></div>
+                    </div>
+                    <p class="muted"><code>/email</code>、<code>/config</code>、<code>/healthz</code> 和 <code>/socket.io</code> 下兼容 MailDev 的接口仍然可用。</p>
+                </section>
+
+                <section id="zh-security" class="help-card">
+                    <div class="section-heading"><span>05</span><h2>安全检查清单</h2></div>
+                    <ul class="checklist">
+                        <li>仅用于本地开发时，保留默认的回环地址监听。</li>
+                        <li>暴露到网络时，同时设置 Web 和 SMTP 凭据，并按场景启用或终止 TLS。</li>
+                        <li>捕获的邮件可能包含凭据、重置链接和个人信息，请保护存储目录及备份。</li>
+                        <li>只处理开发或测试邮件；开启外发转发或自动转发前，请仔细检查收件人。</li>
+                    </ul>
+                </section>
+
+                <section id="zh-troubleshooting" class="help-card">
+                    <div class="section-heading"><span>06</span><h2>问题排查</h2></div>
+                    <details><summary>应用无法连接 SMTP</summary><p>确认主机和端口，检查 OwlMail 是否监听预期网卡，并核对 Docker 端口映射。客户端和服务端的 TLS 设置必须一致。</p></details>
+                    <details><summary>重启后收件箱为空</summary><p>设置 <code>-mail-directory</code> 或 <code>OWLMAIL_MAIL_DIR</code>。在 Docker 中，需要把数据卷挂载到 <code>/app/mail</code>。</p></details>
+                    <details><summary>实时更新停止</summary><p>刷新页面，并确认代理允许 <code>/api/v1/ws</code> 的 WebSocket 升级请求。</p></details>
+                    <details><summary>HTML 与真实邮箱显示不同</summary><p>OwlMail 在隔离框架中预览捕获的 HTML。不同邮件客户端会应用不同的 CSS 和安全规则，重要模板仍应在目标客户端中验证。</p></details>
+                </section>
+            </article>
+        </main>
+
+        <footer>
+            <span class="lang-copy lang-en">Need the complete reference?</span>
+            <span class="lang-copy lang-zh">需要完整参考资料？</span>
+            <a href="https://github.com/soulteary/owlmail/tree/main/docs" target="_blank" rel="noopener noreferrer">
+                <span class="lang-copy lang-en">Open project documentation ↗</span>
+                <span class="lang-copy lang-zh">打开项目文档 ↗</span>
+            </a>
+        </footer>
+    </div>
+    <script src="/help.js"></script>
+</body>
+</html>

--- a/web/help.js
+++ b/web/help.js
@@ -1,0 +1,56 @@
+(() => {
+    const supportedLanguages = new Set(['en', 'zh-CN']);
+    const languageSelect = document.getElementById('helpLanguage');
+    const themeButton = document.getElementById('helpTheme');
+
+    function readPreference(key) {
+        try {
+            return localStorage.getItem(key);
+        } catch (_) {
+            return null;
+        }
+    }
+
+    function savePreference(key, value) {
+        try {
+            localStorage.setItem(key, value);
+        } catch (_) {
+            // The help page still works when storage is blocked.
+        }
+    }
+
+    function detectLanguage() {
+        const saved = readPreference('language');
+        if (saved && supportedLanguages.has(saved)) return saved;
+        return (navigator.language || '').toLowerCase().startsWith('zh') ? 'zh-CN' : 'en';
+    }
+
+    function applyLanguage(language) {
+        const selected = supportedLanguages.has(language) ? language : 'en';
+        document.documentElement.lang = selected;
+        document.documentElement.dataset.language = selected;
+        document.title = selected === 'zh-CN' ? 'OwlMail 本地帮助' : 'OwlMail Help';
+        languageSelect.value = selected;
+        document.querySelectorAll('.language-panel').forEach((panel) => {
+            panel.hidden = panel.dataset.language !== selected;
+        });
+        savePreference('language', selected);
+    }
+
+    function applyTheme(theme) {
+        const dark = theme === 'dark';
+        document.body.classList.toggle('dark-theme', dark);
+        document.body.classList.toggle('light-theme', !dark);
+        themeButton.textContent = dark ? '☀️' : '🌙';
+        themeButton.setAttribute('aria-label', dark ? 'Use light theme' : 'Use dark theme');
+        savePreference('theme', dark ? 'dark' : 'light');
+    }
+
+    languageSelect.addEventListener('change', (event) => applyLanguage(event.target.value));
+    themeButton.addEventListener('click', () => {
+        applyTheme(document.body.classList.contains('dark-theme') ? 'light' : 'dark');
+    });
+
+    applyLanguage(detectLanguage());
+    applyTheme(readPreference('theme') === 'dark' ? 'dark' : 'light');
+})();

--- a/web/index.html
+++ b/web/index.html
@@ -14,6 +14,7 @@
                 <h1>🦉 OwlMail</h1>
                 <div class="header-actions">
                     <select id="langSelect" class="lang-select" title="Switch Language"></select>
+                    <a id="helpBtn" class="btn btn-secondary btn-link" href="/help" target="_blank" rel="noopener">Help</a>
                     <button id="themeToggle" class="btn btn-secondary" title="Toggle Theme">🌙</button>
                     <button id="refreshBtn" class="btn btn-primary">Refresh</button>
                     <button id="markAllReadBtn" class="btn btn-secondary">Mark All Read</button>
@@ -75,4 +76,3 @@
     <script src="app.js"></script>
 </body>
 </html>
-

--- a/web/style.css
+++ b/web/style.css
@@ -90,6 +90,13 @@ body {
     transition: all 0.3s;
 }
 
+.btn-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+}
+
 .btn:hover {
     opacity: 0.9;
     transform: translateY(-1px);
@@ -666,4 +673,3 @@ body.dark-theme ::-webkit-scrollbar-thumb {
 body.dark-theme ::-webkit-scrollbar-thumb:hover {
     background: #777;
 }
-


### PR DESCRIPTION
## Summary

- add a bilingual local help page at `/help` with setup, configuration, API, security, and troubleshooting guidance
- add a localized Help button to the inbox UI
- embed the inbox and help assets into the Go executable
- remove the runtime Docker dependency on a separate `web/` directory
- keep the help page behind HTTP Basic Auth when authentication is enabled

## Verification

- `go test -race ./...`
- `go vet ./...`
- `go build -trimpath`
- JavaScript syntax checks for both UI scripts
- started the compiled binary from an unrelated temporary working directory and fetched the inbox/help assets successfully