### PR TITLE
fix(api): restrict authenticated browser origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ the message body; clicking one focuses OwlMail and opens the message.
 | `-auto-relay-addr` | `MAILDEV_AUTO_RELAY_ADDR` / `OWLMAIL_AUTO_RELAY_ADDR` | - | Auto relay address |
 | `-auto-relay-rules` | `MAILDEV_AUTO_RELAY_RULES` / `OWLMAIL_AUTO_RELAY_RULES` | - | Auto relay rules file |
 | `-webhook-config` | `OWLMAIL_WEBHOOK_CONFIG` | - | JSON webhook forwarding configuration file |
+
+When HTTP Basic Auth is enabled, browser API and WebSocket requests are limited
+to OwlMail's own origin. Command-line and server-to-server clients that omit the
+browser `Origin` header continue to work normally.
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | SMTP authentication username |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | SMTP authentication password |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | Enable SMTP TLS |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -220,6 +220,9 @@ Notifications API 需要 HTTPS，或 `http://localhost` 等受信任的本地来
 | `-auto-relay-addr` | `MAILDEV_AUTO_RELAY_ADDR` / `OWLMAIL_AUTO_RELAY_ADDR` | - | 自动中继地址 |
 | `-auto-relay-rules` | `MAILDEV_AUTO_RELAY_RULES` / `OWLMAIL_AUTO_RELAY_RULES` | - | 自动中继规则文件 |
 | `-webhook-config` | `OWLMAIL_WEBHOOK_CONFIG` | - | Webhook 消息转发 JSON 配置文件 |
+
+启用 HTTP Basic Auth 后，浏览器 API 与 WebSocket 请求仅允许来自 OwlMail
+自身源。命令行和服务端客户端不携带浏览器 `Origin` 请求头时仍可正常访问。
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | SMTP 认证用户名 |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | SMTP 认证密码 |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | 启用 SMTP TLS |

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -46,6 +46,7 @@ func NewAPIWithAuth(mailServer *mailserver.MailServer, port int, host, user, pas
 
 // NewAPIWithHTTPS creates a new API server instance with HTTP Basic Auth and HTTPS support
 func NewAPIWithHTTPS(mailServer *mailserver.MailServer, port int, host, user, password string, httpsEnabled bool, certFile, keyFile string) *API {
+	authEnabled := user != "" && password != ""
 	api := &API{
 		mailServer:    mailServer,
 		port:          port,
@@ -58,7 +59,7 @@ func NewAPIWithHTTPS(mailServer *mailserver.MailServer, port int, host, user, pa
 		httpsKeyFile:  keyFile,
 		wsUpgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
-				return true // Allow all origins
+				return !authEnabled || originMatchesHost(r.Header.Get("Origin"), r.Host)
 			},
 		},
 	}
@@ -73,17 +74,23 @@ func NewAPIWithHTTPS(mailServer *mailserver.MailServer, port int, host, user, pa
 func (api *API) setupRoutes() {
 	app := fiber.New(fiber.Config{})
 
-	// Enable CORS (match original: allow all origins, AllowCredentials, AllowHeaders, AllowMethods)
-	// Fiber disallows AllowCredentials with AllowOrigins "*", so use AllowOriginsFunc to allow all.
-	app.Use(cors.New(cors.Config{
-		AllowOriginsFunc: func(origin string) bool { return true },
-		AllowCredentials: true,
-		AllowHeaders:     []string{"Content-Type", "Content-Length", "Accept-Encoding", "X-CSRF-Token", "Authorization", "accept", "origin", "Cache-Control", "X-Requested-With"},
-		AllowMethods:     []string{"POST", "OPTIONS", "GET", "PUT", "DELETE", "PATCH"},
-	}))
+	authEnabled := api.authUser != "" && api.authPassword != ""
+	if authEnabled {
+		// Browsers must not reuse cached Basic Auth credentials from an unrelated
+		// origin. Non-browser API clients normally omit Origin and remain allowed.
+		app.Use(sameOriginMiddleware())
+	} else {
+		// Preserve the open development API's cross-origin compatibility. There
+		// are no browser credentials to expose when authentication is disabled.
+		app.Use(cors.New(cors.Config{
+			AllowOrigins: []string{"*"},
+			AllowHeaders: []string{"Content-Type", "Content-Length", "Accept-Encoding", "X-CSRF-Token", "Authorization", "accept", "origin", "Cache-Control", "X-Requested-With"},
+			AllowMethods: []string{"POST", "OPTIONS", "GET", "PUT", "DELETE", "PATCH"},
+		}))
+	}
 
 	// HTTP Basic Auth middleware if configured
-	if api.authUser != "" && api.authPassword != "" {
+	if authEnabled {
 		app.Use(basicAuthMiddleware(api.authUser, api.authPassword, "/healthz", "/api/v1/health"))
 	}
 

--- a/internal/api/api_middleware.go
+++ b/internal/api/api_middleware.go
@@ -2,10 +2,35 @@ package api
 
 import (
 	"encoding/base64"
+	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/gofiber/fiber/v3"
 )
+
+// originMatchesHost implements the browser same-origin host check used for
+// authenticated HTTP and WebSocket requests. Requests without an Origin header
+// are non-browser clients and remain allowed.
+func originMatchesHost(origin, host string) bool {
+	if origin == "" {
+		return true
+	}
+	parsed, err := url.Parse(origin)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return false
+	}
+	return parsed.User == nil && strings.EqualFold(parsed.Host, host)
+}
+
+func sameOriginMiddleware() fiber.Handler {
+	return func(c fiber.Ctx) error {
+		if !originMatchesHost(c.Get(fiber.HeaderOrigin), c.Host()) {
+			return c.SendStatus(http.StatusForbidden)
+		}
+		return c.Next()
+	}
+}
 
 // basicAuthMiddleware creates HTTP Basic Auth middleware for Fiber
 func basicAuthMiddleware(username, password string, skippedPaths ...string) fiber.Handler {

--- a/internal/api/api_middleware_test.go
+++ b/internal/api/api_middleware_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/gofiber/fiber/v3"
@@ -32,6 +33,85 @@ func TestCorsMiddleware(t *testing.T) {
 	allowOrigin := resp.Header.Get("Access-Control-Allow-Origin")
 	if allowOrigin != "*" && allowOrigin != "http://example.com" {
 		t.Errorf("CORS Access-Control-Allow-Origin should be set, got %q", allowOrigin)
+	}
+}
+
+func TestAuthenticatedAPIRejectsCrossOriginBrowserRequest(t *testing.T) {
+	tmpDir := t.TempDir()
+	server, err := mailserver.NewMailServer(1025, "localhost", tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	api := NewAPIWithAuth(server, 1080, "localhost", "user", "pass")
+	req, _ := http.NewRequest(http.MethodGet, "http://owlmail.test/api/v1/emails", nil)
+	req.Header.Set("Origin", "https://attacker.example")
+	req.SetBasicAuth("user", "pass")
+	resp, err := api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+	if origin := resp.Header.Get("Access-Control-Allow-Origin"); origin != "" {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want empty", origin)
+	}
+}
+
+func TestAuthenticatedAPIAllowsSameOriginAndNonBrowserRequests(t *testing.T) {
+	tmpDir := t.TempDir()
+	server, err := mailserver.NewMailServer(1025, "localhost", tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	api := NewAPIWithAuth(server, 1080, "localhost", "user", "pass")
+	for _, origin := range []string{"http://owlmail.test", ""} {
+		req, _ := http.NewRequest(http.MethodGet, "http://owlmail.test/api/v1/emails", nil)
+		if origin != "" {
+			req.Header.Set("Origin", origin)
+		}
+		req.SetBasicAuth("user", "pass")
+		resp, err := api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("origin %q: status = %d, want %d", origin, resp.StatusCode, http.StatusOK)
+		}
+	}
+}
+
+func TestAuthenticatedWebSocketOriginPolicy(t *testing.T) {
+	server, err := mailserver.NewMailServer(1025, "localhost", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	api := NewAPIWithAuth(server, 1080, "localhost", "user", "pass")
+	tests := []struct {
+		origin string
+		want   bool
+	}{
+		{origin: "", want: true},
+		{origin: "http://owlmail.test", want: true},
+		{origin: "https://attacker.example", want: false},
+		{origin: "://invalid", want: false},
+	}
+	for _, test := range tests {
+		req := httptest.NewRequest(http.MethodGet, "http://owlmail.test/api/v1/ws", nil)
+		if test.origin != "" {
+			req.Header.Set("Origin", test.origin)
+		}
+		if got := api.wsUpgrader.CheckOrigin(req); got != test.want {
+			t.Errorf("origin %q: CheckOrigin() = %v, want %v", test.origin, got, test.want)
+		}
 	}
 }
 


### PR DESCRIPTION
## 问题

启用 HTTP Basic Auth 后，API 仍会为任意 Origin 开启带凭据 CORS，WebSocket upgrader 也无条件接受任意 Origin。浏览器缓存的 OwlMail 凭据可能因此被不受信任网页复用，读取测试邮件或调用修改接口。

## 修改

- 鉴权开启时拒绝 Host 不匹配的浏览器 `Origin`
- 对 WebSocket 使用相同的同源策略
- 保留无 `Origin` 的 CLI/服务端客户端访问
- 未启用鉴权时保留原有开放开发 API 的跨域兼容性
- 增加跨域拒绝、同源允许、非浏览器允许和 WebSocket 策略测试
- 更新中英文配置说明

## 验证

- `go test -race ./internal/api/...`
- `git diff --check`