### PR TITLE
feat(webhook): bound concurrent deliveries

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,10 +223,7 @@ the message body; clicking one focuses OwlMail and opens the message.
 | `-auto-relay-addr` | `MAILDEV_AUTO_RELAY_ADDR` / `OWLMAIL_AUTO_RELAY_ADDR` | - | Auto relay address |
 | `-auto-relay-rules` | `MAILDEV_AUTO_RELAY_RULES` / `OWLMAIL_AUTO_RELAY_RULES` | - | Auto relay rules file |
 | `-webhook-config` | `OWLMAIL_WEBHOOK_CONFIG` | - | JSON webhook forwarding configuration file |
-
-When HTTP Basic Auth is enabled, browser API and WebSocket requests are limited
-to OwlMail's own origin. Command-line and server-to-server clients that omit the
-browser `Origin` header continue to work normally.
+| `-webhook-max-concurrency` | `OWLMAIL_WEBHOOK_MAX_CONCURRENCY` | 8 | Concurrent email webhook deliveries; `0` disables the limit |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | SMTP authentication username |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | SMTP authentication password |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | Enable SMTP TLS |
@@ -234,6 +231,10 @@ browser `Origin` header continue to work normally.
 | `-tls-key` | `MAILDEV_INCOMING_KEY` / `OWLMAIL_TLS_KEY` | - | SMTP TLS private key file |
 | `-log-level` | `MAILDEV_VERBOSE` / `MAILDEV_SILENT` / `OWLMAIL_LOG_LEVEL` | normal | Log level |
 | `-use-uuid-for-email-id` | `OWLMAIL_USE_UUID_FOR_EMAIL_ID` | false | Use UUID for email IDs (default: 8-character random string) |
+
+When HTTP Basic Auth is enabled, browser API and WebSocket requests are limited
+to OwlMail's own origin. Command-line and server-to-server clients that omit the
+browser `Origin` header continue to work normally.
 
 ### Environment Variable Compatibility
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -220,9 +220,7 @@ Notifications API 需要 HTTPS，或 `http://localhost` 等受信任的本地来
 | `-auto-relay-addr` | `MAILDEV_AUTO_RELAY_ADDR` / `OWLMAIL_AUTO_RELAY_ADDR` | - | 自动中继地址 |
 | `-auto-relay-rules` | `MAILDEV_AUTO_RELAY_RULES` / `OWLMAIL_AUTO_RELAY_RULES` | - | 自动中继规则文件 |
 | `-webhook-config` | `OWLMAIL_WEBHOOK_CONFIG` | - | Webhook 消息转发 JSON 配置文件 |
-
-启用 HTTP Basic Auth 后，浏览器 API 与 WebSocket 请求仅允许来自 OwlMail
-自身源。命令行和服务端客户端不携带浏览器 `Origin` 请求头时仍可正常访问。
+| `-webhook-max-concurrency` | `OWLMAIL_WEBHOOK_MAX_CONCURRENCY` | 8 | Webhook 邮件并发投递数；`0` 表示不限制 |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | SMTP 认证用户名 |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | SMTP 认证密码 |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | 启用 SMTP TLS |
@@ -230,6 +228,9 @@ Notifications API 需要 HTTPS，或 `http://localhost` 等受信任的本地来
 | `-tls-key` | `MAILDEV_INCOMING_KEY` / `OWLMAIL_TLS_KEY` | - | SMTP TLS 私钥文件 |
 | `-log-level` | `MAILDEV_VERBOSE` / `MAILDEV_SILENT` / `OWLMAIL_LOG_LEVEL` | normal | 日志级别 |
 | `-use-uuid-for-email-id` | `OWLMAIL_USE_UUID_FOR_EMAIL_ID` | false | 使用 UUID 作为邮件 ID（默认使用 8 字符随机字符串） |
+
+启用 HTTP Basic Auth 后，浏览器 API 与 WebSocket 请求仅允许来自 OwlMail
+自身源。命令行和服务端客户端不携带浏览器 `Origin` 请求头时仍可正常访问。
 
 ### 环境变量兼容性
 

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -136,12 +136,12 @@ func setupWebhookDispatcher(cfg *config.Config) (*webhooknotify.Dispatcher, erro
 	return dispatcher, nil
 }
 
-func registerWebhookHandler(server *mailserver.MailServer, dispatcher *webhooknotify.Dispatcher) {
+func registerWebhookHandler(server *mailserver.MailServer, dispatcher *webhooknotify.Dispatcher, maxConcurrency int) error {
 	if server == nil || dispatcher == nil {
-		return
+		return nil
 	}
 
-	server.On("new", func(email *mailserver.Email) {
+	err := server.OnWithConcurrency("new", maxConcurrency, func(email *mailserver.Email) {
 		for _, result := range dispatcher.Dispatch(context.Background(), email) {
 			if result.Err != nil {
 				common.Error("Webhook delivery to %q failed after %d attempt(s): %v", result.Target, result.Attempts, result.Err)
@@ -150,7 +150,15 @@ func registerWebhookHandler(server *mailserver.MailServer, dispatcher *webhookno
 			common.Verbose("Webhook delivery to %q succeeded with HTTP %d", result.Target, result.StatusCode)
 		}
 	})
-	common.Log("Webhook forwarding enabled with %d target(s)", dispatcher.TargetCount())
+	if err != nil {
+		return fmt.Errorf("register webhook handler: %w", err)
+	}
+	if maxConcurrency == 0 {
+		common.Log("Webhook forwarding enabled with %d target(s), unlimited concurrency", dispatcher.TargetCount())
+	} else {
+		common.Log("Webhook forwarding enabled with %d target(s), concurrency limit %d", dispatcher.TargetCount(), maxConcurrency)
+	}
+	return nil
 }
 
 // startAPIServer creates and starts the API server
@@ -249,7 +257,10 @@ func createMailServer(cfg *config.Config) (*mailserver.MailServer, error) {
 
 	// Register event handlers
 	registerEventHandlers(server)
-	registerWebhookHandler(server, webhookDispatcher)
+	if err := registerWebhookHandler(server, webhookDispatcher, cfg.WebhookMaxConcurrency); err != nil {
+		_ = server.Close()
+		return nil, err
+	}
 
 	return server, nil
 }

--- a/cmd/owlmail/main_test.go
+++ b/cmd/owlmail/main_test.go
@@ -314,7 +314,12 @@ func TestRegisterWebhookHandlerDispatchesNewEmail(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = server.Close() }()
-	registerWebhookHandler(server, dispatcher)
+	if err := registerWebhookHandler(server, dispatcher, -1); err == nil {
+		t.Fatal("negative webhook concurrency should fail")
+	}
+	if err := registerWebhookHandler(server, dispatcher, 8); err != nil {
+		t.Fatal(err)
+	}
 
 	email := &mailserver.Email{Subject: "Webhook integration"}
 	envelope := &mailserver.Envelope{From: "sender@example.com", To: []string{"recipient@example.com"}}
@@ -329,13 +334,17 @@ func TestRegisterWebhookHandlerDispatchesNewEmail(t *testing.T) {
 }
 
 func TestRegisterWebhookHandlerHandlesNil(t *testing.T) {
-	registerWebhookHandler(nil, nil)
+	if err := registerWebhookHandler(nil, nil, 8); err != nil {
+		t.Fatal(err)
+	}
 	server, err := mailserver.NewMailServer(1025, "localhost", t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() { _ = server.Close() }()
-	registerWebhookHandler(server, nil)
+	if err := registerWebhookHandler(server, nil, 8); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestSetupAuthConfig(t *testing.T) {

--- a/docs/en/Webhook-Forwarding.md
+++ b/docs/en/Webhook-Forwarding.md
@@ -21,18 +21,24 @@ The smallest valid configuration needs only a target name and an HTTP(S) URL:
 Save it and pass it to OwlMail:
 
 ```bash
-./owlmail -webhook-config ./webhooks.json
+./owlmail -webhook-config ./webhooks.json -webhook-max-concurrency 8
 ```
 
 The environment variable form is equivalent:
 
 ```bash
 export OWLMAIL_WEBHOOK_CONFIG=./webhooks.json
+export OWLMAIL_WEBHOOK_MAX_CONCURRENCY=8
 ```
 
 If neither the flag nor environment variable is set, webhook forwarding is
 disabled. The configuration is validated once at startup; restart OwlMail after
 editing it.
+
+The recommended default permits eight emails to be delivered concurrently.
+Set `-webhook-max-concurrency 0` (or the environment variable to `0`) for
+unlimited concurrency when all receivers are trusted, fast, and the incoming
+load is controlled.
 
 ## Choose a runnable example
 
@@ -112,6 +118,22 @@ matching rules, or `bodyTemplate`.
   requests for that target.
 - All targets and templates are compiled before SMTP and Web servers start, so
   a configuration error fails fast without partially enabling forwarding.
+
+## Concurrency and backpressure
+
+`-webhook-max-concurrency` limits concurrent email delivery jobs across all
+targets. The default of `8` is appropriate for local development and small CI
+environments. A useful starting estimate is peak emails per second multiplied
+by the receiver's p95 response time in seconds, rounded up.
+
+The limit is acquired before OwlMail creates the webhook handler goroutine. If
+all slots are busy, the email is already persisted and event processing waits
+for a slot; lightweight logging and WebSocket listeners are still started
+first. This prevents slow receivers from creating an unbounded goroutine pile.
+Within one job, matching targets are delivered sequentially.
+
+Use `0` only when unlimited fan-out is intentional. It preserves the previous
+behavior and can consume large amounts of memory and sockets during a burst.
 
 ## Matching rules
 

--- a/docs/zh-CN/Webhook-Forwarding.md
+++ b/docs/zh-CN/Webhook-Forwarding.md
@@ -21,17 +21,21 @@ OwlMail 可以把符合规则的新邮件发送到一个或多个 HTTP 端点。
 保存配置，并在启动时传给 OwlMail：
 
 ```bash
-./owlmail -webhook-config ./webhooks.json
+./owlmail -webhook-config ./webhooks.json -webhook-max-concurrency 8
 ```
 
 也可以使用等价的环境变量：
 
 ```bash
 export OWLMAIL_WEBHOOK_CONFIG=./webhooks.json
+export OWLMAIL_WEBHOOK_MAX_CONCURRENCY=8
 ```
 
 没有设置参数或环境变量时，Webhook 转发保持关闭。配置只在启动时校验一次；
 修改文件后需要重启 OwlMail。
+
+建议默认值允许同时投递 8 封邮件。仅当所有接收端可信、响应足够快且入口负载
+可控时，才使用 `-webhook-max-concurrency 0`（或把环境变量设为 `0`）取消限制。
 
 ## 选择可运行示例
 
@@ -105,6 +109,19 @@ export OWLMAIL_WEBHOOK_CONFIG=./webhooks.json
 - 单次超时必须大于零且不超过一分钟，默认每次尝试五秒；
 - `retries` 表示额外尝试次数，例如 `2` 表示最多请求三次；
 - SMTP 和 Web 服务启动前，会先编译全部目标与模板，因此错误配置不会造成部分启用。
+
+## 并发与背压
+
+`-webhook-max-concurrency` 限制所有目标共享的并发邮件投递任务数。默认值 `8`
+适合本地开发和小型 CI 环境。估算初始值时，可以用“峰值每秒邮件数 × 接收端
+p95 响应秒数”，然后向上取整。
+
+OwlMail 会在创建 Webhook 处理 goroutine 之前获取并发槽位。槽位耗尽时，邮件已经
+持久化，事件处理会等待空闲槽位；轻量日志和 WebSocket 监听器仍会优先启动。
+因此慢接收端不会制造无限增长的 goroutine。单个任务内的匹配目标仍按顺序投递。
+
+`0` 会保留旧版的无限并发行为，只应在明确需要无限制分发时使用；突发流量下可能
+消耗大量内存和连接。
 
 ## 匹配规则
 

--- a/examples/webhooks/README.md
+++ b/examples/webhooks/README.md
@@ -117,6 +117,10 @@ environment variable, unknown JSON field, bad duration, invalid wildcard, or
 invalid template prevents the service from starting. After changing a file,
 restart OwlMail; webhook configuration is not hot-reloaded.
 
+OwlMail runs at most eight email webhook jobs concurrently by default. Keep the
+recommended limit for most development and CI workloads; use
+`-webhook-max-concurrency 0` only for deliberately unlimited concurrency.
+
 See the [full English reference](../../docs/en/Webhook-Forwarding.md) or
 [中文参考](../../docs/zh-CN/Webhook-Forwarding.md) for every field, payload,
 header, matching rule, retry behavior, and security boundary.

--- a/examples/webhooks/README.zh-CN.md
+++ b/examples/webhooks/README.zh-CN.md
@@ -114,6 +114,9 @@ OwlMail 会在启动时校验并编译整个配置文件。环境变量缺失或
 非法时长、无效通配符或错误模板都会阻止服务启动。修改配置后需要重启 OwlMail；
 Webhook 配置不会热加载。
 
+OwlMail 默认最多并发处理 8 个邮件 Webhook 任务，适合多数开发和 CI 负载。
+仅在明确需要无限并发时使用 `-webhook-max-concurrency 0`。
+
 所有字段、默认请求体、请求头、规则、重试行为和安全边界见
 [中文完整参考](../../docs/zh-CN/Webhook-Forwarding.md) 或
 [English reference](../../docs/en/Webhook-Forwarding.md)。

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,10 @@ import (
 	"github.com/soulteary/cli-kit/flagutil"
 )
 
+// DefaultWebhookMaxConcurrency is the recommended concurrent email delivery
+// limit. Zero remains available as an explicit unlimited mode.
+const DefaultWebhookMaxConcurrency = 8
+
 // EnvMapping defines the mapping from MailDev environment variables to OwlMail environment variables.
 // This maintains backward compatibility with MailDev deployments.
 var EnvMapping = map[string]string{
@@ -226,69 +230,72 @@ type Config struct {
 	UseUUIDForEmailID bool
 
 	// Webhook forwarding configuration
-	WebhookConfig string
+	WebhookConfig         string
+	WebhookMaxConcurrency int
 }
 
 // DefaultConfig returns a Config with default values
 func DefaultConfig() *Config {
 	return &Config{
-		SMTPPort:          1025,
-		SMTPHost:          "localhost",
-		MailDir:           "",
-		WebPort:           1080,
-		WebHost:           "localhost",
-		WebUser:           "",
-		WebPassword:       "",
-		HTTPSEnabled:      false,
-		HTTPSCertFile:     "",
-		HTTPSKeyFile:      "",
-		OutgoingHost:      "",
-		OutgoingPort:      587,
-		OutgoingUser:      "",
-		OutgoingPass:      "",
-		OutgoingSecure:    false,
-		AutoRelay:         false,
-		AutoRelayAddr:     "",
-		AutoRelayRules:    "",
-		SMTPUser:          "",
-		SMTPPassword:      "",
-		TLSEnabled:        false,
-		TLSCertFile:       "",
-		TLSKeyFile:        "",
-		LogLevel:          "normal",
-		UseUUIDForEmailID: false,
-		WebhookConfig:     "",
+		SMTPPort:              1025,
+		SMTPHost:              "localhost",
+		MailDir:               "",
+		WebPort:               1080,
+		WebHost:               "localhost",
+		WebUser:               "",
+		WebPassword:           "",
+		HTTPSEnabled:          false,
+		HTTPSCertFile:         "",
+		HTTPSKeyFile:          "",
+		OutgoingHost:          "",
+		OutgoingPort:          587,
+		OutgoingUser:          "",
+		OutgoingPass:          "",
+		OutgoingSecure:        false,
+		AutoRelay:             false,
+		AutoRelayAddr:         "",
+		AutoRelayRules:        "",
+		SMTPUser:              "",
+		SMTPPassword:          "",
+		TLSEnabled:            false,
+		TLSCertFile:           "",
+		TLSKeyFile:            "",
+		LogLevel:              "normal",
+		UseUUIDForEmailID:     false,
+		WebhookConfig:         "",
+		WebhookMaxConcurrency: DefaultWebhookMaxConcurrency,
 	}
 }
 
 // FlagRefs holds references to all flag values for resolution after parsing.
 type FlagRefs struct {
-	SMTPPort          *int
-	SMTPHost          *string
-	MailDir           *string
-	WebPort           *int
-	WebHost           *string
-	WebUser           *string
-	WebPassword       *string
-	HTTPSEnabled      *bool
-	HTTPSCertFile     *string
-	HTTPSKeyFile      *string
-	OutgoingHost      *string
-	OutgoingPort      *int
-	OutgoingUser      *string
-	OutgoingPass      *string
-	OutgoingSecure    *bool
-	AutoRelay         *bool
-	AutoRelayAddr     *string
-	AutoRelayRules    *string
-	SMTPUser          *string
-	SMTPPassword      *string
-	TLSEnabled        *bool
-	TLSCertFile       *string
-	TLSKeyFile        *string
-	LogLevel          *string
-	UseUUIDForEmailID *bool
-	WebhookConfig     *string
+	SMTPPort              *int
+	SMTPHost              *string
+	MailDir               *string
+	WebPort               *int
+	WebHost               *string
+	WebUser               *string
+	WebPassword           *string
+	HTTPSEnabled          *bool
+	HTTPSCertFile         *string
+	HTTPSKeyFile          *string
+	OutgoingHost          *string
+	OutgoingPort          *int
+	OutgoingUser          *string
+	OutgoingPass          *string
+	OutgoingSecure        *bool
+	AutoRelay             *bool
+	AutoRelayAddr         *string
+	AutoRelayRules        *string
+	SMTPUser              *string
+	SMTPPassword          *string
+	TLSEnabled            *bool
+	TLSCertFile           *string
+	TLSKeyFile            *string
+	LogLevel              *string
+	UseUUIDForEmailID     *bool
+	WebhookConfig         *string
+	WebhookMaxConcurrency *int
 }
 
 // DefineFlags defines all configuration flags on the given FlagSet.
@@ -296,32 +303,33 @@ type FlagRefs struct {
 func DefineFlags(fs *flag.FlagSet) *FlagRefs {
 	cfg := DefaultConfig()
 	return &FlagRefs{
-		SMTPPort:          fs.Int("smtp", cfg.SMTPPort, "SMTP port to catch emails"),
-		SMTPHost:          fs.String("ip", cfg.SMTPHost, "IP address to bind SMTP service to"),
-		MailDir:           fs.String("mail-directory", cfg.MailDir, "Directory for persisting mails"),
-		WebPort:           fs.Int("web", cfg.WebPort, "Web API port"),
-		WebHost:           fs.String("web-ip", cfg.WebHost, "IP address to bind Web API to"),
-		WebUser:           fs.String("web-user", cfg.WebUser, "HTTP Basic Auth username"),
-		WebPassword:       fs.String("web-password", cfg.WebPassword, "HTTP Basic Auth password"),
-		HTTPSEnabled:      fs.Bool("https", cfg.HTTPSEnabled, "Enable HTTPS for Web API"),
-		HTTPSCertFile:     fs.String("https-cert", cfg.HTTPSCertFile, "HTTPS certificate file path"),
-		HTTPSKeyFile:      fs.String("https-key", cfg.HTTPSKeyFile, "HTTPS private key file path"),
-		OutgoingHost:      fs.String("outgoing-host", cfg.OutgoingHost, "Outgoing SMTP server host"),
-		OutgoingPort:      fs.Int("outgoing-port", cfg.OutgoingPort, "Outgoing SMTP server port"),
-		OutgoingUser:      fs.String("outgoing-user", cfg.OutgoingUser, "Outgoing SMTP server username"),
-		OutgoingPass:      fs.String("outgoing-pass", cfg.OutgoingPass, "Outgoing SMTP server password"),
-		OutgoingSecure:    fs.Bool("outgoing-secure", cfg.OutgoingSecure, "Use TLS for outgoing SMTP"),
-		AutoRelay:         fs.Bool("auto-relay", cfg.AutoRelay, "Automatically relay all emails"),
-		AutoRelayAddr:     fs.String("auto-relay-addr", cfg.AutoRelayAddr, "Auto relay to specific address"),
-		AutoRelayRules:    fs.String("auto-relay-rules", cfg.AutoRelayRules, "JSON file path for auto relay rules"),
-		SMTPUser:          fs.String("smtp-user", cfg.SMTPUser, "SMTP server username for authentication"),
-		SMTPPassword:      fs.String("smtp-password", cfg.SMTPPassword, "SMTP server password for authentication"),
-		TLSEnabled:        fs.Bool("tls", cfg.TLSEnabled, "Enable TLS/STARTTLS for SMTP server"),
-		TLSCertFile:       fs.String("tls-cert", cfg.TLSCertFile, "TLS certificate file path"),
-		TLSKeyFile:        fs.String("tls-key", cfg.TLSKeyFile, "TLS private key file path"),
-		LogLevel:          fs.String("log-level", cfg.LogLevel, "Log level: silent, normal, or verbose"),
-		UseUUIDForEmailID: fs.Bool("use-uuid-for-email-id", cfg.UseUUIDForEmailID, "Use UUID instead of random string for email IDs"),
-		WebhookConfig:     fs.String("webhook-config", cfg.WebhookConfig, "JSON file path for webhook forwarding targets"),
+		SMTPPort:              fs.Int("smtp", cfg.SMTPPort, "SMTP port to catch emails"),
+		SMTPHost:              fs.String("ip", cfg.SMTPHost, "IP address to bind SMTP service to"),
+		MailDir:               fs.String("mail-directory", cfg.MailDir, "Directory for persisting mails"),
+		WebPort:               fs.Int("web", cfg.WebPort, "Web API port"),
+		WebHost:               fs.String("web-ip", cfg.WebHost, "IP address to bind Web API to"),
+		WebUser:               fs.String("web-user", cfg.WebUser, "HTTP Basic Auth username"),
+		WebPassword:           fs.String("web-password", cfg.WebPassword, "HTTP Basic Auth password"),
+		HTTPSEnabled:          fs.Bool("https", cfg.HTTPSEnabled, "Enable HTTPS for Web API"),
+		HTTPSCertFile:         fs.String("https-cert", cfg.HTTPSCertFile, "HTTPS certificate file path"),
+		HTTPSKeyFile:          fs.String("https-key", cfg.HTTPSKeyFile, "HTTPS private key file path"),
+		OutgoingHost:          fs.String("outgoing-host", cfg.OutgoingHost, "Outgoing SMTP server host"),
+		OutgoingPort:          fs.Int("outgoing-port", cfg.OutgoingPort, "Outgoing SMTP server port"),
+		OutgoingUser:          fs.String("outgoing-user", cfg.OutgoingUser, "Outgoing SMTP server username"),
+		OutgoingPass:          fs.String("outgoing-pass", cfg.OutgoingPass, "Outgoing SMTP server password"),
+		OutgoingSecure:        fs.Bool("outgoing-secure", cfg.OutgoingSecure, "Use TLS for outgoing SMTP"),
+		AutoRelay:             fs.Bool("auto-relay", cfg.AutoRelay, "Automatically relay all emails"),
+		AutoRelayAddr:         fs.String("auto-relay-addr", cfg.AutoRelayAddr, "Auto relay to specific address"),
+		AutoRelayRules:        fs.String("auto-relay-rules", cfg.AutoRelayRules, "JSON file path for auto relay rules"),
+		SMTPUser:              fs.String("smtp-user", cfg.SMTPUser, "SMTP server username for authentication"),
+		SMTPPassword:          fs.String("smtp-password", cfg.SMTPPassword, "SMTP server password for authentication"),
+		TLSEnabled:            fs.Bool("tls", cfg.TLSEnabled, "Enable TLS/STARTTLS for SMTP server"),
+		TLSCertFile:           fs.String("tls-cert", cfg.TLSCertFile, "TLS certificate file path"),
+		TLSKeyFile:            fs.String("tls-key", cfg.TLSKeyFile, "TLS private key file path"),
+		LogLevel:              fs.String("log-level", cfg.LogLevel, "Log level: silent, normal, or verbose"),
+		UseUUIDForEmailID:     fs.Bool("use-uuid-for-email-id", cfg.UseUUIDForEmailID, "Use UUID instead of random string for email IDs"),
+		WebhookConfig:         fs.String("webhook-config", cfg.WebhookConfig, "JSON file path for webhook forwarding targets"),
+		WebhookMaxConcurrency: fs.Int("webhook-max-concurrency", cfg.WebhookMaxConcurrency, "Maximum concurrent webhook deliveries (0 = unlimited)"),
 	}
 }
 
@@ -361,8 +369,9 @@ func ResolveConfig(fs *flag.FlagSet, refs *FlagRefs) *Config {
 
 		LogLevel: resolveLogLevelWithFlag(fs, "log-level", *refs.LogLevel),
 
-		UseUUIDForEmailID: resolveBoolWithFlag(fs, "use-uuid-for-email-id", "OWLMAIL_USE_UUID_FOR_EMAIL_ID", *refs.UseUUIDForEmailID),
-		WebhookConfig:     resolveStringWithFlag(fs, "webhook-config", "OWLMAIL_WEBHOOK_CONFIG", *refs.WebhookConfig),
+		UseUUIDForEmailID:     resolveBoolWithFlag(fs, "use-uuid-for-email-id", "OWLMAIL_USE_UUID_FOR_EMAIL_ID", *refs.UseUUIDForEmailID),
+		WebhookConfig:         resolveStringWithFlag(fs, "webhook-config", "OWLMAIL_WEBHOOK_CONFIG", *refs.WebhookConfig),
+		WebhookMaxConcurrency: resolveIntWithFlag(fs, "webhook-max-concurrency", "OWLMAIL_WEBHOOK_MAX_CONCURRENCY", *refs.WebhookMaxConcurrency),
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -277,6 +277,9 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.WebhookConfig != "" {
 		t.Errorf("DefaultConfig().WebhookConfig = %q, want empty", cfg.WebhookConfig)
 	}
+	if cfg.WebhookMaxConcurrency != 8 {
+		t.Errorf("DefaultConfig().WebhookMaxConcurrency = %d, want 8", cfg.WebhookMaxConcurrency)
+	}
 }
 
 func TestDefineAndResolveConfig(t *testing.T) {
@@ -307,7 +310,7 @@ func TestDefineAndResolveConfig(t *testing.T) {
 	t.Run("CLI flags override defaults", func(t *testing.T) {
 		fs := flag.NewFlagSet("test-cli", flag.ContinueOnError)
 		refs := DefineFlags(fs)
-		_ = fs.Parse([]string{"-smtp", "2025", "-ip", "0.0.0.0", "-web", "8080", "-webhook-config", "cli-webhooks.json"})
+		_ = fs.Parse([]string{"-smtp", "2025", "-ip", "0.0.0.0", "-web", "8080", "-webhook-config", "cli-webhooks.json", "-webhook-max-concurrency", "0"})
 		cfg := ResolveConfig(fs, refs)
 
 		if cfg.SMTPPort != 2025 {
@@ -322,12 +325,16 @@ func TestDefineAndResolveConfig(t *testing.T) {
 		if cfg.WebhookConfig != "cli-webhooks.json" {
 			t.Errorf("ResolveConfig().WebhookConfig = %q", cfg.WebhookConfig)
 		}
+		if cfg.WebhookMaxConcurrency != 0 {
+			t.Errorf("ResolveConfig().WebhookMaxConcurrency = %d, want 0", cfg.WebhookMaxConcurrency)
+		}
 	})
 
 	t.Run("environment variables work", func(t *testing.T) {
 		_ = envMgr.Set("OWLMAIL_SMTP_PORT", "3025")
 		_ = envMgr.Set("OWLMAIL_SMTP_HOST", "192.168.1.1")
 		_ = envMgr.Set("OWLMAIL_WEBHOOK_CONFIG", "env-webhooks.json")
+		_ = envMgr.Set("OWLMAIL_WEBHOOK_MAX_CONCURRENCY", "24")
 		defer envMgr.Cleanup()
 
 		fs := flag.NewFlagSet("test-env", flag.ContinueOnError)
@@ -343,6 +350,9 @@ func TestDefineAndResolveConfig(t *testing.T) {
 		}
 		if cfg.WebhookConfig != "env-webhooks.json" {
 			t.Errorf("ResolveConfig().WebhookConfig = %q", cfg.WebhookConfig)
+		}
+		if cfg.WebhookMaxConcurrency != 24 {
+			t.Errorf("ResolveConfig().WebhookMaxConcurrency = %d, want 24", cfg.WebhookMaxConcurrency)
 		}
 	})
 

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -64,6 +64,9 @@ func ValidateConfig(cfg *Config) error {
 			return fmt.Errorf("webhook config file: %w", err)
 		}
 	}
+	if cfg.WebhookMaxConcurrency < 0 {
+		return fmt.Errorf("webhook max concurrency must be zero or greater")
+	}
 
 	return nil
 }

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -218,6 +218,14 @@ func TestValidateConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("negative webhook concurrency", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.WebhookMaxConcurrency = -1
+		if err := ValidateConfig(cfg); err == nil {
+			t.Error("ValidateConfig with negative webhook concurrency should return error")
+		}
+	})
+
 	t.Run("valid full config", func(t *testing.T) {
 		cfg := DefaultConfig()
 		cfg.SMTPPort = 2525

--- a/internal/mailserver/config.go
+++ b/internal/mailserver/config.go
@@ -51,7 +51,7 @@ func NewMailServerWithFullConfig(port int, host, mailDir string, outgoingConfig 
 		port:         port,
 		host:         host,
 		eventChan:    make(chan Event, 100),
-		listeners:    make(map[string][]func(*types.Email)),
+		listeners:    make(map[string][]eventListener),
 		authConfig:   authConfig,
 		tlsConfig:    tlsConfig,
 		useUUIDForID: useUUIDForID,

--- a/internal/mailserver/events.go
+++ b/internal/mailserver/events.go
@@ -1,22 +1,59 @@
 package mailserver
 
 import (
+	"fmt"
+
 	"github.com/soulteary/owlmail/internal/types"
 )
 
 // On registers an event listener
 func (ms *MailServer) On(event string, handler func(*types.Email)) {
+	_ = ms.OnWithConcurrency(event, 0, handler)
+}
+
+// OnWithConcurrency registers an event listener with an optional concurrency
+// limit. A limit of zero preserves the original unlimited behavior. Limited
+// listeners acquire a slot before their goroutine is created, providing real
+// backpressure instead of accumulating goroutines that only wait on a lock.
+func (ms *MailServer) OnWithConcurrency(event string, maxConcurrency int, handler func(*types.Email)) error {
+	if maxConcurrency < 0 {
+		return fmt.Errorf("max concurrency must be zero or greater")
+	}
+	if handler == nil {
+		return fmt.Errorf("event handler cannot be nil")
+	}
+
+	listener := eventListener{handler: handler}
+	if maxConcurrency > 0 {
+		listener.slots = make(chan struct{}, maxConcurrency)
+	}
 	ms.listenersMutex.Lock()
 	defer ms.listenersMutex.Unlock()
-	ms.listeners[event] = append(ms.listeners[event], handler)
+	ms.listeners[event] = append(ms.listeners[event], listener)
+	return nil
 }
 
 // emit sends an event to all listeners
 func (ms *MailServer) emit(event string, email *types.Email) {
 	ms.listenersMutex.RLock()
-	defer ms.listenersMutex.RUnlock()
-	handlers := ms.listeners[event]
-	for _, handler := range handlers {
-		go handler(email)
+	listeners := append([]eventListener(nil), ms.listeners[event]...)
+	ms.listenersMutex.RUnlock()
+
+	// Start unlimited listeners first so a saturated bounded listener cannot
+	// delay UI broadcasts or lightweight logging handlers registered after it.
+	for _, listener := range listeners {
+		if listener.slots == nil {
+			go listener.handler(email)
+		}
+	}
+	for _, listener := range listeners {
+		if listener.slots == nil {
+			continue
+		}
+		listener.slots <- struct{}{}
+		go func(listener eventListener) {
+			defer func() { <-listener.slots }()
+			listener.handler(email)
+		}(listener)
 	}
 }

--- a/internal/mailserver/mailserver_events_test.go
+++ b/internal/mailserver/mailserver_events_test.go
@@ -1,6 +1,8 @@
 package mailserver
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -32,5 +34,128 @@ func TestMailServerOn(t *testing.T) {
 		// Event handler was called
 	case <-time.After(1 * time.Second):
 		t.Error("Event handler should have been called")
+	}
+}
+
+func TestOnWithConcurrencyBoundsHandlersBeforeStartingGoroutines(t *testing.T) {
+	server, err := NewMailServer(1025, "localhost", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	const total = 12
+	const limit = 2
+	var active atomic.Int32
+	var maximum atomic.Int32
+	started := make(chan struct{}, total)
+	done := make(chan struct{}, total)
+	release := make(chan struct{})
+	if err := server.OnWithConcurrency("limited", limit, func(_ *Email) {
+		current := active.Add(1)
+		for {
+			observed := maximum.Load()
+			if current <= observed || maximum.CompareAndSwap(observed, current) {
+				break
+			}
+		}
+		started <- struct{}{}
+		<-release
+		active.Add(-1)
+		done <- struct{}{}
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var emitters sync.WaitGroup
+	for index := 0; index < total; index++ {
+		emitters.Add(1)
+		go func() {
+			defer emitters.Done()
+			server.emit("limited", &Email{})
+		}()
+	}
+	for index := 0; index < limit; index++ {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("limited handlers did not start")
+		}
+	}
+	select {
+	case <-started:
+		t.Fatal("handler started above the configured concurrency limit")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	emitters.Wait()
+	for index := 0; index < total; index++ {
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("limited handler did not finish")
+		}
+	}
+	if got := maximum.Load(); got > limit {
+		t.Fatalf("maximum concurrency = %d, want <= %d", got, limit)
+	}
+}
+
+func TestEmitStartsUnlimitedListenersBeforeBoundedBackpressure(t *testing.T) {
+	server, err := NewMailServer(1025, "localhost", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	boundedStarted := make(chan struct{}, 1)
+	release := make(chan struct{})
+	if err := server.OnWithConcurrency("new", 1, func(_ *Email) {
+		boundedStarted <- struct{}{}
+		<-release
+	}); err != nil {
+		t.Fatal(err)
+	}
+	server.emit("new", &Email{})
+	<-boundedStarted
+
+	unlimitedStarted := make(chan struct{}, 1)
+	server.On("new", func(_ *Email) { unlimitedStarted <- struct{}{} })
+	secondEmitDone := make(chan struct{})
+	go func() {
+		server.emit("new", &Email{})
+		close(secondEmitDone)
+	}()
+	select {
+	case <-unlimitedStarted:
+	case <-time.After(time.Second):
+		t.Fatal("unlimited listener was delayed by bounded listener")
+	}
+	select {
+	case <-secondEmitDone:
+		t.Fatal("bounded listener did not apply backpressure")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case <-secondEmitDone:
+	case <-time.After(time.Second):
+		t.Fatal("emit did not resume after a concurrency slot was released")
+	}
+}
+
+func TestOnWithConcurrencyRejectsInvalidRegistration(t *testing.T) {
+	server, err := NewMailServer(1025, "localhost", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	if err := server.OnWithConcurrency("new", -1, func(_ *Email) {}); err == nil {
+		t.Fatal("negative concurrency should fail")
+	}
+	if err := server.OnWithConcurrency("new", 1, nil); err == nil {
+		t.Fatal("nil handler should fail")
 	}
 }

--- a/internal/mailserver/types.go
+++ b/internal/mailserver/types.go
@@ -36,6 +36,11 @@ type TLSConfig struct {
 	Enabled  bool
 }
 
+type eventListener struct {
+	handler func(*types.Email)
+	slots   chan struct{}
+}
+
 // MailServer represents the SMTP mail server
 type MailServer struct {
 	store          []*types.Email
@@ -46,7 +51,7 @@ type MailServer struct {
 	smtpServer     *smtp.Server
 	smtpsServer    *smtp.Server // SMTPS server (direct TLS on 465)
 	eventChan      chan Event
-	listeners      map[string][]func(*types.Email)
+	listeners      map[string][]eventListener
 	listenersMutex sync.RWMutex
 	outgoing       interface {
 		RelayMail(email *types.Email, emlPath, relayTo string, isAutoRelay bool, callback func(error))

--- a/web/help.html
+++ b/web/help.html
@@ -95,6 +95,7 @@ SMTP_SECURE=false</code></pre>
                                 <tr><td>SMTP TLS</td><td><code>-tls</code>, <code>-tls-cert</code>, <code>-tls-key</code></td><td><code>OWLMAIL_TLS_ENABLED</code>, certificate/key variables</td><td>Disabled</td></tr>
                                 <tr><td>Web HTTPS</td><td><code>-https</code>, <code>-https-cert</code>, <code>-https-key</code></td><td><code>OWLMAIL_HTTPS_ENABLED</code>, certificate/key variables</td><td>Disabled</td></tr>
                                 <tr><td>Webhook forwarding</td><td><code>-webhook-config</code></td><td><code>OWLMAIL_WEBHOOK_CONFIG</code></td><td>Disabled</td></tr>
+                                <tr><td>Webhook concurrency</td><td><code>-webhook-max-concurrency</code></td><td><code>OWLMAIL_WEBHOOK_MAX_CONCURRENCY</code></td><td><code>8</code>; <code>0</code> is unlimited</td></tr>
                             </tbody>
                         </table>
                     </div>
@@ -124,6 +125,7 @@ SMTP_SECURE=false</code></pre>
 }</code></pre>
                     <pre><code>./owlmail -webhook-config ./webhooks.json</code></pre>
                     <p>Omit both <code>-webhook-config</code> and <code>OWLMAIL_WEBHOOK_CONFIG</code> to keep forwarding disabled. Restart OwlMail after changing the file.</p>
+                    <p>At most eight email delivery jobs run concurrently by default. When the limit is full, stored-mail event processing waits instead of creating more webhook goroutines. Set <code>-webhook-max-concurrency 0</code> only for intentional unlimited concurrency.</p>
                     <p><a href="https://github.com/soulteary/owlmail/tree/main/examples/webhooks" target="_blank" rel="noopener noreferrer">Open runnable filtering, custom JSON, multi-target, plain-text, and soulteary/webhook examples ↗</a></p>
                 </section>
 
@@ -222,6 +224,7 @@ SMTP_SECURE=false</code></pre>
                                 <tr><td>SMTP TLS</td><td><code>-tls</code>、证书和私钥参数</td><td><code>OWLMAIL_TLS_ENABLED</code>、证书和私钥变量</td><td>关闭</td></tr>
                                 <tr><td>Web HTTPS</td><td><code>-https</code>、证书和私钥参数</td><td><code>OWLMAIL_HTTPS_ENABLED</code>、证书和私钥变量</td><td>关闭</td></tr>
                                 <tr><td>Webhook 转发</td><td><code>-webhook-config</code></td><td><code>OWLMAIL_WEBHOOK_CONFIG</code></td><td>关闭</td></tr>
+                                <tr><td>Webhook 并发</td><td><code>-webhook-max-concurrency</code></td><td><code>OWLMAIL_WEBHOOK_MAX_CONCURRENCY</code></td><td><code>8</code>；<code>0</code> 表示不限制</td></tr>
                             </tbody>
                         </table>
                     </div>
@@ -251,6 +254,7 @@ SMTP_SECURE=false</code></pre>
 }</code></pre>
                     <pre><code>./owlmail -webhook-config ./webhooks.json</code></pre>
                     <p>同时省略 <code>-webhook-config</code> 和 <code>OWLMAIL_WEBHOOK_CONFIG</code> 时，转发保持关闭。修改文件后需要重启 OwlMail。</p>
+                    <p>默认最多同时处理 8 个邮件投递任务。达到上限时，已持久化邮件的事件处理会等待，而不会继续创建 Webhook goroutine。仅在明确需要无限并发时设置 <code>-webhook-max-concurrency 0</code>。</p>
                     <p><a href="https://github.com/soulteary/owlmail/tree/main/examples/webhooks" target="_blank" rel="noopener noreferrer">打开可运行的过滤、自定义 JSON、多目标、纯文本和 soulteary/webhook 联动示例 ↗</a></p>
                 </section>
 


### PR DESCRIPTION
## 问题

MailServer 会为每个事件监听器直接创建 goroutine。慢 Webhook 或突发邮件会产生无上限的投递 goroutine，最终消耗大量内存与连接。

## 修改

- 新增 `-webhook-max-concurrency` / `OWLMAIL_WEBHOOK_MAX_CONCURRENCY`
- 推荐默认值为 `8`，显式设置 `0` 可恢复无限并发
- 在创建 Webhook goroutine **之前** 获取并发槽位，饱和时施加背压
- 邮件在等待前已经持久化；日志和 WebSocket 等无限制监听器优先调度
- 单封邮件的多个目标继续按顺序投递，不改变匹配、重试和签名语义
- 补充上限、背压、无限模式、配置解析和非法值测试
- 更新 README、中英文完整参考、场景示例和内置帮助页

## 容量建议

默认 `8` 适合本地开发和小型 CI。初始值可按 `峰值邮件/秒 × 接收端 p95 响应秒数` 向上取整；仅在接收端可信、快速且入口负载受控时使用 `0`。

## 验证

- `go test -race ./...`
- `go vet ./...`
- `node --check web/app.js && node --check web/help.js`
- `node --test tests/web/*.test.js`
- `git diff --check`