### PR TITLE
docs: expand webhook examples and local help

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,11 +429,14 @@ EOF
 ### Webhook Forwarding
 
 ```bash
-export OWLMAIL_WEBHOOK_SECRET='replace-with-a-random-secret'
-./owlmail -webhook-config ./examples/webhooks.json
+# Terminal 1: local test receiver
+go run ./examples/webhooks/receiver
+
+# Terminal 2: forward every new email with the default JSON payload
+./owlmail -webhook-config ./examples/webhooks/minimal.json
 ```
 
-Webhook targets support case-insensitive wildcard rules, custom JSON-safe body templates, environment-backed secrets, HMAC-SHA256 signatures, timeouts, and bounded retries. See the [Webhook forwarding guide](./docs/en/Webhook-Forwarding.md), including a ready-to-use `soulteary/webhook` example.
+Webhook targets support case-insensitive wildcard rules, custom JSON-safe body templates, environment-backed secrets, HMAC-SHA256 signatures, timeouts, and bounded retries. See the [scenario examples](./examples/webhooks/README.md) for filtering, custom APIs, multiple targets, plain text, and a runnable `soulteary/webhook` stack. The [Webhook forwarding guide](./docs/en/Webhook-Forwarding.md) is the complete reference.
 
 ### Using HTTPS
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -426,11 +426,14 @@ EOF
 ### Webhook 消息转发
 
 ```bash
-export OWLMAIL_WEBHOOK_SECRET='请替换为随机密钥'
-./owlmail -webhook-config ./examples/webhooks.json
+# 终端 1：启动本地测试接收器
+go run ./examples/webhooks/receiver
+
+# 终端 2：使用默认 JSON 请求体转发所有新邮件
+./owlmail -webhook-config ./examples/webhooks/minimal.json
 ```
 
-Webhook 目标支持不区分大小写的通配规则、JSON 安全的自定义请求体模板、环境变量密钥、HMAC-SHA256 签名、超时和有限重试。完整配置和 `soulteary/webhook` 对接方式见 [Webhook 消息转发指南](./docs/zh-CN/Webhook-Forwarding.md)。
+Webhook 目标支持不区分大小写的通配规则、JSON 安全的自定义请求体模板、环境变量密钥、HMAC-SHA256 签名、超时和有限重试。[场景示例](./examples/webhooks/README.zh-CN.md)覆盖过滤、自定义 API、多目标、纯文本和可直接运行的 `soulteary/webhook` 联动；完整参考见 [Webhook 消息转发指南](./docs/zh-CN/Webhook-Forwarding.md)。
 
 ### 使用 HTTPS
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,11 +4,11 @@ Welcome to the OwlMail documentation directory. This directory contains technica
 
 ## 📸 Preview
 
-![OwlMail Preview](../../.github/assets/preview.png)
+![OwlMail Preview](../.github/assets/preview.png)
 
 ## 🎥 Demo Video
 
-![Demo Video](../../.github/assets/realtime.gif)
+![Demo Video](../.github/assets/realtime.gif)
 
 ## 🌍 Languages / 语言 / Sprachen / Langues / Lingue / 言語 / 언어
 
@@ -27,6 +27,7 @@ Select your preferred language:
 - [OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper](./en/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [API Refactoring Record](./en/internal/API_Refactoring_Record.md)
 - [Webhook Forwarding](./en/Webhook-Forwarding.md)
+- [Webhook Scenario Examples](../examples/webhooks/README.md)
 
 ---
 
@@ -39,6 +40,7 @@ Select your preferred language:
 - [OwlMail × MailDev - 功能与 API 完整对比与迁移白皮书](./zh-CN/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [API 重构记录](./zh-CN/internal/API_Refactoring_Record.md)
 - [Webhook 消息转发](./zh-CN/Webhook-Forwarding.md)
+- [Webhook 场景示例](../examples/webhooks/README.zh-CN.md)
 
 ---
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -22,6 +22,7 @@ Welcome to the OwlMail documentation directory. This directory contains technica
 
 - **[Webhook Forwarding](./Webhook-Forwarding.md)**
   - Configure filtering, custom payload templates, HMAC signatures, retries, and integration with `soulteary/webhook`.
+  - **Runnable examples**: [minimal, filtered, custom, multi-target, plain text, and Compose](../../examples/webhooks/README.md)
   - **Other languages**: [简体中文](../zh-CN/Webhook-Forwarding.md)
 
 - **[OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper](./OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)**

--- a/docs/en/Webhook-Forwarding.md
+++ b/docs/en/Webhook-Forwarding.md
@@ -4,10 +4,23 @@ OwlMail can send every matching new email to one or more HTTP endpoints. The fea
 
 ## Enable forwarding
 
-Create a JSON file and pass it to OwlMail:
+The smallest valid configuration needs only a target name and an HTTP(S) URL:
+
+```json
+{
+  "version": 1,
+  "targets": [
+    {
+      "name": "local-receiver",
+      "url": "http://127.0.0.1:18080/owlmail"
+    }
+  ]
+}
+```
+
+Save it and pass it to OwlMail:
 
 ```bash
-export OWLMAIL_WEBHOOK_SECRET='replace-with-a-random-secret'
 ./owlmail -webhook-config ./webhooks.json
 ```
 
@@ -17,7 +30,24 @@ The environment variable form is equivalent:
 export OWLMAIL_WEBHOOK_CONFIG=./webhooks.json
 ```
 
-See [`examples/webhooks.json`](../../examples/webhooks.json) for a complete configuration.
+If neither the flag nor environment variable is set, webhook forwarding is
+disabled. The configuration is validated once at startup; restart OwlMail after
+editing it.
+
+## Choose a runnable example
+
+| Scenario | Configuration |
+|---|---|
+| Minimal forwarding with the default payload | [`examples/webhooks/minimal.json`](../../examples/webhooks/minimal.json) |
+| Recipient and subject filtering | [`examples/webhooks/filtered-alerts.json`](../../examples/webhooks/filtered-alerts.json) |
+| Authenticated custom JSON and HMAC | [`examples/webhooks/custom-json.json`](../../examples/webhooks/custom-json.json) |
+| Archive plus filtered incident fan-out | [`examples/webhooks/multiple-targets.json`](../../examples/webhooks/multiple-targets.json) |
+| Plain-text request body | [`examples/webhooks/plain-text.json`](../../examples/webhooks/plain-text.json) |
+| Complete OwlMail + `soulteary/webhook` Compose stack | [`examples/webhooks/soulteary-webhook/`](../../examples/webhooks/soulteary-webhook/) |
+| Most options in one target | [`examples/webhooks.json`](../../examples/webhooks.json) |
+
+The [example walkthrough](../../examples/webhooks/README.md) includes a
+loopback-only receiver, exact startup commands, and a test SMTP message.
 
 ## Configuration format
 
@@ -52,10 +82,10 @@ See [`examples/webhooks.json`](../../examples/webhooks.json) for a complete conf
 |---|---:|---|
 | `version` | No | Configuration version. Omitted and `1` both mean version 1. |
 | `targets` | Yes | One to 32 destinations. Target names must be unique. |
-| `name` | Yes | Safe identifier used in logs; the full URL and configured secrets are never logged. |
-| `url` | Yes | Fixed `http` or `https` URL. Redirects are not followed. |
+| `name` | Yes | Safe identifier used in logs; maximum 100 characters with no newline. The full URL and configured secrets are never logged. |
+| `url` | Yes | Fixed `http` or `https` URL. User information and fragments are rejected; redirects are not followed. |
 | `method` | No | `POST` by default; `POST`, `PUT`, and `PATCH` are accepted. |
-| `headers` | No | Static request headers. `Host` and `Content-Length` cannot be overridden. |
+| `headers` | No | Static request headers. Header names and values are validated; `Host` and `Content-Length` cannot be overridden. |
 | `contentType` | No | `application/json` by default. An explicit `Content-Type` header takes precedence. |
 | `secret` | No | Generates `X-OwlMail-Signature: sha256=<hex>` over the exact request body. |
 | `timeout` | No | Per-attempt timeout; default `5s`, maximum `1m`. |
@@ -65,15 +95,40 @@ See [`examples/webhooks.json`](../../examples/webhooks.json) for a complete conf
 
 `${VARIABLE}` placeholders are supported in `url`, header values, and `secret`. OwlMail fails at startup if a referenced variable is missing, rather than silently sending an unauthenticated request.
 
+Only the braced `${VARIABLE}` form is expanded; `$VARIABLE` is treated as
+literal text. Environment expansion does not apply to `name`, `contentType`,
+matching rules, or `bodyTemplate`.
+
+### Validation and limits
+
+- The configuration file is limited to 1 MiB, must contain exactly one JSON
+  value, and rejects unknown fields.
+- Version 1 accepts 1–32 uniquely named targets.
+- A rendered request body is limited to 2 MiB. Oversized bodies fail before an
+  HTTP request is made.
+- Target timeout must be greater than zero and no more than one minute. The
+  default is five seconds per attempt.
+- `retries` counts extra attempts. For example, `2` means at most three total
+  requests for that target.
+- All targets and templates are compiled before SMTP and Web servers start, so
+  a configuration error fails fast without partially enabling forwarding.
+
 ## Matching rules
 
-The `from`, `to`, `subject`, and `text` fields accept arrays of shell-style patterns using `*` and `?`.
+The `from`, `to`, `subject`, and `text` fields accept arrays of Go
+shell-style patterns: `*`, `?`, character classes such as `[a-z]`, and `\`
+escapes. As with Go's `path.Match`, `*` does not match `/`.
 
 - Patterns inside one field are ORed.
 - Different non-empty fields are ANDed.
 - Empty fields match every email.
 - Matching is case-insensitive.
 - `to` considers envelope recipients as well as To, Cc, and Bcc headers.
+- `from` considers parsed From addresses and the SMTP envelope sender.
+- `text` matches the parsed plain-text body only; it does not search HTML or
+  attachments. An HTML-only email normally has an empty text value.
+- Matching by arbitrary headers is not supported. Use `.Headers` in a custom
+  template when the receiver needs header values.
 
 For example, this rule forwards alerts from any `example.com` sender only when their text contains a verification code:
 
@@ -105,6 +160,11 @@ Available helpers are:
 - `join STRINGS SEPARATOR`: join an address array.
 - `truncate STRING LENGTH`: truncate by Unicode code points.
 
+Templates use `missingkey=error`; a missing map key or template execution error
+fails that target delivery. Parsed addresses contain mailbox addresses without
+display names. `.Headers` may contain strings, arrays, or other parsed values,
+so pass it through `json` instead of assuming every value is a string.
+
 Always use `json` when placing email-controlled text into JSON:
 
 ```json
@@ -116,22 +176,65 @@ Without a template, OwlMail sends:
 ```json
 {
   "event": "email.received",
-  "message": "Subject followed by plain-text content",
+  "message": "Example\nMessage body",
   "email": {
     "id": "email-id",
+    "time": "2026-08-29T12:00:00Z",
     "subject": "Example",
     "from": ["sender@example.com"],
     "to": ["recipient@example.com"],
-    "text": "Message body"
+    "envelopeFrom": "sender@example.com",
+    "envelopeTo": ["recipient@example.com"],
+    "text": "Message body",
+    "html": "<p>Message body</p>",
+    "size": 123,
+    "sizeHuman": "123 B",
+    "attachments": [
+      {
+        "fileName": "report.txt",
+        "contentType": "text/plain",
+        "size": 42
+      }
+    ],
+    "attachmentCount": 1
   }
 }
 ```
 
-The exact email ID is also sent as `X-OwlMail-Email-ID`, which receivers can use as an idempotency key when retries produce a duplicate request.
+Empty optional arrays and strings such as `cc`, `bcc`, `html`, envelope fields,
+and `attachments` are omitted. `headers` is intentionally excluded from the
+default payload and is exposed only to explicit templates. Attachment bytes and
+local storage paths are never included.
+
+## Request headers
+
+| Header | Value |
+|---|---|
+| `Content-Type` | Target `contentType`, defaulting to `application/json`; an explicit custom header wins. |
+| `User-Agent` | `OwlMail-Webhook/1`, unless overridden by a custom header. |
+| `X-OwlMail-Event` | Always `email.received`. |
+| `X-OwlMail-Email-ID` | Exact OwlMail email ID; use it as an idempotency key. |
+| `X-OwlMail-Signature` | Present only when `secret` is set; `sha256=` plus lowercase hex HMAC over the exact body bytes. |
+
+Retries send the same body and email ID, so receivers should deduplicate before
+performing a non-idempotent action.
 
 ## Send to `soulteary/webhook`
 
-Use the hook URL exposed by [`soulteary/webhook`](https://github.com/soulteary/webhook):
+The runnable example starts both projects, validates HMAC, maps payload fields
+to environment variables, and executes a visible demo command:
+
+```bash
+cd examples/webhooks/soulteary-webhook
+export OWLMAIL_WEBHOOK_SECRET='replace-with-a-long-random-secret'
+docker compose up --build
+```
+
+Follow the [complete integration walkthrough](../../examples/webhooks/soulteary-webhook/README.md)
+to send a test message and inspect the result.
+
+For a manual deployment, use the hook URL exposed by
+[`soulteary/webhook`](https://github.com/soulteary/webhook):
 
 ```json
 {
@@ -147,9 +250,11 @@ Use the hook URL exposed by [`soulteary/webhook`](https://github.com/soulteary/w
 }
 ```
 
-One matching `soulteary/webhook` hook configuration is:
+One matching `soulteary/webhook` hook configuration is shown below. This is a
+Go-template source file, so it is intentionally not valid JSON until
+`soulteary/webhook -template` renders it:
 
-```json
+```text
 [
   {
     "id": "owlmail",
@@ -164,7 +269,7 @@ One matching `soulteary/webhook` hook configuration is:
     "trigger-rule": {
       "match": {
         "type": "payload-hmac-sha256",
-        "secret": "{{ getenv \"OWLMAIL_WEBHOOK_SECRET\" | js }}",
+        "secret": "{{ getenv "OWLMAIL_WEBHOOK_SECRET" | js }}",
         "parameter": { "source": "header", "name": "X-OwlMail-Signature" }
       }
     }
@@ -172,7 +277,45 @@ One matching `soulteary/webhook` hook configuration is:
 ]
 ```
 
-Start `soulteary/webhook` with its `-template` option when using `getenv` in the hook file. Give both containers the same `OWLMAIL_WEBHOOK_SECRET` value.
+Start `soulteary/webhook` with its `-template` option when using `getenv` in the
+hook file. Give both containers the same `OWLMAIL_WEBHOOK_SECRET` value.
+
+## Delivery lifecycle and troubleshooting
+
+1. OwlMail parses and stores the SMTP message first.
+2. The `new` event starts webhook delivery asynchronously, so a slow or failed
+   target does not change the SMTP result.
+3. Targets matching one email are called sequentially in configuration order.
+   Different email events may be delivered concurrently.
+4. A 2xx response completes the target. Network errors, 408, 425, 429, and 5xx
+   responses retry after approximately 100 ms, 200 ms, 400 ms, 800 ms, and
+   1.6 s as needed. `Retry-After` is not interpreted.
+5. Other 3xx/4xx responses fail immediately. Response bodies are not used.
+
+Forwarding has no persistent delivery queue or dead-letter store. After the
+configured attempts are exhausted, OwlMail keeps the email and logs the failure;
+it does not retry that event after a restart.
+
+For a local check, run the bundled receiver and the minimal configuration in
+separate terminals:
+
+```bash
+go run ./examples/webhooks/receiver
+go run ./cmd/owlmail -webhook-config ./examples/webhooks/minimal.json
+```
+
+When debugging:
+
+- A startup error normally means invalid JSON, an unknown field, a missing
+  `${VARIABLE}`, an invalid wildcard/duration, or a template parse error.
+- No request usually means the target did not match. Temporarily remove `match`
+  or start with `minimal.json`.
+- In containers, `127.0.0.1` points back to OwlMail. Use the receiver's service
+  name and container port.
+- HTTP 401/403 usually means the custom token or HMAC secret differs. HMAC covers
+  the exact body bytes; do not reformat the body before verifying it.
+- Successful deliveries are logged at verbose level. Failures are logged with
+  the safe target name, status, and attempt count, without the full URL or secret.
 
 ## Operational and security notes
 
@@ -182,3 +325,8 @@ Start `soulteary/webhook` with its `-template` option when using `getenv` in the
 - A successful response is any 2xx status. Redirects and other non-2xx responses are failures.
 - Delivery is asynchronous relative to SMTP storage. A failed webhook does not reject or delete the received email.
 - Retries can duplicate a request. Deduplicate with `email.id` or `X-OwlMail-Email-ID` before performing non-idempotent actions.
+- Default payloads may contain both plain-text and HTML email bodies. Use a
+  custom template to minimize data when a receiver needs only a title or code.
+- Webhook delivery is intended for notifications and automation, not as a
+  guaranteed message queue. Use a durable downstream endpoint when delivery
+  guarantees are required.

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -22,6 +22,7 @@
 
 - **[Webhook 消息转发](./Webhook-Forwarding.md)**
   - 配置邮件过滤、自定义消息模板、HMAC 签名、失败重试，以及与 `soulteary/webhook` 的对接。
+  - **可运行示例**：[最小、过滤、自定义、多目标、纯文本与 Compose 联动](../../examples/webhooks/README.zh-CN.md)
   - **其他语言**：[English](../en/Webhook-Forwarding.md)
 
 - **[OwlMail × MailDev - 功能与 API 完整对比与迁移白皮书](./OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)**

--- a/docs/zh-CN/Webhook-Forwarding.md
+++ b/docs/zh-CN/Webhook-Forwarding.md
@@ -4,10 +4,23 @@ OwlMail 可以把符合规则的新邮件发送到一个或多个 HTTP 端点。
 
 ## 开启转发
 
-创建 JSON 配置文件，并在启动时传给 OwlMail：
+最小有效配置只需要目标名称和 HTTP(S) 地址：
+
+```json
+{
+  "version": 1,
+  "targets": [
+    {
+      "name": "local-receiver",
+      "url": "http://127.0.0.1:18080/owlmail"
+    }
+  ]
+}
+```
+
+保存配置，并在启动时传给 OwlMail：
 
 ```bash
-export OWLMAIL_WEBHOOK_SECRET='请替换为随机密钥'
 ./owlmail -webhook-config ./webhooks.json
 ```
 
@@ -17,7 +30,23 @@ export OWLMAIL_WEBHOOK_SECRET='请替换为随机密钥'
 export OWLMAIL_WEBHOOK_CONFIG=./webhooks.json
 ```
 
-完整示例见 [`examples/webhooks.json`](../../examples/webhooks.json)。
+没有设置参数或环境变量时，Webhook 转发保持关闭。配置只在启动时校验一次；
+修改文件后需要重启 OwlMail。
+
+## 选择可运行示例
+
+| 场景 | 配置 |
+|---|---|
+| 使用默认请求体转发所有新邮件 | [`examples/webhooks/minimal.json`](../../examples/webhooks/minimal.json) |
+| 按收件人和主题过滤 | [`examples/webhooks/filtered-alerts.json`](../../examples/webhooks/filtered-alerts.json) |
+| 带鉴权的自定义 JSON 和 HMAC | [`examples/webhooks/custom-json.json`](../../examples/webhooks/custom-json.json) |
+| 全量归档与事故目标多路分发 | [`examples/webhooks/multiple-targets.json`](../../examples/webhooks/multiple-targets.json) |
+| 纯文本请求体 | [`examples/webhooks/plain-text.json`](../../examples/webhooks/plain-text.json) |
+| 完整 OwlMail + `soulteary/webhook` Compose 联动 | [`examples/webhooks/soulteary-webhook/`](../../examples/webhooks/soulteary-webhook/) |
+| 单个目标展示大部分参数 | [`examples/webhooks.json`](../../examples/webhooks.json) |
+
+[示例操作指南](../../examples/webhooks/README.zh-CN.md)包含仅监听本机的接收器、
+完整启动命令和测试 SMTP 邮件。
 
 ## 配置格式
 
@@ -52,10 +81,10 @@ export OWLMAIL_WEBHOOK_CONFIG=./webhooks.json
 |---|---:|---|
 | `version` | 否 | 配置版本；省略或设置为 `1` 都表示版本 1。 |
 | `targets` | 是 | 1～32 个目标，目标名称必须唯一。 |
-| `name` | 是 | 仅用于日志的安全标识；完整 URL 和配置密钥不会写入日志。 |
-| `url` | 是 | 固定的 `http` 或 `https` 地址；不会跟随重定向。 |
+| `name` | 是 | 仅用于日志的安全标识，最长 100 字符且不能包含换行；完整 URL 和配置密钥不会写入日志。 |
+| `url` | 是 | 固定的 `http` 或 `https` 地址；拒绝用户信息和片段，不会跟随重定向。 |
 | `method` | 否 | 默认 `POST`，支持 `POST`、`PUT`、`PATCH`。 |
-| `headers` | 否 | 静态请求头；不能覆盖 `Host` 和 `Content-Length`。 |
+| `headers` | 否 | 静态请求头；名称和值会被校验，不能覆盖 `Host` 和 `Content-Length`。 |
 | `contentType` | 否 | 默认 `application/json`；显式 `Content-Type` 请求头优先。 |
 | `secret` | 否 | 对最终请求体生成 `X-OwlMail-Signature: sha256=<hex>`。 |
 | `timeout` | 否 | 每次请求的超时，默认 `5s`，最大 `1m`。 |
@@ -65,15 +94,32 @@ export OWLMAIL_WEBHOOK_CONFIG=./webhooks.json
 
 `url`、请求头值和 `secret` 支持 `${VARIABLE}` 占位符。如果变量不存在，OwlMail 会在启动阶段报错，不会静默发送缺少鉴权信息的请求。
 
+只有带花括号的 `${VARIABLE}` 会展开，`$VARIABLE` 会作为普通文本。环境变量
+不会展开到 `name`、`contentType`、匹配规则或 `bodyTemplate`。
+
+### 校验与限制
+
+- 配置文件最大 1 MiB，只能包含一个 JSON 值，并拒绝未知字段；
+- 版本 1 支持 1～32 个名称唯一的目标；
+- 模板渲染后的请求体最大 2 MiB，超出时不会发出 HTTP 请求；
+- 单次超时必须大于零且不超过一分钟，默认每次尝试五秒；
+- `retries` 表示额外尝试次数，例如 `2` 表示最多请求三次；
+- SMTP 和 Web 服务启动前，会先编译全部目标与模板，因此错误配置不会造成部分启用。
+
 ## 匹配规则
 
-`from`、`to`、`subject`、`text` 支持含 `*`、`?` 的通配符数组：
+`from`、`to`、`subject`、`text` 支持 Go shell 风格通配符数组：`*`、`?`、
+`[a-z]` 等字符组以及 `\` 转义。与 Go 的 `path.Match` 一致，`*` 不匹配 `/`。
 
 - 同一个字段内的多个规则是“或”关系；
 - 多个非空字段之间是“且”关系；
 - 空字段匹配所有邮件；
 - 匹配不区分大小写；
 - `to` 同时检查 SMTP 信封收件人，以及 To、Cc、Bcc 邮件头。
+- `from` 同时检查解析后的 From 地址与 SMTP 信封发件人；
+- `text` 只匹配解析后的纯文本正文，不搜索 HTML 或附件；只有 HTML 的邮件通常
+  没有可匹配的 `text`；
+- 不支持按任意邮件头过滤。如果接收端需要邮件头，可在自定义模板中读取 `.Headers`。
 
 例如，下面的规则只转发来自 `example.com`、主题为告警或验证码、正文包含验证码的邮件：
 
@@ -105,6 +151,10 @@ export OWLMAIL_WEBHOOK_CONFIG=./webhooks.json
 - `join STRINGS SEPARATOR`：连接地址数组；
 - `truncate STRING LENGTH`：按 Unicode 字符数截断文本。
 
+模板使用 `missingkey=error`；映射键不存在或模板执行错误会使该目标发送失败。
+解析后的地址只包含邮箱地址，不包含显示名称。`.Headers` 的值可能是字符串、数组
+或其他解析类型，因此应通过 `json` 传递，不要假设所有值都是字符串。
+
 把邮件内容写进 JSON 时，应始终使用 `json`：
 
 ```json
@@ -116,22 +166,62 @@ export OWLMAIL_WEBHOOK_CONFIG=./webhooks.json
 ```json
 {
   "event": "email.received",
-  "message": "主题和纯文本正文",
+  "message": "示例\n邮件正文",
   "email": {
     "id": "email-id",
+    "time": "2026-08-29T12:00:00Z",
     "subject": "示例",
     "from": ["sender@example.com"],
     "to": ["recipient@example.com"],
-    "text": "邮件正文"
+    "envelopeFrom": "sender@example.com",
+    "envelopeTo": ["recipient@example.com"],
+    "text": "邮件正文",
+    "html": "<p>邮件正文</p>",
+    "size": 123,
+    "sizeHuman": "123 B",
+    "attachments": [
+      {
+        "fileName": "report.txt",
+        "contentType": "text/plain",
+        "size": 42
+      }
+    ],
+    "attachmentCount": 1
   }
 }
 ```
 
-请求头还会包含 `X-OwlMail-Email-ID`。接收端可用它作为幂等键，处理重试造成的重复请求。
+`cc`、`bcc`、`html`、信封字段和 `attachments` 等可选值为空时会省略。
+默认请求体有意不包含 `headers`，只有显式模板可以读取。附件正文和本地存储路径
+永远不会发送。
+
+## 请求头
+
+| 请求头 | 值 |
+|---|---|
+| `Content-Type` | 目标的 `contentType`，默认为 `application/json`；显式自定义请求头优先。 |
+| `User-Agent` | 默认为 `OwlMail-Webhook/1`，可用自定义请求头覆盖。 |
+| `X-OwlMail-Event` | 固定为 `email.received`。 |
+| `X-OwlMail-Email-ID` | OwlMail 邮件 ID，可作为幂等键。 |
+| `X-OwlMail-Signature` | 只在配置 `secret` 时发送；格式为 `sha256=` 加上对原始请求体计算的十六进制小写 HMAC。 |
+
+重试会使用相同的请求体和邮件 ID。接收端在执行非幂等操作前应先去重。
 
 ## 发送到 `soulteary/webhook`
 
-把目标地址设置为 [`soulteary/webhook`](https://github.com/soulteary/webhook) 提供的 Hook 地址：
+可运行示例会同时启动两个项目，验证 HMAC，把请求字段映射为环境变量，并执行
+一个可以直接观察结果的演示命令：
+
+```bash
+cd examples/webhooks/soulteary-webhook
+export OWLMAIL_WEBHOOK_SECRET='replace-with-a-long-random-secret'
+docker compose up --build
+```
+
+发送测试邮件和查看结果的步骤见[完整联动指南](../../examples/webhooks/soulteary-webhook/README.zh-CN.md)。
+
+手动部署时，把目标地址设置为
+[`soulteary/webhook`](https://github.com/soulteary/webhook) 提供的 Hook 地址：
 
 ```json
 {
@@ -147,9 +237,10 @@ export OWLMAIL_WEBHOOK_CONFIG=./webhooks.json
 }
 ```
 
-对应的 `soulteary/webhook` Hook 配置示例：
+对应的 `soulteary/webhook` Hook 配置如下。这是 Go 模板源文件，在
+`soulteary/webhook -template` 渲染之前有意不是合法 JSON：
 
-```json
+```text
 [
   {
     "id": "owlmail",
@@ -164,7 +255,7 @@ export OWLMAIL_WEBHOOK_CONFIG=./webhooks.json
     "trigger-rule": {
       "match": {
         "type": "payload-hmac-sha256",
-        "secret": "{{ getenv \"OWLMAIL_WEBHOOK_SECRET\" | js }}",
+        "secret": "{{ getenv "OWLMAIL_WEBHOOK_SECRET" | js }}",
         "parameter": { "source": "header", "name": "X-OwlMail-Signature" }
       }
     }
@@ -172,7 +263,38 @@ export OWLMAIL_WEBHOOK_CONFIG=./webhooks.json
 ]
 ```
 
-Hook 文件使用 `getenv` 时，需要用 `-template` 参数启动 `soulteary/webhook`。两个容器应配置相同的 `OWLMAIL_WEBHOOK_SECRET`。
+Hook 文件使用 `getenv` 时，需要用 `-template` 参数启动 `soulteary/webhook`。
+两个容器应配置相同的 `OWLMAIL_WEBHOOK_SECRET`。
+
+## 发送生命周期与问题排查
+
+1. OwlMail 先解析并保存 SMTP 邮件；
+2. `new` 事件异步启动 Webhook 发送，因此目标缓慢或失败不会改变 SMTP 接收结果；
+3. 同一封邮件命中的目标按照配置顺序依次调用，不同邮件事件可能并发发送；
+4. 2xx 表示目标完成。网络错误、408、425、429 和 5xx 会根据需要等待约
+   100 ms、200 ms、400 ms、800 ms、1.6 s 后重试；不会解析 `Retry-After`；
+5. 其他 3xx/4xx 会立即失败，响应正文不会参与处理。
+
+转发没有持久化发送队列或死信存储。配置的尝试次数耗尽后，OwlMail 会保留邮件并
+记录失败，但重启后不会再次发送该事件。
+
+本地检查时，可在不同终端运行内置接收器和最小配置：
+
+```bash
+go run ./examples/webhooks/receiver
+go run ./cmd/owlmail -webhook-config ./examples/webhooks/minimal.json
+```
+
+排查建议：
+
+- 启动错误通常来自非法 JSON、未知字段、缺失 `${VARIABLE}`、错误通配符/时长
+  或模板解析失败；
+- 没有收到请求通常表示规则未命中，可暂时移除 `match` 或改用 `minimal.json`；
+- 容器内的 `127.0.0.1` 指向 OwlMail 自身，应使用接收器服务名和容器端口；
+- HTTP 401/403 通常表示自定义 Token 或 HMAC 密钥不同。HMAC 覆盖请求体的精确
+  字节，验证前不要重新格式化请求体；
+- 成功发送记录在 verbose 日志中；失败日志包含安全目标名、状态和尝试次数，
+  不包含完整 URL 或密钥。
 
 ## 运行与安全边界
 
@@ -182,3 +304,7 @@ Hook 文件使用 `getenv` 时，需要用 `-template` 参数启动 `soulteary/w
 - 任意 2xx 都视为成功；重定向和其他非 2xx 响应视为失败；
 - Webhook 发送相对于 SMTP 存储是异步的，发送失败不会拒收或删除邮件；
 - 重试可能造成重复请求，执行非幂等动作前应使用 `email.id` 或 `X-OwlMail-Email-ID` 去重。
+- 默认请求体可能同时包含纯文本和 HTML 正文；接收端只需要标题或验证码时，
+  应使用自定义模板减少数据；
+- Webhook 转发适合通知和自动化，不是可靠消息队列；需要投递保证时，应把目标
+  设置为具备持久化能力的下游服务。

--- a/examples/webhooks/README.md
+++ b/examples/webhooks/README.md
@@ -1,0 +1,122 @@
+# OwlMail webhook examples
+
+These examples are intentionally separate: start with the smallest file that
+matches your use case instead of deleting fields from one large configuration.
+
+| Scenario | Configuration | What it demonstrates |
+|---|---|---|
+| Send every new email | [`minimal.json`](./minimal.json) | The two required target fields and OwlMail's default JSON event. |
+| Route selected alerts | [`filtered-alerts.json`](./filtered-alerts.json) | Recipient and subject matching, timeout, and retries. |
+| Call an authenticated JSON API | [`custom-json.json`](./custom-json.json) | Environment-backed URL/token/secret, custom headers, HMAC, and a JSON-safe template. |
+| Fan out to several destinations | [`multiple-targets.json`](./multiple-targets.json) | An archive target plus a filtered incident target. One email may match both. |
+| Send a plain-text message | [`plain-text.json`](./plain-text.json) | A non-JSON content type and a text template. |
+| Integrate with `soulteary/webhook` | [`soulteary-webhook/`](./soulteary-webhook/) | A complete Docker Compose stack, HMAC validation, payload mapping, and command execution. |
+| Full single-file reference | [`../webhooks.json`](../webhooks.json) | Most target options together in one configuration. |
+
+## Five-minute local smoke test
+
+The bundled receiver listens only on `127.0.0.1:18080`, prints each request,
+returns HTTP 204, and can optionally verify OwlMail's HMAC signature.
+
+Terminal 1 — start the receiver:
+
+```bash
+go run ./examples/webhooks/receiver
+```
+
+Terminal 2 — start OwlMail with the minimal configuration:
+
+```bash
+go run ./cmd/owlmail -webhook-config ./examples/webhooks/minimal.json
+```
+
+Terminal 3 — send a test email (curl must include SMTP protocol support):
+
+```bash
+printf 'From: sender@example.test\r\nTo: inbox@example.test\r\nSubject: Minimal webhook\r\n\r\nHello from OwlMail.\r\n' \
+  | curl --url smtp://127.0.0.1:1025 \
+      --mail-from sender@example.test \
+      --mail-rcpt inbox@example.test \
+      --upload-file -
+```
+
+The receiver output includes the request path, event type, email ID, content
+type, signature state, and body. Stop both processes with Ctrl+C.
+
+## Run each scenario
+
+### Minimal: forward everything
+
+```bash
+./owlmail -webhook-config ./examples/webhooks/minimal.json
+```
+
+There is no `match`, `bodyTemplate`, secret, or custom header, so every new
+email is sent once using OwlMail's default `email.received` JSON payload.
+
+### Filter alerts
+
+```bash
+./owlmail -webhook-config ./examples/webhooks/filtered-alerts.json
+```
+
+An email must match at least one `to` pattern **and** at least one `subject`
+pattern. Change the example addresses and words to match your own alerts.
+
+### Authenticated custom JSON
+
+Start the example receiver with signature verification:
+
+```bash
+export OWLMAIL_WEBHOOK_SECRET='replace-this-development-secret'
+go run ./examples/webhooks/receiver
+```
+
+In the OwlMail terminal, set every placeholder used by the configuration:
+
+```bash
+export OWLMAIL_WEBHOOK_URL='http://127.0.0.1:18080/custom'
+export OWLMAIL_WEBHOOK_TOKEN='development-token'
+export OWLMAIL_WEBHOOK_SECRET='replace-this-development-secret'
+./owlmail -webhook-config ./examples/webhooks/custom-json.json
+```
+
+The receiver verifies `X-OwlMail-Signature`. It deliberately logs only whether
+the `Authorization` header is present, never its value.
+
+### Multiple targets
+
+```bash
+./owlmail -webhook-config ./examples/webhooks/multiple-targets.json
+```
+
+Every message goes to `/archive`. Messages addressed to `ops@*` whose subject
+contains `critical` or `outage` also go to `/incidents`. Destinations are
+evaluated in file order for each email.
+
+### Plain text
+
+```bash
+./owlmail -webhook-config ./examples/webhooks/plain-text.json
+```
+
+This sends `text/plain; charset=utf-8` instead of JSON and truncates the message
+body to 2,000 Unicode characters.
+
+## Running OwlMail in a container
+
+`127.0.0.1` inside a container refers to that container. Replace the example
+URL with a Compose service name such as `http://receiver:18080/owlmail`, or with
+an address reachable from the OwlMail container. The
+[`soulteary-webhook`](./soulteary-webhook/) example shows service-name routing.
+
+## Validate before deployment
+
+OwlMail validates and compiles the complete file at startup. A missing
+environment variable, unknown JSON field, bad duration, invalid wildcard, or
+invalid template prevents the service from starting. After changing a file,
+restart OwlMail; webhook configuration is not hot-reloaded.
+
+See the [full English reference](../../docs/en/Webhook-Forwarding.md) or
+[中文参考](../../docs/zh-CN/Webhook-Forwarding.md) for every field, payload,
+header, matching rule, retry behavior, and security boundary.

--- a/examples/webhooks/README.zh-CN.md
+++ b/examples/webhooks/README.zh-CN.md
@@ -1,0 +1,119 @@
+# OwlMail Webhook 示例
+
+示例按场景拆分。建议从最接近需求的最小配置开始，而不是从一份大配置中逐项删除。
+
+| 场景 | 配置 | 重点 |
+|---|---|---|
+| 转发所有新邮件 | [`minimal.json`](./minimal.json) | 目标所需的两个必填字段，以及 OwlMail 默认 JSON 事件。 |
+| 只转发指定告警 | [`filtered-alerts.json`](./filtered-alerts.json) | 收件人和主题过滤、超时、重试。 |
+| 调用带鉴权的 JSON API | [`custom-json.json`](./custom-json.json) | 环境变量 URL/Token/密钥、自定义请求头、HMAC 和 JSON 安全模板。 |
+| 同时发送多个目标 | [`multiple-targets.json`](./multiple-targets.json) | 全量归档目标和按规则触发的事故目标；同一邮件可以命中两者。 |
+| 发送纯文本消息 | [`plain-text.json`](./plain-text.json) | 非 JSON Content-Type 和文本模板。 |
+| 联动 `soulteary/webhook` | [`soulteary-webhook/`](./soulteary-webhook/) | 完整 Docker Compose、HMAC 校验、字段映射和命令执行。 |
+| 单文件完整参考 | [`../webhooks.json`](../webhooks.json) | 在一个目标中同时展示大部分配置项。 |
+
+## 五分钟本地验证
+
+仓库内置的示例接收器只监听 `127.0.0.1:18080`，会打印请求并返回 HTTP
+204；配置密钥后还可以验证 OwlMail 的 HMAC 签名。
+
+终端 1——启动接收器：
+
+```bash
+go run ./examples/webhooks/receiver
+```
+
+终端 2——使用最小配置启动 OwlMail：
+
+```bash
+go run ./cmd/owlmail -webhook-config ./examples/webhooks/minimal.json
+```
+
+终端 3——发送测试邮件（curl 需要包含 SMTP 协议支持）：
+
+```bash
+printf 'From: sender@example.test\r\nTo: inbox@example.test\r\nSubject: Minimal webhook\r\n\r\nHello from OwlMail.\r\n' \
+  | curl --url smtp://127.0.0.1:1025 \
+      --mail-from sender@example.test \
+      --mail-rcpt inbox@example.test \
+      --upload-file -
+```
+
+接收器会输出请求路径、事件类型、邮件 ID、Content-Type、签名状态和请求体。
+使用 Ctrl+C 停止两个进程。
+
+## 各场景使用方法
+
+### 最小配置：转发全部邮件
+
+```bash
+./owlmail -webhook-config ./examples/webhooks/minimal.json
+```
+
+配置不包含 `match`、`bodyTemplate`、密钥或自定义请求头，因此每封新邮件都会
+使用 OwlMail 默认的 `email.received` JSON 结构发送一次。
+
+### 过滤告警
+
+```bash
+./owlmail -webhook-config ./examples/webhooks/filtered-alerts.json
+```
+
+邮件必须至少命中一个 `to` 规则，**并且**至少命中一个 `subject` 规则。
+请把示例地址和关键词替换为实际告警规则。
+
+### 带鉴权的自定义 JSON
+
+先在接收器终端开启签名校验：
+
+```bash
+export OWLMAIL_WEBHOOK_SECRET='replace-this-development-secret'
+go run ./examples/webhooks/receiver
+```
+
+在 OwlMail 终端设置配置引用的全部环境变量：
+
+```bash
+export OWLMAIL_WEBHOOK_URL='http://127.0.0.1:18080/custom'
+export OWLMAIL_WEBHOOK_TOKEN='development-token'
+export OWLMAIL_WEBHOOK_SECRET='replace-this-development-secret'
+./owlmail -webhook-config ./examples/webhooks/custom-json.json
+```
+
+接收器会校验 `X-OwlMail-Signature`。对于 `Authorization`，它只记录请求头
+是否存在，不会输出 Token 内容。
+
+### 多目标分发
+
+```bash
+./owlmail -webhook-config ./examples/webhooks/multiple-targets.json
+```
+
+每封邮件都会发送到 `/archive`；同时，收件人为 `ops@*` 且主题包含
+`critical` 或 `outage` 的邮件也会发送到 `/incidents`。每封邮件的目标按照
+配置文件中的顺序依次处理。
+
+### 纯文本消息
+
+```bash
+./owlmail -webhook-config ./examples/webhooks/plain-text.json
+```
+
+该配置发送 `text/plain; charset=utf-8`，并把邮件正文截断为 2,000 个 Unicode
+字符，而不是发送 JSON。
+
+## 在容器中运行 OwlMail
+
+容器内的 `127.0.0.1` 指向容器自身。请把示例 URL 换成 Compose 服务名（例如
+`http://receiver:18080/owlmail`），或换成 OwlMail 容器能够访问的地址。
+[`soulteary-webhook`](./soulteary-webhook/) 示例展示了服务名寻址方式。
+
+## 部署前验证
+
+OwlMail 会在启动时校验并编译整个配置文件。缺少环境变量、未知 JSON 字段、
+非法时长、无效通配符或错误模板都会阻止服务启动。修改配置后需要重启 OwlMail；
+Webhook 配置不会热加载。
+
+所有字段、默认请求体、请求头、规则、重试行为和安全边界见
+[中文完整参考](../../docs/zh-CN/Webhook-Forwarding.md) 或
+[English reference](../../docs/en/Webhook-Forwarding.md)。

--- a/examples/webhooks/custom-json.json
+++ b/examples/webhooks/custom-json.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "targets": [
+    {
+      "name": "authenticated-api",
+      "url": "${OWLMAIL_WEBHOOK_URL}",
+      "headers": {
+        "Authorization": "Bearer ${OWLMAIL_WEBHOOK_TOKEN}",
+        "X-Source": "owlmail"
+      },
+      "contentType": "application/json",
+      "secret": "${OWLMAIL_WEBHOOK_SECRET}",
+      "timeout": "5s",
+      "retries": 3,
+      "bodyTemplate": "{\"type\":\"owlmail.email.received\",\"id\":{{ json .ID }},\"receivedAt\":{{ json .Time }},\"subject\":{{ json .Subject }},\"preview\":{{ json (truncate .Text 500) }},\"sender\":{{ json (join .From \",\") }},\"recipients\":{{ json .To }},\"attachmentCount\":{{ .AttachmentCount }}}"
+    }
+  ]
+}

--- a/examples/webhooks/filtered-alerts.json
+++ b/examples/webhooks/filtered-alerts.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "targets": [
+    {
+      "name": "filtered-alerts",
+      "url": "http://127.0.0.1:18080/alerts",
+      "timeout": "3s",
+      "retries": 2,
+      "match": {
+        "to": ["alerts@*", "ops@*"],
+        "subject": ["*alert*", "*critical*", "*verification*", "*验证码*"]
+      }
+    }
+  ]
+}

--- a/examples/webhooks/minimal.json
+++ b/examples/webhooks/minimal.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "targets": [
+    {
+      "name": "local-receiver",
+      "url": "http://127.0.0.1:18080/owlmail"
+    }
+  ]
+}

--- a/examples/webhooks/multiple-targets.json
+++ b/examples/webhooks/multiple-targets.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "targets": [
+    {
+      "name": "all-messages",
+      "url": "http://127.0.0.1:18080/archive"
+    },
+    {
+      "name": "critical-alerts",
+      "url": "http://127.0.0.1:18080/incidents",
+      "retries": 2,
+      "match": {
+        "to": ["ops@*"],
+        "subject": ["*critical*", "*outage*"]
+      },
+      "bodyTemplate": "{\"severity\":\"critical\",\"emailId\":{{ json .ID }},\"title\":{{ json .Subject }},\"message\":{{ json (truncate .Text 2000) }}}"
+    }
+  ]
+}

--- a/examples/webhooks/plain-text.json
+++ b/examples/webhooks/plain-text.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "targets": [
+    {
+      "name": "plain-text-endpoint",
+      "url": "http://127.0.0.1:18080/plain-text",
+      "contentType": "text/plain; charset=utf-8",
+      "bodyTemplate": "Subject: {{ .Subject }}\nFrom: {{ join .From \", \" }}\nTo: {{ join .To \", \" }}\n\n{{ truncate .Text 2000 }}"
+    }
+  ]
+}

--- a/examples/webhooks/receiver/main.go
+++ b/examples/webhooks/receiver/main.go
@@ -1,0 +1,90 @@
+// Command receiver runs a loopback-only HTTP endpoint for exercising OwlMail
+// webhook configurations during local development.
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+const (
+	listenAddress  = "127.0.0.1:18080"
+	maxRequestBody = 2 << 20
+)
+
+func main() {
+	server := &http.Server{
+		Addr:              listenAddress,
+		Handler:           http.HandlerFunc(receive),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	log.Printf("OwlMail example receiver listening on http://%s", listenAddress)
+	log.Fatal(server.ListenAndServe())
+}
+
+func receive(writer http.ResponseWriter, request *http.Request) {
+	if request.Method != http.MethodPost && request.Method != http.MethodPut && request.Method != http.MethodPatch {
+		writer.Header().Set("Allow", "POST, PUT, PATCH")
+		http.Error(writer, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	request.Body = http.MaxBytesReader(writer, request.Body, maxRequestBody)
+	body, err := io.ReadAll(request.Body)
+	if err != nil {
+		http.Error(writer, "request body is too large or unreadable", http.StatusBadRequest)
+		return
+	}
+
+	verified, err := verifySignature(request.Header.Get("X-OwlMail-Signature"), body, os.Getenv("OWLMAIL_WEBHOOK_SECRET"))
+	if err != nil {
+		http.Error(writer, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	log.Printf(
+		"path=%s event=%q email_id=%q content_type=%q authorization=%t signature_verified=%t body=%s",
+		request.URL.Path,
+		request.Header.Get("X-OwlMail-Event"),
+		request.Header.Get("X-OwlMail-Email-ID"),
+		request.Header.Get("Content-Type"),
+		request.Header.Get("Authorization") != "",
+		verified,
+		body,
+	)
+	writer.WriteHeader(http.StatusNoContent)
+}
+
+func verifySignature(signature string, body []byte, secret string) (bool, error) {
+	if signature == "" {
+		if secret != "" {
+			return false, fmt.Errorf("X-OwlMail-Signature is required when OWLMAIL_WEBHOOK_SECRET is set")
+		}
+		return false, nil
+	}
+	if secret == "" {
+		return false, nil
+	}
+
+	const prefix = "sha256="
+	if len(signature) <= len(prefix) || signature[:len(prefix)] != prefix {
+		return false, fmt.Errorf("invalid X-OwlMail-Signature format")
+	}
+	provided, err := hex.DecodeString(signature[len(prefix):])
+	if err != nil {
+		return false, fmt.Errorf("invalid X-OwlMail-Signature encoding")
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(body)
+	if !hmac.Equal(provided, mac.Sum(nil)) {
+		return false, fmt.Errorf("X-OwlMail-Signature verification failed")
+	}
+	return true, nil
+}

--- a/examples/webhooks/receiver/main_test.go
+++ b/examples/webhooks/receiver/main_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestReceiveUnsignedRequest(t *testing.T) {
+	t.Setenv("OWLMAIL_WEBHOOK_SECRET", "")
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/owlmail", bytes.NewBufferString(`{"event":"email.received"}`))
+
+	receive(recorder, request)
+
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNoContent)
+	}
+}
+
+func TestReceiveVerifiesSignature(t *testing.T) {
+	const secret = "example-secret"
+	body := []byte(`{"event":"email.received"}`)
+	t.Setenv("OWLMAIL_WEBHOOK_SECRET", secret)
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(body)
+	signature := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/owlmail", bytes.NewReader(body))
+	request.Header.Set("X-OwlMail-Signature", signature)
+	receive(recorder, request)
+
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNoContent)
+	}
+}
+
+func TestReceiveRejectsMissingSignature(t *testing.T) {
+	t.Setenv("OWLMAIL_WEBHOOK_SECRET", "example-secret")
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/owlmail", bytes.NewBufferString(`{}`))
+
+	receive(recorder, request)
+
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestReceiveRejectsUnsupportedMethod(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/owlmail", nil)
+
+	receive(recorder, request)
+
+	if recorder.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusMethodNotAllowed)
+	}
+}

--- a/examples/webhooks/soulteary-webhook/README.md
+++ b/examples/webhooks/soulteary-webhook/README.md
@@ -1,0 +1,95 @@
+# OwlMail + `soulteary/webhook`
+
+This runnable example sends each new OwlMail message to
+[`soulteary/webhook`](https://github.com/soulteary/webhook), verifies the exact
+request body with HMAC-SHA256, maps JSON fields into command environment
+variables, and runs `print-email.sh`.
+
+## Files
+
+| File | Used by | Purpose |
+|---|---|---|
+| [`owlmail.json`](./owlmail.json) | OwlMail | Environment-backed target URL and HMAC secret, retry policy, and custom JSON body. |
+| [`hooks.json.tmpl`](./hooks.json.tmpl) | `soulteary/webhook` | Hook, payload mapping, and `X-OwlMail-Signature` verification. |
+| [`print-email.sh`](./print-email.sh) | `soulteary/webhook` | Side-effect-free demo command that prints mapped fields. |
+| [`compose.yaml`](./compose.yaml) | Docker Compose | Builds OwlMail and starts both services on one private network. |
+
+## Start the stack
+
+From this directory:
+
+```bash
+cd examples/webhooks/soulteary-webhook
+export OWLMAIL_WEBHOOK_SECRET='replace-with-a-long-random-secret'
+docker compose up --build
+```
+
+The Compose file has a development-only fallback secret so the demo can start,
+but set your own value whenever the ports are reachable by another machine.
+The same secret is passed to both containers. Compose also supplies the command
+and working-directory paths used inside the `webhook` container.
+`soulteary/webhook` starts in template mode so `getenv` can inject all three
+values into the hook definition. The Hook waits for the demo command and
+captures its output, so command failures become non-2xx responses to OwlMail.
+Debug logging is enabled so the command summary is visible in this demo; turn
+off `DEBUG` (and normally `VERBOSE`) before production because mapped email
+values can appear in logs.
+
+## Send a message
+
+In another terminal:
+
+```bash
+printf 'From: monitor@example.test\r\nTo: ops@example.test\r\nSubject: Demo alert\r\n\r\nThe integration works.\r\n' \
+  | curl --url smtp://127.0.0.1:1025 \
+      --mail-from monitor@example.test \
+      --mail-rcpt ops@example.test \
+      --upload-file -
+```
+
+Open `http://localhost:1080` to inspect the stored email. The Compose output for
+the `webhook` service prints a summary similar to:
+
+```text
+OwlMail webhook event
+  event: email.received
+  id: Ab12Cd34
+  title: Demo alert
+  from: monitor@example.test
+  to: ops@example.test
+  received: 2026-08-29T12:00:00Z
+  message: The integration works.
+```
+
+If the secrets differ or the request body changes after signing,
+`soulteary/webhook` rejects the trigger and the command does not run. OwlMail
+logs the non-2xx delivery result and retries according to `owlmail.json`.
+
+## Stop and clean up
+
+```bash
+docker compose down
+```
+
+No mail volume is configured, so the demo's captured mail is removed with its
+container. Add a volume at `/app/mail` when persistence is wanted.
+
+For a non-container setup, run `soulteary/webhook` from this directory:
+
+```bash
+export OWLMAIL_WEBHOOK_SECRET='replace-with-a-long-random-secret'
+export OWLMAIL_WEBHOOK_COMMAND="$PWD/print-email.sh"
+export OWLMAIL_WEBHOOK_WORKDIR="$PWD"
+webhook -template -hooks hooks.json.tmpl -verbose -debug
+```
+
+In another terminal, pass OwlMail the local Hook URL and the same secret:
+
+```bash
+export OWLMAIL_WEBHOOK_URL='http://127.0.0.1:9000/hooks/owlmail'
+export OWLMAIL_WEBHOOK_SECRET='replace-with-a-long-random-secret'
+owlmail -webhook-config owlmail.json
+```
+
+[中文说明](./README.zh-CN.md) ·
+[Webhook forwarding reference](../../../docs/en/Webhook-Forwarding.md)

--- a/examples/webhooks/soulteary-webhook/README.zh-CN.md
+++ b/examples/webhooks/soulteary-webhook/README.zh-CN.md
@@ -1,0 +1,90 @@
+# OwlMail + `soulteary/webhook`
+
+这个可运行示例会把 OwlMail 新邮件发送到
+[`soulteary/webhook`](https://github.com/soulteary/webhook)，使用 HMAC-SHA256
+校验完整请求体，把 JSON 字段映射为命令环境变量，并执行 `print-email.sh`。
+
+## 文件说明
+
+| 文件 | 使用方 | 作用 |
+|---|---|---|
+| [`owlmail.json`](./owlmail.json) | OwlMail | 环境变量目标 URL 与 HMAC 密钥、重试策略和自定义 JSON 请求体。 |
+| [`hooks.json.tmpl`](./hooks.json.tmpl) | `soulteary/webhook` | Hook、字段映射和 `X-OwlMail-Signature` 校验。 |
+| [`print-email.sh`](./print-email.sh) | `soulteary/webhook` | 无外部副作用、仅输出映射字段的演示命令。 |
+| [`compose.yaml`](./compose.yaml) | Docker Compose | 构建 OwlMail，并在同一私有网络启动两个服务。 |
+
+## 启动服务
+
+从该目录执行：
+
+```bash
+cd examples/webhooks/soulteary-webhook
+export OWLMAIL_WEBHOOK_SECRET='replace-with-a-long-random-secret'
+docker compose up --build
+```
+
+Compose 文件提供了仅用于本地演示的默认密钥，因此不设置变量也能启动；只要端口
+可能被其他机器访问，就应设置自己的长随机密钥。同一个密钥会传给两个容器。
+Compose 还会传入 `webhook` 容器内的命令和工作目录路径。`soulteary/webhook`
+使用模板模式启动，使 `getenv` 能把这三个值写入 Hook 定义。Hook 会等待演示命令
+完成并捕获输出，因此命令失败时会向 OwlMail 返回非 2xx 状态。
+本示例开启了调试日志以显示命令摘要；生产环境应关闭 `DEBUG`（通常也关闭
+`VERBOSE`），因为日志中可能出现映射后的邮件内容。
+
+## 发送邮件
+
+在另一个终端执行：
+
+```bash
+printf 'From: monitor@example.test\r\nTo: ops@example.test\r\nSubject: Demo alert\r\n\r\nThe integration works.\r\n' \
+  | curl --url smtp://127.0.0.1:1025 \
+      --mail-from monitor@example.test \
+      --mail-rcpt ops@example.test \
+      --upload-file -
+```
+
+打开 `http://localhost:1080` 可以查看已保存邮件。`webhook` 服务的 Compose
+日志会输出类似内容：
+
+```text
+OwlMail webhook event
+  event: email.received
+  id: Ab12Cd34
+  title: Demo alert
+  from: monitor@example.test
+  to: ops@example.test
+  received: 2026-08-29T12:00:00Z
+  message: The integration works.
+```
+
+如果两边密钥不同，或请求体在签名后被修改，`soulteary/webhook` 会拒绝触发，
+命令不会执行。OwlMail 会记录非 2xx 结果，并按照 `owlmail.json` 进行重试。
+
+## 停止并清理
+
+```bash
+docker compose down
+```
+
+示例未配置邮件数据卷，因此容器被移除后，捕获的邮件也会删除。如需持久化，
+请为 `/app/mail` 添加数据卷。
+
+如果不使用容器，先在当前目录启动 `soulteary/webhook`：
+
+```bash
+export OWLMAIL_WEBHOOK_SECRET='replace-with-a-long-random-secret'
+export OWLMAIL_WEBHOOK_COMMAND="$PWD/print-email.sh"
+export OWLMAIL_WEBHOOK_WORKDIR="$PWD"
+webhook -template -hooks hooks.json.tmpl -verbose -debug
+```
+
+在另一个终端传入本机 Hook 地址和相同密钥，再启动 OwlMail：
+
+```bash
+export OWLMAIL_WEBHOOK_URL='http://127.0.0.1:9000/hooks/owlmail'
+export OWLMAIL_WEBHOOK_SECRET='replace-with-a-long-random-secret'
+owlmail -webhook-config owlmail.json
+```
+
+[English](./README.md) ·
+[Webhook 消息转发参考](../../../docs/zh-CN/Webhook-Forwarding.md)

--- a/examples/webhooks/soulteary-webhook/compose.yaml
+++ b/examples/webhooks/soulteary-webhook/compose.yaml
@@ -1,0 +1,41 @@
+services:
+  webhook:
+    image: soulteary/webhook:extend-5.0.0
+    ports:
+      - "9000:9000"
+    environment:
+      HOST: "0.0.0.0"
+      PORT: "9000"
+      HOOKS: "/app/hooks.json.tmpl"
+      TEMPLATE: "true"
+      VERBOSE: "true"
+      DEBUG: "true"
+      OWLMAIL_WEBHOOK_SECRET: "${OWLMAIL_WEBHOOK_SECRET:-local-demo-change-me}"
+      OWLMAIL_WEBHOOK_COMMAND: "/app/print-email.sh"
+      OWLMAIL_WEBHOOK_WORKDIR: "/app"
+    volumes:
+      - ./hooks.json.tmpl:/app/hooks.json.tmpl:ro
+      - ./print-email.sh:/app/print-email.sh:ro
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:9000/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
+
+  owlmail:
+    build:
+      context: ../../..
+    depends_on:
+      webhook:
+        condition: service_healthy
+    ports:
+      - "1025:1025"
+      - "1080:1080"
+    environment:
+      OWLMAIL_SMTP_HOST: "0.0.0.0"
+      OWLMAIL_WEB_HOST: "0.0.0.0"
+      OWLMAIL_WEBHOOK_CONFIG: "/app/config/owlmail.json"
+      OWLMAIL_WEBHOOK_URL: "http://webhook:9000/hooks/owlmail"
+      OWLMAIL_WEBHOOK_SECRET: "${OWLMAIL_WEBHOOK_SECRET:-local-demo-change-me}"
+    volumes:
+      - ./owlmail.json:/app/config/owlmail.json:ro

--- a/examples/webhooks/soulteary-webhook/hooks.json.tmpl
+++ b/examples/webhooks/soulteary-webhook/hooks.json.tmpl
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "owlmail",
+    "execute-command": "{{ getenv "OWLMAIL_WEBHOOK_COMMAND" | js }}",
+    "command-working-directory": "{{ getenv "OWLMAIL_WEBHOOK_WORKDIR" | js }}",
+    "http-methods": ["POST"],
+    "incoming-payload-content-type": "application/json",
+    "include-command-output-in-response": true,
+    "pass-environment-to-command": [
+      { "source": "payload", "name": "event", "envname": "OWLMAIL_EVENT" },
+      { "source": "payload", "name": "emailId", "envname": "OWLMAIL_EMAIL_ID" },
+      { "source": "payload", "name": "title", "envname": "OWLMAIL_TITLE" },
+      { "source": "payload", "name": "message", "envname": "OWLMAIL_MESSAGE" },
+      { "source": "payload", "name": "from", "envname": "OWLMAIL_FROM" },
+      { "source": "payload", "name": "to", "envname": "OWLMAIL_TO" },
+      { "source": "payload", "name": "receivedAt", "envname": "OWLMAIL_RECEIVED_AT" }
+    ],
+    "trigger-rule": {
+      "match": {
+        "type": "payload-hmac-sha256",
+        "secret": "{{ getenv "OWLMAIL_WEBHOOK_SECRET" | js }}",
+        "parameter": {
+          "source": "header",
+          "name": "X-OwlMail-Signature"
+        }
+      }
+    }
+  }
+]

--- a/examples/webhooks/soulteary-webhook/owlmail.json
+++ b/examples/webhooks/soulteary-webhook/owlmail.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "targets": [
+    {
+      "name": "soulteary-webhook",
+      "url": "${OWLMAIL_WEBHOOK_URL}",
+      "secret": "${OWLMAIL_WEBHOOK_SECRET}",
+      "timeout": "5s",
+      "retries": 2,
+      "bodyTemplate": "{\"event\":\"email.received\",\"emailId\":{{ json .ID }},\"title\":{{ json .Subject }},\"message\":{{ json (truncate .Text 4000) }},\"from\":{{ json (join .From \",\") }},\"to\":{{ json (join .To \",\") }},\"receivedAt\":{{ json .Time }}}"
+    }
+  ]
+}

--- a/examples/webhooks/soulteary-webhook/print-email.sh
+++ b/examples/webhooks/soulteary-webhook/print-email.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -eu
+
+summary=$(printf '%s\n' \
+  "OwlMail webhook event" \
+  "  event: ${OWLMAIL_EVENT:-}" \
+  "  id: ${OWLMAIL_EMAIL_ID:-}" \
+  "  title: ${OWLMAIL_TITLE:-}" \
+  "  from: ${OWLMAIL_FROM:-}" \
+  "  to: ${OWLMAIL_TO:-}" \
+  "  received: ${OWLMAIL_RECEIVED_AT:-}" \
+  "  message: ${OWLMAIL_MESSAGE:-}")
+
+printf '%s\n' "$summary"

--- a/internal/webhook/examples_test.go
+++ b/internal/webhook/examples_test.go
@@ -1,0 +1,149 @@
+package webhook
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDocumentedExampleConfigurations(t *testing.T) {
+	t.Setenv("OWLMAIL_WEBHOOK_URL", "http://127.0.0.1:18080/custom")
+	t.Setenv("OWLMAIL_WEBHOOK_TOKEN", "example-token")
+	t.Setenv("OWLMAIL_WEBHOOK_SECRET", "example-secret")
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repositoryRoot := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", ".."))
+
+	tests := []struct {
+		path        string
+		targetCount int
+	}{
+		{path: "examples/webhooks.json", targetCount: 1},
+		{path: "examples/webhooks/minimal.json", targetCount: 1},
+		{path: "examples/webhooks/filtered-alerts.json", targetCount: 1},
+		{path: "examples/webhooks/custom-json.json", targetCount: 1},
+		{path: "examples/webhooks/multiple-targets.json", targetCount: 2},
+		{path: "examples/webhooks/plain-text.json", targetCount: 1},
+		{path: "examples/webhooks/soulteary-webhook/owlmail.json", targetCount: 1},
+	}
+
+	payload := EmailPayload{
+		ID:              "example-id",
+		Time:            time.Date(2026, time.August, 29, 12, 0, 0, 0, time.UTC),
+		Subject:         "Critical \"example\" alert",
+		From:            []string{"sender@example.test"},
+		To:              []string{"ops@example.test"},
+		Text:            "Example\n\"message\" body",
+		Size:            20,
+		SizeHuman:       "20 B",
+		AttachmentCount: 0,
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			config, err := LoadConfig(filepath.Join(repositoryRoot, filepath.FromSlash(tt.path)))
+			if err != nil {
+				t.Fatalf("LoadConfig() error: %v", err)
+			}
+			targets, err := compileConfig(config)
+			if err != nil {
+				t.Fatalf("compileConfig() error: %v", err)
+			}
+			if len(targets) != tt.targetCount {
+				t.Fatalf("target count = %d, want %d", len(targets), tt.targetCount)
+			}
+			for _, target := range targets {
+				body, err := renderBody(target, payload)
+				if err != nil {
+					t.Fatalf("renderBody(%q) error: %v", target.name, err)
+				}
+				if len(body) == 0 {
+					t.Errorf("renderBody(%q) produced an empty body", target.name)
+				}
+				if strings.HasPrefix(target.contentType, "application/json") && !json.Valid(body) {
+					t.Errorf("renderBody(%q) produced invalid JSON: %s", target.name, body)
+				}
+			}
+		})
+	}
+}
+
+func TestDocumentedMatchingScenarios(t *testing.T) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repositoryRoot := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", ".."))
+
+	tests := []struct {
+		name         string
+		path         string
+		to           string
+		subject      string
+		matchedNames string
+	}{
+		{
+			name:         "filtered alert matches both fields",
+			path:         "examples/webhooks/filtered-alerts.json",
+			to:           "ops@example.test",
+			subject:      "Critical service alert",
+			matchedNames: "filtered-alerts",
+		},
+		{
+			name:    "filtered alert rejects a routine subject",
+			path:    "examples/webhooks/filtered-alerts.json",
+			to:      "ops@example.test",
+			subject: "Weekly report",
+		},
+		{
+			name:    "filtered alert rejects another recipient",
+			path:    "examples/webhooks/filtered-alerts.json",
+			to:      "inbox@example.test",
+			subject: "Critical service alert",
+		},
+		{
+			name:         "critical message fans out to both targets",
+			path:         "examples/webhooks/multiple-targets.json",
+			to:           "ops@example.test",
+			subject:      "Critical outage",
+			matchedNames: "all-messages,critical-alerts",
+		},
+		{
+			name:         "routine message uses the archive target only",
+			path:         "examples/webhooks/multiple-targets.json",
+			to:           "inbox@example.test",
+			subject:      "Weekly report",
+			matchedNames: "all-messages",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := LoadConfig(filepath.Join(repositoryRoot, filepath.FromSlash(tt.path)))
+			if err != nil {
+				t.Fatalf("LoadConfig() error: %v", err)
+			}
+			targets, err := compileConfig(config)
+			if err != nil {
+				t.Fatalf("compileConfig() error: %v", err)
+			}
+
+			payload := EmailPayload{To: []string{tt.to}, Subject: tt.subject}
+			matched := make([]string, 0, len(targets))
+			for _, target := range targets {
+				if target.matches(payload) {
+					matched = append(matched, target.name)
+				}
+			}
+			if got := strings.Join(matched, ","); got != tt.matchedNames {
+				t.Fatalf("matched targets = %q, want %q", got, tt.matchedNames)
+			}
+		})
+	}
+}

--- a/web/help.html
+++ b/web/help.html
@@ -41,6 +41,7 @@
                     <a href="#en-quick-start">Quick start</a>
                     <a href="#en-workflow">Inbox workflow</a>
                     <a href="#en-config">Configuration</a>
+                    <a href="#en-notifications-webhooks">Notifications &amp; webhooks</a>
                     <a href="#en-api">API</a>
                     <a href="#en-security">Security</a>
                     <a href="#en-troubleshooting">Troubleshooting</a>
@@ -93,6 +94,7 @@ SMTP_SECURE=false</code></pre>
                                 <tr><td>SMTP authentication</td><td><code>-smtp-user</code>, <code>-smtp-password</code></td><td><code>OWLMAIL_SMTP_USER</code>, <code>OWLMAIL_SMTP_PASSWORD</code></td><td>Disabled</td></tr>
                                 <tr><td>SMTP TLS</td><td><code>-tls</code>, <code>-tls-cert</code>, <code>-tls-key</code></td><td><code>OWLMAIL_TLS_ENABLED</code>, certificate/key variables</td><td>Disabled</td></tr>
                                 <tr><td>Web HTTPS</td><td><code>-https</code>, <code>-https-cert</code>, <code>-https-key</code></td><td><code>OWLMAIL_HTTPS_ENABLED</code>, certificate/key variables</td><td>Disabled</td></tr>
+                                <tr><td>Webhook forwarding</td><td><code>-webhook-config</code></td><td><code>OWLMAIL_WEBHOOK_CONFIG</code></td><td>Disabled</td></tr>
                             </tbody>
                         </table>
                     </div>
@@ -103,8 +105,30 @@ SMTP_SECURE=false</code></pre>
   ghcr.io/soulteary/owlmail:latest</code></pre>
                 </section>
 
+                <section id="en-notifications-webhooks" class="help-card">
+                    <div class="section-heading"><span>04</span><h2>Notifications and webhooks</h2></div>
+                    <div class="feature-grid">
+                        <div><h3>Browser notifications</h3><p>Notifications are off by default. Click <strong>Notifications off</strong> in the inbox header to request permission. Only new WebSocket messages received after enabling the preference create notifications; loading existing mail does not.</p></div>
+                        <div><h3>Server-side webhooks</h3><p>Webhook forwarding runs even when no browser is open. Targets can filter mail, send custom JSON or text, add authentication headers and HMAC signatures, and retry transient failures.</p></div>
+                    </div>
+                    <aside class="note"><strong>Browser requirement:</strong> notifications need HTTPS or a trusted local origin such as <code>http://localhost</code>. If permission was denied, allow OwlMail in the browser's site settings first.</aside>
+                    <h3>Minimal webhook configuration</h3>
+                    <pre><code>{
+  "version": 1,
+  "targets": [
+    {
+      "name": "local-receiver",
+      "url": "http://127.0.0.1:18080/owlmail"
+    }
+  ]
+}</code></pre>
+                    <pre><code>./owlmail -webhook-config ./webhooks.json</code></pre>
+                    <p>Omit both <code>-webhook-config</code> and <code>OWLMAIL_WEBHOOK_CONFIG</code> to keep forwarding disabled. Restart OwlMail after changing the file.</p>
+                    <p><a href="https://github.com/soulteary/owlmail/tree/main/examples/webhooks" target="_blank" rel="noopener noreferrer">Open runnable filtering, custom JSON, multi-target, plain-text, and soulteary/webhook examples ↗</a></p>
+                </section>
+
                 <section id="en-api" class="help-card">
-                    <div class="section-heading"><span>04</span><h2>API essentials</h2></div>
+                    <div class="section-heading"><span>05</span><h2>API essentials</h2></div>
                     <div class="endpoint-list">
                         <div><code>GET /api/v1/emails</code><span>List and search messages</span></div>
                         <div><code>GET /api/v1/emails/:id</code><span>Read a message</span></div>
@@ -118,20 +142,23 @@ SMTP_SECURE=false</code></pre>
                 </section>
 
                 <section id="en-security" class="help-card">
-                    <div class="section-heading"><span>05</span><h2>Security checklist</h2></div>
+                    <div class="section-heading"><span>06</span><h2>Security checklist</h2></div>
                     <ul class="checklist">
                         <li>Keep the default loopback binding for local-only development.</li>
                         <li>If exposed to a network, set both web credentials and SMTP credentials; terminate TLS as appropriate.</li>
                         <li>Captured messages can contain credentials, reset links, and personal data. Protect the storage directory and backups.</li>
                         <li>Use development or test messages only. Review recipients carefully before enabling outgoing relay or auto-relay.</li>
+                        <li>Webhook targets receive email content. Use trusted HTTPS endpoints, keep tokens in environment variables, and verify HMAC signatures.</li>
                     </ul>
                 </section>
 
                 <section id="en-troubleshooting" class="help-card">
-                    <div class="section-heading"><span>06</span><h2>Troubleshooting</h2></div>
+                    <div class="section-heading"><span>07</span><h2>Troubleshooting</h2></div>
                     <details><summary>The application cannot connect to SMTP</summary><p>Confirm host and port, check whether OwlMail is bound to the expected interface, and verify Docker port publishing. TLS must match on both sides.</p></details>
                     <details><summary>The inbox is empty after restart</summary><p>Set <code>-mail-directory</code> or <code>OWLMAIL_MAIL_DIR</code>. In Docker, mount a volume at <code>/app/mail</code>.</p></details>
                     <details><summary>Live updates stopped</summary><p>Refresh the page and check that proxies allow WebSocket upgrade requests to <code>/api/v1/ws</code>.</p></details>
+                    <details><summary>Browser notifications are blocked</summary><p>Allow notifications in the browser's site settings, return to OwlMail, and click the notification button again. Confirm the page uses HTTPS or <code>localhost</code>.</p></details>
+                    <details><summary>A webhook receives no request</summary><p>Check startup logs, target matching rules, and container networking. Inside a container, <code>127.0.0.1</code> points to OwlMail itself; use the receiver service name.</p></details>
                     <details><summary>HTML looks different from a real mailbox</summary><p>OwlMail previews captured HTML in an isolated frame. Email clients apply different CSS and security rules, so validate important templates in target clients too.</p></details>
                 </section>
             </article>
@@ -141,6 +168,7 @@ SMTP_SECURE=false</code></pre>
                     <a href="#zh-quick-start">快速开始</a>
                     <a href="#zh-workflow">收件箱操作</a>
                     <a href="#zh-config">配置</a>
+                    <a href="#zh-notifications-webhooks">通知与 Webhook</a>
                     <a href="#zh-api">API</a>
                     <a href="#zh-security">安全</a>
                     <a href="#zh-troubleshooting">问题排查</a>
@@ -193,6 +221,7 @@ SMTP_SECURE=false</code></pre>
                                 <tr><td>SMTP 认证</td><td><code>-smtp-user</code>、<code>-smtp-password</code></td><td><code>OWLMAIL_SMTP_USER</code>、<code>OWLMAIL_SMTP_PASSWORD</code></td><td>关闭</td></tr>
                                 <tr><td>SMTP TLS</td><td><code>-tls</code>、证书和私钥参数</td><td><code>OWLMAIL_TLS_ENABLED</code>、证书和私钥变量</td><td>关闭</td></tr>
                                 <tr><td>Web HTTPS</td><td><code>-https</code>、证书和私钥参数</td><td><code>OWLMAIL_HTTPS_ENABLED</code>、证书和私钥变量</td><td>关闭</td></tr>
+                                <tr><td>Webhook 转发</td><td><code>-webhook-config</code></td><td><code>OWLMAIL_WEBHOOK_CONFIG</code></td><td>关闭</td></tr>
                             </tbody>
                         </table>
                     </div>
@@ -203,8 +232,30 @@ SMTP_SECURE=false</code></pre>
   ghcr.io/soulteary/owlmail:latest</code></pre>
                 </section>
 
+                <section id="zh-notifications-webhooks" class="help-card">
+                    <div class="section-heading"><span>04</span><h2>通知与 Webhook</h2></div>
+                    <div class="feature-grid">
+                        <div><h3>浏览器通知</h3><p>通知默认关闭。点击收件箱顶部的<strong>通知已关闭</strong>后，浏览器才会请求权限。只有启用后通过 WebSocket 实时到达的新邮件会通知，加载已有邮件不会通知。</p></div>
+                        <div><h3>服务端 Webhook</h3><p>即使没有打开浏览器，Webhook 转发也会运行。目标支持过滤邮件、发送自定义 JSON 或文本、添加鉴权请求头与 HMAC 签名，并对临时故障进行有限重试。</p></div>
+                    </div>
+                    <aside class="note"><strong>浏览器要求：</strong>通知需要 HTTPS 或 <code>http://localhost</code> 等受信任的本地来源。如果曾拒绝权限，应先在浏览器的网站设置中允许 OwlMail。</aside>
+                    <h3>最小 Webhook 配置</h3>
+                    <pre><code>{
+  "version": 1,
+  "targets": [
+    {
+      "name": "local-receiver",
+      "url": "http://127.0.0.1:18080/owlmail"
+    }
+  ]
+}</code></pre>
+                    <pre><code>./owlmail -webhook-config ./webhooks.json</code></pre>
+                    <p>同时省略 <code>-webhook-config</code> 和 <code>OWLMAIL_WEBHOOK_CONFIG</code> 时，转发保持关闭。修改文件后需要重启 OwlMail。</p>
+                    <p><a href="https://github.com/soulteary/owlmail/tree/main/examples/webhooks" target="_blank" rel="noopener noreferrer">打开可运行的过滤、自定义 JSON、多目标、纯文本和 soulteary/webhook 联动示例 ↗</a></p>
+                </section>
+
                 <section id="zh-api" class="help-card">
-                    <div class="section-heading"><span>04</span><h2>常用 API</h2></div>
+                    <div class="section-heading"><span>05</span><h2>常用 API</h2></div>
                     <div class="endpoint-list">
                         <div><code>GET /api/v1/emails</code><span>列出和搜索邮件</span></div>
                         <div><code>GET /api/v1/emails/:id</code><span>读取单封邮件</span></div>
@@ -218,20 +269,23 @@ SMTP_SECURE=false</code></pre>
                 </section>
 
                 <section id="zh-security" class="help-card">
-                    <div class="section-heading"><span>05</span><h2>安全检查清单</h2></div>
+                    <div class="section-heading"><span>06</span><h2>安全检查清单</h2></div>
                     <ul class="checklist">
                         <li>仅用于本地开发时，保留默认的回环地址监听。</li>
                         <li>暴露到网络时，同时设置 Web 和 SMTP 凭据，并按场景启用或终止 TLS。</li>
                         <li>捕获的邮件可能包含凭据、重置链接和个人信息，请保护存储目录及备份。</li>
                         <li>只处理开发或测试邮件；开启外发转发或自动转发前，请仔细检查收件人。</li>
+                        <li>Webhook 目标会收到邮件内容；应使用可信 HTTPS 端点、通过环境变量保存 Token，并校验 HMAC 签名。</li>
                     </ul>
                 </section>
 
                 <section id="zh-troubleshooting" class="help-card">
-                    <div class="section-heading"><span>06</span><h2>问题排查</h2></div>
+                    <div class="section-heading"><span>07</span><h2>问题排查</h2></div>
                     <details><summary>应用无法连接 SMTP</summary><p>确认主机和端口，检查 OwlMail 是否监听预期网卡，并核对 Docker 端口映射。客户端和服务端的 TLS 设置必须一致。</p></details>
                     <details><summary>重启后收件箱为空</summary><p>设置 <code>-mail-directory</code> 或 <code>OWLMAIL_MAIL_DIR</code>。在 Docker 中，需要把数据卷挂载到 <code>/app/mail</code>。</p></details>
                     <details><summary>实时更新停止</summary><p>刷新页面，并确认代理允许 <code>/api/v1/ws</code> 的 WebSocket 升级请求。</p></details>
+                    <details><summary>浏览器通知被阻止</summary><p>先在浏览器的网站设置中允许通知，返回 OwlMail 后再次点击通知按钮，并确认页面使用 HTTPS 或 <code>localhost</code>。</p></details>
+                    <details><summary>Webhook 没有收到请求</summary><p>检查启动日志、目标匹配规则和容器网络。容器内的 <code>127.0.0.1</code> 指向 OwlMail 自身，应使用接收器的服务名。</p></details>
                     <details><summary>HTML 与真实邮箱显示不同</summary><p>OwlMail 在隔离框架中预览捕获的 HTML。不同邮件客户端会应用不同的 CSS 和安全规则，重要模板仍应在目标客户端中验证。</p></details>
                 </section>
             </article>


### PR DESCRIPTION
## Summary

- expand the English and Chinese webhook reference with startup behavior, limits, matching semantics, payload fields, headers, delivery lifecycle, troubleshooting, and security guidance
- add runnable examples for minimal forwarding, filtered alerts, authenticated custom JSON, multi-target fan-out, and plain-text payloads
- add a loopback-only test receiver with optional HMAC verification
- add a complete OwlMail + `soulteary/webhook` Compose example with shared HMAC, environment-backed paths, payload mapping, synchronous command execution, and bilingual walkthroughs
- expand the embedded bilingual `/help` page with browser-notification guidance, a minimal webhook setup, scenario links, security notes, and troubleshooting
- link the scenario matrix from the root README and documentation indexes
- fix two pre-existing broken preview asset paths in `docs/README.md`

## Verification

- `go test -race ./...`
- `go vet ./...`
- `go build -trimpath`
- `node --check web/app.js` and `node --check web/help.js`
- validate every JSON example and render all OwlMail templates with email-controlled quotes/newlines
- validate Compose YAML, referenced paths, shell syntax, executable mode, and all changed Markdown links
- validate local-help HTML structure, unique IDs, and in-page anchors
- start the combined binary and confirm the notification and webhook sections are embedded and served at `/help`
- validate the Hook template with the real `soulteary/webhook -template -validate-config`
- end-to-end SMTP tests for minimal forwarding and authenticated custom JSON with verified HMAC
- end-to-end OwlMail → real `soulteary/webhook` binary → mapped command execution

Docker is not available in the local verification environment, so the Compose file was structurally validated while the same configs were exercised directly against the real binaries.