### PR TITLE
test(web): cover browser notification behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,27 @@ on:
     branches: [ main, develop ]
 
 jobs:
+  web-test:
+    name: Web Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Check browser scripts
+        run: |
+          node --check web/app.js
+          node --check web/help.js
+
+      - name: Test browser notifications
+        run: node --test tests/web/*.test.js
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/tests/web/app.test.js
+++ b/tests/web/app.test.js
@@ -1,0 +1,170 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const appSource = fs.readFileSync(path.join(__dirname, '../../web/app.js'), 'utf8');
+
+function createClassList() {
+    const values = new Set();
+    return {
+        contains: (name) => values.has(name),
+        toggle(name, enabled) {
+            if (enabled) values.add(name);
+            else values.delete(name);
+        }
+    };
+}
+
+function createElement() {
+    const listeners = new Map();
+    const attributes = new Map();
+    return {
+        listeners,
+        attributes,
+        classList: createClassList(),
+        hidden: true,
+        disabled: false,
+        textContent: '',
+        title: '',
+        addEventListener(name, handler) { listeners.set(name, handler); },
+        setAttribute(name, value) { attributes.set(name, value); }
+    };
+}
+
+function createHarness({ permission = 'default', secure = true, savedPreference = null } = {}) {
+    const storage = new Map();
+    if (savedPreference !== null) {
+        storage.set('owlmail.browserNotifications.enabled', savedPreference);
+    }
+    const notificationToggle = createElement();
+    const notificationStatus = createElement();
+    const elements = new Map([
+        ['notificationToggle', notificationToggle],
+        ['notificationStatus', notificationStatus]
+    ]);
+    const notifications = [];
+    const windowListeners = new Map();
+    const documentListeners = new Map();
+
+    function Notification(title, options) {
+        const instance = { title, options, closed: false, close() { this.closed = true; } };
+        notifications.push(instance);
+        return instance;
+    }
+    Notification.permission = permission;
+    Notification.requestPermission = async () => {
+        Notification.permission = 'granted';
+        return 'granted';
+    };
+
+    const window = {
+        Notification,
+        isSecureContext: secure,
+        location: { origin: 'http://owlmail.test', protocol: 'http:', host: 'owlmail.test' },
+        addEventListener(name, handler) { windowListeners.set(name, handler); },
+        focus() {}
+    };
+    const document = {
+        title: '',
+        documentElement: { lang: '', dataset: {} },
+        body: { classList: createClassList() },
+        addEventListener(name, handler) { documentListeners.set(name, handler); },
+        getElementById(id) { return elements.get(id) || null; },
+        querySelector() { return null; },
+        querySelectorAll() { return []; },
+        createElement() { return createElement(); }
+    };
+    const sandbox = {
+        window,
+        document,
+        navigator: { language: 'en-US' },
+        localStorage: {
+            getItem(key) { return storage.has(key) ? storage.get(key) : null; },
+            setItem(key, value) { storage.set(key, value); }
+        },
+        console,
+        setTimeout() { return 1; },
+        clearTimeout() {},
+        fetch: async () => { throw new Error('unexpected fetch'); },
+        WebSocket: function WebSocket() {},
+        URL,
+        Blob,
+        confirm: () => true
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(appSource, sandbox, { filename: 'web/app.js' });
+
+    return {
+        documentListeners,
+        notificationStatus,
+        notificationToggle,
+        notifications,
+        storage,
+        window,
+        windowListeners,
+        run(source) { return vm.runInContext(source, sandbox); }
+    };
+}
+
+test('initialization never prompts and keeps notifications disabled by default', () => {
+    const harness = createHarness();
+    let permissionRequests = 0;
+    harness.window.Notification.requestPermission = async () => {
+        permissionRequests++;
+        return 'granted';
+    };
+
+    harness.run('initializeBrowserNotifications()');
+
+    assert.equal(permissionRequests, 0);
+    assert.equal(harness.notificationToggle.attributes.get('aria-pressed'), 'false');
+    assert.equal(harness.notificationToggle.listeners.has('click'), true);
+});
+
+test('user opt-in requests permission and persists the enabled preference', async () => {
+    const harness = createHarness();
+    harness.run('initializeBrowserNotifications()');
+
+    await harness.run('toggleBrowserNotifications()');
+
+    assert.equal(harness.window.Notification.permission, 'granted');
+    assert.equal(harness.storage.get('owlmail.browserNotifications.enabled'), 'true');
+    assert.equal(harness.notificationToggle.attributes.get('aria-pressed'), 'true');
+});
+
+test('a revoked permission clears a previously enabled preference', () => {
+    const harness = createHarness({ permission: 'granted', savedPreference: 'true' });
+    harness.run('initializeBrowserNotifications()');
+    harness.window.Notification.permission = 'denied';
+
+    harness.run('synchronizeBrowserNotificationPermission()');
+
+    assert.equal(harness.storage.get('owlmail.browserNotifications.enabled'), 'false');
+    assert.equal(harness.notificationToggle.attributes.get('aria-pressed'), 'false');
+});
+
+test('new email notification uses bounded text and a stable message tag', () => {
+    const harness = createHarness({ permission: 'granted', savedPreference: 'true' });
+    harness.run('initializeBrowserNotifications()');
+    const longSubject = `  ${'subject '.repeat(30)}  `;
+
+    harness.run(`notifyBrowserForEmail(${JSON.stringify({ id: 'mail-42', subject: longSubject, from: [] })})`);
+
+    assert.equal(harness.notifications.length, 1);
+    assert.equal(harness.notifications[0].title.length, 160);
+    assert.equal(harness.notifications[0].title.endsWith('…'), true);
+    assert.equal(harness.notifications[0].options.tag, 'owlmail-email-mail-42');
+    assert.match(harness.notifications[0].options.body, /Unknown/);
+});
+
+test('insecure contexts report notifications as unavailable', () => {
+    const harness = createHarness({ permission: 'granted', secure: false, savedPreference: 'true' });
+
+    harness.run('initializeBrowserNotifications()');
+
+    assert.equal(harness.notificationToggle.disabled, true);
+    assert.equal(harness.notificationToggle.attributes.get('aria-pressed'), 'false');
+    assert.equal(harness.storage.get('owlmail.browserNotifications.enabled'), 'true');
+});


### PR DESCRIPTION
## 问题

浏览器通知已经成为用户可见功能，但现有 CI 只检查 Go。`web/app.js` 的语法错误、权限状态回归和通知内容行为都无法被自动发现。

## 修改

- 使用 Node 内置 `node:test` 与 `vm`，无需新增 npm 依赖
- 覆盖默认不请求权限、主动启用、权限撤销、通知内容边界与非安全上下文
- CI 固定 Node.js 24
- 对 `web/app.js`、`web/help.js` 执行语法检查
- 在 CI 中运行浏览器通知测试

## 验证

- `node --check web/app.js`
- `node --check web/help.js`
- `node --test tests/web/*.test.js`
- `git diff --check`