### PR TITLE
fix(webhook): reject empty environment values

### DIFF
--- a/docs/en/Webhook-Forwarding.md
+++ b/docs/en/Webhook-Forwarding.md
@@ -93,7 +93,7 @@ loopback-only receiver, exact startup commands, and a test SMTP message.
 | `match` | No | Case-insensitive wildcard rules. See the rule semantics below. |
 | `bodyTemplate` | No | Go text template for a custom body. When omitted, OwlMail sends the default event payload. |
 
-`${VARIABLE}` placeholders are supported in `url`, header values, and `secret`. OwlMail fails at startup if a referenced variable is missing, rather than silently sending an unauthenticated request.
+`${VARIABLE}` placeholders are supported in `url`, header values, and `secret`. OwlMail fails at startup if a referenced variable is missing or empty, rather than silently sending an unauthenticated request.
 
 Only the braced `${VARIABLE}` form is expanded; `$VARIABLE` is treated as
 literal text. Environment expansion does not apply to `name`, `contentType`,

--- a/docs/zh-CN/Webhook-Forwarding.md
+++ b/docs/zh-CN/Webhook-Forwarding.md
@@ -92,7 +92,7 @@ export OWLMAIL_WEBHOOK_CONFIG=./webhooks.json
 | `match` | 否 | 不区分大小写的通配符规则，语义见下文。 |
 | `bodyTemplate` | 否 | 自定义请求体的 Go 文本模板；省略时发送默认事件结构。 |
 
-`url`、请求头值和 `secret` 支持 `${VARIABLE}` 占位符。如果变量不存在，OwlMail 会在启动阶段报错，不会静默发送缺少鉴权信息的请求。
+`url`、请求头值和 `secret` 支持 `${VARIABLE}` 占位符。如果变量不存在或值为空，OwlMail 会在启动阶段报错，不会静默发送缺少鉴权信息的请求。
 
 只有带花括号的 `${VARIABLE}` 会展开，`$VARIABLE` 会作为普通文本。环境变量
 不会展开到 `name`、`contentType`、匹配规则或 `bodyTemplate`。

--- a/examples/webhooks/README.md
+++ b/examples/webhooks/README.md
@@ -112,7 +112,7 @@ an address reachable from the OwlMail container. The
 
 ## Validate before deployment
 
-OwlMail validates and compiles the complete file at startup. A missing
+OwlMail validates and compiles the complete file at startup. A missing or empty
 environment variable, unknown JSON field, bad duration, invalid wildcard, or
 invalid template prevents the service from starting. After changing a file,
 restart OwlMail; webhook configuration is not hot-reloaded.

--- a/examples/webhooks/README.zh-CN.md
+++ b/examples/webhooks/README.zh-CN.md
@@ -110,7 +110,7 @@ export OWLMAIL_WEBHOOK_SECRET='replace-this-development-secret'
 
 ## 部署前验证
 
-OwlMail 会在启动时校验并编译整个配置文件。缺少环境变量、未知 JSON 字段、
+OwlMail 会在启动时校验并编译整个配置文件。环境变量缺失或值为空、未知 JSON 字段、
 非法时长、无效通配符或错误模板都会阻止服务启动。修改配置后需要重启 OwlMail；
 Webhook 配置不会热加载。
 

--- a/internal/webhook/config.go
+++ b/internal/webhook/config.go
@@ -299,17 +299,25 @@ func validateMatch(match Match) error {
 }
 
 func expandEnvironmentVariables(value string) (string, error) {
-	var missing string
+	var invalidName string
+	var invalidReason string
 	expanded := environmentVariablePattern.ReplaceAllStringFunc(value, func(token string) string {
 		name := environmentVariablePattern.FindStringSubmatch(token)[1]
 		resolved, exists := os.LookupEnv(name)
-		if !exists && missing == "" {
-			missing = name
+		if invalidName == "" {
+			switch {
+			case !exists:
+				invalidName = name
+				invalidReason = "is not set"
+			case resolved == "":
+				invalidName = name
+				invalidReason = "is empty"
+			}
 		}
 		return resolved
 	})
-	if missing != "" {
-		return "", fmt.Errorf("environment variable %s is not set", missing)
+	if invalidName != "" {
+		return "", fmt.Errorf("environment variable %s %s", invalidName, invalidReason)
 	}
 	return expanded, nil
 }

--- a/internal/webhook/config_test.go
+++ b/internal/webhook/config_test.go
@@ -149,6 +149,19 @@ func TestCompileConfigRejectsMissingEnvironment(t *testing.T) {
 	}
 }
 
+func TestCompileConfigRejectsEmptyEnvironment(t *testing.T) {
+	const variable = "OWLMAIL_TEST_EMPTY_SECRET_42C1"
+	t.Setenv(variable, "")
+	_, err := NewDispatcher(Config{Targets: []Target{{
+		Name:   "primary",
+		URL:    "https://example.com/hooks/owlmail",
+		Secret: "${" + variable + "}",
+	}}}, nil)
+	if err == nil || !strings.Contains(err.Error(), variable+" is empty") {
+		t.Fatalf("NewDispatcher() error = %v, want empty environment variable error", err)
+	}
+}
+
 func TestCompileConfigLimitsTargets(t *testing.T) {
 	targets := make([]Target, maxTargets+1)
 	for index := range targets {


### PR DESCRIPTION
## 问题

Webhook 配置中的 `${VAR}` 目前只检查变量是否存在。如果签名密钥或鉴权 Token 被设置为空字符串，OwlMail 会继续启动，并可能静默发送未签名或无鉴权的请求。

## 修改

- 对 URL、Header 和 `secret` 中引用的环境变量统一拒绝空值
- 保留未显式配置 `secret` 时的无签名模式
- 增加空环境变量回归测试
- 同步更新中英文参考文档和示例说明

## 验证

- `go test -race ./internal/webhook/...`
- `git diff --check`