### PR TITLE
release: prepare OwlMail 0.5.0

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,15 +49,24 @@ jobs:
             type=sha,prefix=sha-
             type=raw,value=latest,enable={{is_default_branch}}
 
+      - name: Prepare build metadata
+        id: build-meta
+        shell: bash
+        run: echo "build-date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${GITHUB_OUTPUT}"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+            COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ steps.build-meta.outputs.build-date }}
+            BRANCH=${{ github.ref_name }}
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,43 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Resolve release metadata
+        id: release
+        shell: bash
+        env:
+          REQUESTED_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            VERSION="${REQUESTED_VERSION}"
+          else
+            VERSION="${GITHUB_REF_NAME}"
+          fi
+
+          if [[ ! "${VERSION}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "::error::Release version must be a semantic-version tag such as v0.5.0"
+            exit 1
+          fi
+
+          if ! git rev-parse --verify "refs/tags/${VERSION}^{commit}" >/dev/null; then
+            echo "::error::Tag ${VERSION} does not exist; create and push it before running a release"
+            exit 1
+          fi
+
+          git checkout --detach "${VERSION}"
+          NOTES="docs/en/Release-${VERSION#v}.md"
+          if [ ! -f "${NOTES}" ]; then
+            echo "::error::Missing curated release notes: ${NOTES}"
+            exit 1
+          fi
+
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "notes=${NOTES}" >> "${GITHUB_OUTPUT}"
+          if [[ "${VERSION}" == *-* ]]; then
+            echo "prerelease=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "prerelease=false" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -41,23 +78,73 @@ jobs:
         env:
           CGO_ENABLED: 0
         run: |
-          VERSION=${GITHUB_REF#refs/tags/}
-          if [ -z "$VERSION" ] || [ "$VERSION" = "$GITHUB_REF" ]; then
-            VERSION=${{ github.event.inputs.version }}
-          fi
+          VERSION="${{ steps.release.outputs.version }}"
+          APP_VERSION="${VERSION#v}"
+          COMMIT="$(git rev-parse HEAD)"
+          BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          LDFLAGS="-s -w \
+            -X github.com/soulteary/version-kit/v2.Version=${APP_VERSION} \
+            -X github.com/soulteary/version-kit/v2.Commit=${COMMIT} \
+            -X github.com/soulteary/version-kit/v2.BuildDate=${BUILD_DATE} \
+            -X github.com/soulteary/version-kit/v2.Branch=${VERSION}"
           
-          echo "Building version: $VERSION"
+          echo "Building version: ${APP_VERSION} (${COMMIT})"
           
           # Linux (static linking for better compatibility)
-          GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o owlmail-linux-amd64 ./cmd/owlmail
-          GOOS=linux GOARCH=arm64 go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o owlmail-linux-arm64 ./cmd/owlmail
+          GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags "${LDFLAGS} -extldflags=-static" -o owlmail-linux-amd64 ./cmd/owlmail
+          GOOS=linux GOARCH=arm64 go build -a -installsuffix cgo -ldflags "${LDFLAGS} -extldflags=-static" -o owlmail-linux-arm64 ./cmd/owlmail
           
           # macOS
-          GOOS=darwin GOARCH=amd64 go build -a -installsuffix cgo -o owlmail-darwin-amd64 ./cmd/owlmail
-          GOOS=darwin GOARCH=arm64 go build -a -installsuffix cgo -o owlmail-darwin-arm64 ./cmd/owlmail
+          GOOS=darwin GOARCH=amd64 go build -a -installsuffix cgo -ldflags "${LDFLAGS}" -o owlmail-darwin-amd64 ./cmd/owlmail
+          GOOS=darwin GOARCH=arm64 go build -a -installsuffix cgo -ldflags "${LDFLAGS}" -o owlmail-darwin-arm64 ./cmd/owlmail
           
           # Windows
-          GOOS=windows GOARCH=amd64 go build -a -installsuffix cgo -o owlmail-windows-amd64.exe ./cmd/owlmail
+          GOOS=windows GOARCH=amd64 go build -a -installsuffix cgo -ldflags "${LDFLAGS}" -o owlmail-windows-amd64.exe ./cmd/owlmail
+
+      - name: Verify embedded release metadata
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          EXPECTED_VERSION="${RELEASE_VERSION#v}"
+          EXPECTED_COMMIT="$(git rev-parse HEAD)"
+          LOG_FILE="${RUNNER_TEMP}/owlmail-release-smoke.log"
+          DATA_DIR="${RUNNER_TEMP}/owlmail-release-smoke-data"
+
+          ./owlmail-linux-amd64 \
+            -ip 127.0.0.1 -smtp 11025 \
+            -web-ip 127.0.0.1 -web 11080 \
+            -mail-directory "${DATA_DIR}" >"${LOG_FILE}" 2>&1 &
+          SERVER_PID=$!
+          cleanup() {
+            kill "${SERVER_PID}" 2>/dev/null || true
+            wait "${SERVER_PID}" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          READY=false
+          for _ in {1..30}; do
+            if curl --silent --show-error --fail http://127.0.0.1:11080/healthz >/dev/null; then
+              READY=true
+              break
+            fi
+            sleep 1
+          done
+          if [ "${READY}" != "true" ]; then
+            cat "${LOG_FILE}"
+            echo "::error::Release binary did not become ready"
+            exit 1
+          fi
+
+          VERSION_JSON="$(curl --silent --show-error --fail http://127.0.0.1:11080/api/v1/version)"
+          if ! grep -Fq "\"version\":\"${EXPECTED_VERSION}\"" <<<"${VERSION_JSON}"; then
+            echo "::error::Expected embedded version ${EXPECTED_VERSION}, got ${VERSION_JSON}"
+            exit 1
+          fi
+          if ! grep -Fq "\"commit\":\"${EXPECTED_COMMIT}\"" <<<"${VERSION_JSON}"; then
+            echo "::error::Expected embedded commit ${EXPECTED_COMMIT}, got ${VERSION_JSON}"
+            exit 1
+          fi
 
       - name: Create checksums
         run: |
@@ -66,11 +153,15 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
+          name: ${{ steps.release.outputs.version }}
+          tag_name: ${{ steps.release.outputs.version }}
+          body_path: ${{ steps.release.outputs.notes }}
           files: |
             owlmail-*
             checksums.txt
+          fail_on_unmatched_files: true
           generate_release_notes: true
           draft: false
-          prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'alpha') || contains(github.ref, 'rc') }}
+          prerelease: ${{ steps.release.outputs.prerelease }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to OwlMail are documented in this file. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and release tags use
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0]
+
+### Added
+
+- Generic outgoing webhook delivery for newly received email, including
+  multiple targets, wildcard filters, JSON-safe and plain-text templates,
+  environment-backed values, HMAC-SHA256 signatures, bounded retries, and
+  per-target timeouts.
+- Runnable webhook scenarios for a minimal receiver, filtered notifications,
+  custom payloads, multiple targets, plain text, and an end-to-end
+  `soulteary/webhook` Compose stack.
+- An embedded English/Chinese help page available from the inbox and at
+  `/help` without separate runtime assets.
+- Opt-in browser notifications for messages received over the live WebSocket.
+- A process-wide webhook concurrency setting with a recommended default of
+  `8`; `0` explicitly selects unlimited delivery concurrency.
+- Browser and documentation contract tests, including API-route, configuration,
+  local-link, and notification checks.
+
+### Changed
+
+- Migrated the HTTP implementation to Fiber v3.
+- A lone Web Basic Auth username now receives a generated 32-character
+  temporary password printed once to stderr. A lone password now uses the
+  default username `admin`; neither value still disables authentication.
+- Authenticated browser API and WebSocket requests are restricted to OwlMail's
+  own origin. Server-to-server clients without a browser `Origin` header are
+  unaffected.
+- Webhook capacity is acquired before starting a handler goroutine, preventing
+  unbounded goroutine creation when a finite concurrency limit is configured.
+- Source builds move to Go 1.27.0 and refresh the project's Go, container, and
+  CI dependencies.
+- Project documentation now distinguishes MailDev-style workflows from exact
+  API compatibility and records the current SMTP-authentication limitation.
+
+### Release engineering
+
+- Release notes are versioned in the repository and prepended to GitHub's
+  generated change list.
+- Manual release workflow runs must reference an existing semantic-version tag
+  and build that tag instead of the default branch.
+- Release binaries and container images embed their version, commit, build
+  timestamp, and source tag; the workflow smoke-tests the version endpoint.
+- Go Report Card output is generated in the repository with
+  `soulteary/goreportcard-action` rather than loaded from the external service.
+
+## [0.4.0] - 2026-01-27
+
+- Adopted `soulteary/cli-kit` for command-line and environment configuration.
+
+Earlier release notes remain available on the
+[GitHub Releases page](https://github.com/soulteary/owlmail/releases).
+
+[Unreleased]: https://github.com/soulteary/owlmail/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/soulteary/owlmail/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/soulteary/owlmail/releases/tag/v0.4.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ FROM golang:1.26.6-alpine AS builder
 # Build arguments for multi-arch support
 ARG TARGETOS=linux
 ARG TARGETARCH
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+ARG BRANCH=unknown
 
 # Set working directory
 WORKDIR /build
@@ -20,8 +24,14 @@ RUN go mod download
 # Copy source code
 COPY . .
 
-# Build application with target architecture
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o owlmail ./cmd/owlmail
+# Build application with target architecture and observable release metadata
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -installsuffix cgo \
+    -ldflags "-s -w -extldflags=-static \
+      -X github.com/soulteary/version-kit/v2.Version=${VERSION} \
+      -X github.com/soulteary/version-kit/v2.Commit=${COMMIT} \
+      -X github.com/soulteary/version-kit/v2.BuildDate=${BUILD_DATE} \
+      -X github.com/soulteary/version-kit/v2.Branch=${BRANCH}" \
+    -o owlmail ./cmd/owlmail
 
 # Runtime stage
 FROM alpine:latest

--- a/README.de.md
+++ b/README.de.md
@@ -118,24 +118,25 @@ export MAILDEV_WEB_PORT=1080
 Der einfachste Weg, OwlMail zu verwenden, ist das Abrufen des vorgefertigten Images von GitHub Container Registry:
 
 ```bash
-# Neuestes Image abrufen
-docker pull ghcr.io/soulteary/owlmail:latest
+# Release 0.5.0 abrufen
+docker pull ghcr.io/soulteary/owlmail:0.5.0
 
-# Bestimmte Version abrufen (mit Commit-SHA)
-docker pull ghcr.io/soulteary/owlmail:sha-49b5f35
+# Image für einen exakten Commit abrufen (Beispiel)
+docker pull ghcr.io/soulteary/owlmail:sha-b130f33
 
 # Container ausführen
 docker run -d \
   -p 1025:1025 \
   -p 1080:1080 \
   --name owlmail \
-  ghcr.io/soulteary/owlmail:latest
+  ghcr.io/soulteary/owlmail:0.5.0
 ```
 
 **Verfügbare Tags:**
-- `latest` - Neueste stabile Version
-- `sha-<commit>` - Bestimmter Commit-SHA (z.B. `sha-49b5f35`)
-- `main` - Neueste Version vom main-Branch
+- `0.5.0` - Exaktes Release-Tag; `0.5` und `0` werden mit späteren Releases der Reihe aktualisiert
+- `sha-<commit>` - Image für einen bestimmten kurzen Commit-SHA (z. B. `sha-b130f33`)
+- `main` - Veränderliches Image des neuesten `main`-Builds
+- `latest` - Veränderliches Standard-Branch-Image, kein stabiles Release-Tag
 
 **Multi-Architektur-Unterstützung:**
 Das Image unterstützt sowohl `linux/amd64` als auch `linux/arm64` Architekturen. Docker lädt automatisch das richtige Image für Ihre Plattform herunter.
@@ -609,9 +610,13 @@ Dieses Projekt ist unter der MIT-Lizenz lizenziert - siehe [LICENSE](LICENSE)-Da
 
 ## 📚 Verwandte Dokumentation
 
+- [Versionshinweise zu OwlMail 0.5.0](./docs/en/Release-0.5.0.md) ([中文](./docs/zh-CN/Release-0.5.0.md))
+- [Änderungsprotokoll](./CHANGELOG.md)
 - [OwlMail × MailDev: Vollständiger Funktions- und API-Vergleich und Migrations-Whitepaper](./docs/de/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [API-Referenz (English)](./docs/en/API-Reference.md)
 - [Betrieb und Fehlerbehebung (English)](./docs/en/Operations.md)
+- [Webhook-Weiterleitung (English)](./docs/en/Webhook-Forwarding.md)
+- [Veröffentlichungsprozess (English)](./docs/en/Releasing.md)
 - [API-Refactoring-Aufzeichnung (historisch)](./docs/de/internal/API_Refactoring_Record.md)
 
 ## 🐛 Problemberichterstattung

--- a/README.fr.md
+++ b/README.fr.md
@@ -119,24 +119,25 @@ export MAILDEV_WEB_PORT=1080
 La façon la plus simple d'utiliser OwlMail est de récupérer l'image pré-construite depuis GitHub Container Registry :
 
 ```bash
-# Récupérer la dernière image
-docker pull ghcr.io/soulteary/owlmail:latest
+# Récupérer la version 0.5.0
+docker pull ghcr.io/soulteary/owlmail:0.5.0
 
-# Récupérer une version spécifique (en utilisant le SHA du commit)
-docker pull ghcr.io/soulteary/owlmail:sha-49b5f35
+# Récupérer l'image d'un commit exact (exemple)
+docker pull ghcr.io/soulteary/owlmail:sha-b130f33
 
 # Exécuter le conteneur
 docker run -d \
   -p 1025:1025 \
   -p 1080:1080 \
   --name owlmail \
-  ghcr.io/soulteary/owlmail:latest
+  ghcr.io/soulteary/owlmail:0.5.0
 ```
 
 **Tags disponibles :**
-- `latest` - Dernière version stable
-- `sha-<commit>` - SHA de commit spécifique (ex. : `sha-49b5f35`)
-- `main` - Dernière version de la branche main
+- `0.5.0` - Tag de version exact ; `0.5` et `0` évoluent avec les versions ultérieures de ces séries
+- `sha-<commit>` - Image d'un SHA court précis (par exemple `sha-b130f33`)
+- `main` - Image mobile issue du dernier build de `main`
+- `latest` - Image mobile de la branche par défaut, pas un sélecteur de version stable
 
 **Support multi-architecture :**
 L'image prend en charge les architectures `linux/amd64` et `linux/arm64`. Docker récupérera automatiquement la bonne image pour votre plateforme.
@@ -608,9 +609,13 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 📚 Related Documentation
 
+- [Notes de version OwlMail 0.5.0](./docs/en/Release-0.5.0.md) ([中文](./docs/zh-CN/Release-0.5.0.md))
+- [Journal des modifications](./CHANGELOG.md)
 - [OwlMail × MailDev: Full Feature & API Comparison and Migration White Paper](./docs/fr/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [Référence API (English)](./docs/en/API-Reference.md)
 - [Exploitation et dépannage (English)](./docs/en/Operations.md)
+- [Transmission Webhook (English)](./docs/en/Webhook-Forwarding.md)
+- [Processus de publication (English)](./docs/en/Releasing.md)
 - [Journal de refactorisation API (historique)](./docs/fr/internal/API_Refactoring_Record.md)
 
 ## 🐛 Issue Reporting

--- a/README.it.md
+++ b/README.it.md
@@ -118,24 +118,25 @@ export MAILDEV_WEB_PORT=1080
 Il modo più semplice per usare OwlMail è scaricare l'immagine pre-costruita da GitHub Container Registry:
 
 ```bash
-# Scarica l'ultima immagine
-docker pull ghcr.io/soulteary/owlmail:latest
+# Scarica la release 0.5.0
+docker pull ghcr.io/soulteary/owlmail:0.5.0
 
-# Scarica una versione specifica (usando il SHA del commit)
-docker pull ghcr.io/soulteary/owlmail:sha-49b5f35
+# Scarica l'immagine di un commit esatto (esempio)
+docker pull ghcr.io/soulteary/owlmail:sha-b130f33
 
 # Esegui container
 docker run -d \
   -p 1025:1025 \
   -p 1080:1080 \
   --name owlmail \
-  ghcr.io/soulteary/owlmail:latest
+  ghcr.io/soulteary/owlmail:0.5.0
 ```
 
 **Tag disponibili:**
-- `latest` - Ultima versione stabile
-- `sha-<commit>` - SHA del commit specifico (es. `sha-49b5f35`)
-- `main` - Ultima versione dal branch main
+- `0.5.0` - Tag di release esatto; `0.5` e `0` avanzano con le release successive della serie
+- `sha-<commit>` - Immagine per uno SHA breve specifico (ad esempio `sha-b130f33`)
+- `main` - Immagine mobile dell'ultimo build di `main`
+- `latest` - Immagine mobile del branch predefinito, non un selettore di release stabile
 
 **Supporto multi-architettura:**
 L'immagine supporta sia le architetture `linux/amd64` che `linux/arm64`. Docker scaricherà automaticamente l'immagine corretta per la tua piattaforma.
@@ -606,9 +607,13 @@ Questo progetto è concesso in licenza sotto la Licenza MIT - vedi il file [LICE
 
 ## 📚 Documentazione Correlata
 
+- [Note di rilascio OwlMail 0.5.0](./docs/en/Release-0.5.0.md) ([中文](./docs/zh-CN/Release-0.5.0.md))
+- [Registro delle modifiche](./CHANGELOG.md)
 - [OwlMail × MailDev: Confronto Completo Funzionalità e API e White Paper di Migrazione](./docs/it/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [Riferimento API (English)](./docs/en/API-Reference.md)
 - [Operazioni e risoluzione problemi (English)](./docs/en/Operations.md)
+- [Inoltro Webhook (English)](./docs/en/Webhook-Forwarding.md)
+- [Processo di rilascio (English)](./docs/en/Releasing.md)
 - [Registro Refactoring API (storico)](./docs/it/internal/API_Refactoring_Record.md)
 
 ## 🐛 Segnalazione Problemi

--- a/README.ja.md
+++ b/README.ja.md
@@ -118,24 +118,25 @@ export MAILDEV_WEB_PORT=1080
 OwlMail を使用する最も簡単な方法は、GitHub Container Registry から事前に構築されたイメージを取得することです：
 
 ```bash
-# 最新のイメージを取得
-docker pull ghcr.io/soulteary/owlmail:latest
+# リリース 0.5.0 を取得
+docker pull ghcr.io/soulteary/owlmail:0.5.0
 
-# 特定のバージョンを取得（コミット SHA を使用）
-docker pull ghcr.io/soulteary/owlmail:sha-49b5f35
+# 特定コミットのイメージを取得（例）
+docker pull ghcr.io/soulteary/owlmail:sha-b130f33
 
 # コンテナを実行
 docker run -d \
   -p 1025:1025 \
   -p 1080:1080 \
   --name owlmail \
-  ghcr.io/soulteary/owlmail:latest
+  ghcr.io/soulteary/owlmail:0.5.0
 ```
 
 **利用可能なタグ：**
-- `latest` - 最新の安定版
-- `sha-<commit>` - 特定のコミット SHA（例：`sha-49b5f35`）
-- `main` - main ブランチの最新版
+- `0.5.0` - 正確なリリースタグ。`0.5` と `0` は同じ系列の後続リリースで更新
+- `sha-<commit>` - 特定の短いコミット SHA のイメージ（例：`sha-b130f33`）
+- `main` - 最新の `main` ビルドに追随する可変イメージ
+- `latest` - デフォルトブランチに追随する可変イメージで、安定版の指定には使用不可
 
 **マルチアーキテクチャサポート：**
 イメージは `linux/amd64` と `linux/arm64` の両方のアーキテクチャをサポートしています。Docker は自動的にプラットフォームに適したイメージを取得します。
@@ -606,9 +607,13 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 📚 Related Documentation
 
+- [OwlMail 0.5.0 リリースノート](./docs/en/Release-0.5.0.md) ([中文](./docs/zh-CN/Release-0.5.0.md))
+- [変更履歴](./CHANGELOG.md)
 - [OwlMail × MailDev: Full Feature & API Comparison and Migration White Paper](./docs/ja/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [API リファレンス (English)](./docs/en/API-Reference.md)
 - [運用・トラブルシューティング (English)](./docs/en/Operations.md)
+- [Webhook 転送 (English)](./docs/en/Webhook-Forwarding.md)
+- [リリース手順 (English)](./docs/en/Releasing.md)
 - [API リファクタリング記録（履歴）](./docs/ja/internal/API_Refactoring_Record.md)
 
 ## 🐛 Issue Reporting

--- a/README.ko.md
+++ b/README.ko.md
@@ -118,24 +118,25 @@ export MAILDEV_WEB_PORT=1080
 OwlMail을 사용하는 가장 쉬운 방법은 GitHub Container Registry에서 사전 빌드된 이미지를 가져오는 것입니다:
 
 ```bash
-# 최신 이미지 가져오기
-docker pull ghcr.io/soulteary/owlmail:latest
+# 0.5.0 릴리스 가져오기
+docker pull ghcr.io/soulteary/owlmail:0.5.0
 
-# 특정 버전 가져오기 (커밋 SHA 사용)
-docker pull ghcr.io/soulteary/owlmail:sha-49b5f35
+# 정확한 커밋 이미지 가져오기 (예시)
+docker pull ghcr.io/soulteary/owlmail:sha-b130f33
 
 # 컨테이너 실행
 docker run -d \
   -p 1025:1025 \
   -p 1080:1080 \
   --name owlmail \
-  ghcr.io/soulteary/owlmail:latest
+  ghcr.io/soulteary/owlmail:0.5.0
 ```
 
 **사용 가능한 태그:**
-- `latest` - 최신 안정 버전
-- `sha-<commit>` - 특정 커밋 SHA (예: `sha-49b5f35`)
-- `main` - main 브랜치의 최신 버전
+- `0.5.0` - 정확한 릴리스 태그. `0.5`와 `0`은 해당 계열의 후속 릴리스에 따라 이동
+- `sha-<commit>` - 특정 짧은 커밋 SHA의 이미지(예: `sha-b130f33`)
+- `main` - 최신 `main` 빌드를 가리키는 이동 태그
+- `latest` - 기본 브랜치를 가리키는 이동 태그이며 안정 릴리스 선택자가 아님
 
 **다중 아키텍처 지원:**
 이미지는 `linux/amd64` 및 `linux/arm64` 아키텍처를 모두 지원합니다. Docker는 플랫폼에 맞는 올바른 이미지를 자동으로 가져옵니다.
@@ -606,9 +607,13 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 📚 Related Documentation
 
+- [OwlMail 0.5.0 릴리스 노트](./docs/en/Release-0.5.0.md) ([中文](./docs/zh-CN/Release-0.5.0.md))
+- [변경 기록](./CHANGELOG.md)
 - [OwlMail × MailDev: Full Feature & API Comparison and Migration White Paper](./docs/ko/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [API 참조 (English)](./docs/en/API-Reference.md)
 - [운영 및 문제 해결 (English)](./docs/en/Operations.md)
+- [Webhook 전달 (English)](./docs/en/Webhook-Forwarding.md)
+- [릴리스 절차 (English)](./docs/en/Releasing.md)
 - [API 리팩토링 기록(과거 자료)](./docs/ko/internal/API_Refactoring_Record.md)
 
 ## 🐛 Issue Reporting

--- a/README.md
+++ b/README.md
@@ -124,24 +124,25 @@ in the executable, so installed binaries do not need a separate `web` folder.
 The easiest way to use OwlMail is to pull the pre-built image from GitHub Container Registry:
 
 ```bash
-# Pull the latest image
-docker pull ghcr.io/soulteary/owlmail:latest
+# Pull release 0.5.0
+docker pull ghcr.io/soulteary/owlmail:0.5.0
 
-# Pull a specific version (using commit SHA)
-docker pull ghcr.io/soulteary/owlmail:sha-49b5f35
+# Pull an image for one exact commit (example)
+docker pull ghcr.io/soulteary/owlmail:sha-b130f33
 
 # Run container
 docker run -d \
   -p 1025:1025 \
   -p 1080:1080 \
   --name owlmail \
-  ghcr.io/soulteary/owlmail:latest
+  ghcr.io/soulteary/owlmail:0.5.0
 ```
 
 **Available Tags:**
-- `latest` - Latest stable release
-- `sha-<commit>` - Specific commit SHA (e.g., `sha-49b5f35`)
-- `main` - Latest from main branch
+- `0.5.0` - Exact release tag; `0.5` and `0` move with later releases in those series
+- `sha-<commit>` - Image for a specific short commit SHA (for example, `sha-b130f33`)
+- `main` - Moving image from the latest `main` branch build
+- `latest` - Moving default-branch image; it is not a stable-release selector
 
 **Multi-Architecture Support:**
 The image supports both `linux/amd64` and `linux/arm64` architectures. Docker will automatically pull the correct image for your platform.
@@ -643,9 +644,14 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 📚 Related Documentation
 
+- [OwlMail 0.5.0 Release Notes](./docs/en/Release-0.5.0.md)
+- [Changelog](./CHANGELOG.md)
 - [OwlMail × MailDev: Full Feature & API Comparison and Migration White Paper](./docs/en/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [API Reference](./docs/en/API-Reference.md)
 - [Operations and Troubleshooting](./docs/en/Operations.md)
+- [Webhook Forwarding](./docs/en/Webhook-Forwarding.md)
+- [Runnable Webhook Scenarios](./examples/webhooks/README.md)
+- [Release Process (maintainers)](./docs/en/Releasing.md)
 - [API Refactoring Record (historical)](./docs/en/internal/API_Refactoring_Record.md)
 
 ## 🐛 Issue Reporting

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -122,24 +122,25 @@ export MAILDEV_WEB_PORT=1080
 使用 OwlMail 最简单的方式是从 GitHub Container Registry 拉取预构建的镜像：
 
 ```bash
-# 拉取最新镜像
-docker pull ghcr.io/soulteary/owlmail:latest
+# 拉取 0.5.0 发布镜像
+docker pull ghcr.io/soulteary/owlmail:0.5.0
 
-# 拉取特定版本（使用提交 SHA）
-docker pull ghcr.io/soulteary/owlmail:sha-49b5f35
+# 拉取某个准确提交的镜像（示例）
+docker pull ghcr.io/soulteary/owlmail:sha-b130f33
 
 # 运行容器
 docker run -d \
   -p 1025:1025 \
   -p 1080:1080 \
   --name owlmail \
-  ghcr.io/soulteary/owlmail:latest
+  ghcr.io/soulteary/owlmail:0.5.0
 ```
 
 **可用标签：**
-- `latest` - 最新稳定版本
-- `sha-<commit>` - 特定提交 SHA（例如：`sha-49b5f35`）
-- `main` - main 分支的最新版本
+- `0.5.0` - 准确发布标签；`0.5` 与 `0` 会随对应版本系列的后续发布移动
+- `sha-<commit>` - 指定短提交 SHA 的镜像（例如 `sha-b130f33`）
+- `main` - 随 `main` 分支最新构建移动的镜像
+- `latest` - 随默认分支移动的镜像，不是稳定版本选择器
 
 **多架构支持：**
 镜像支持 `linux/amd64` 和 `linux/arm64` 两种架构。Docker 会自动为您的平台拉取正确的镜像。
@@ -632,9 +633,14 @@ OwlMail/
 
 ## 📚 相关文档
 
+- [OwlMail 0.5.0 发布说明](./docs/zh-CN/Release-0.5.0.md)
+- [变更日志](./CHANGELOG.md)
 - [OwlMail × MailDev：功能与 API 完整对比与迁移白皮书](./docs/zh-CN/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [API 参考](./docs/zh-CN/API-Reference.md)
 - [运维与排障](./docs/zh-CN/Operations.md)
+- [Webhook 消息转发](./docs/zh-CN/Webhook-Forwarding.md)
+- [可运行 Webhook 场景](./examples/webhooks/README.zh-CN.md)
+- [发布流程（维护者）](./docs/zh-CN/Releasing.md)
 - [API 重构记录（历史资料）](./docs/zh-CN/internal/API_Refactoring_Record.md)
 
 ## 🐛 问题反馈

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,8 +24,10 @@ Select your preferred language:
 
 ### Available Documents
 
+- [OwlMail 0.5.0 Release Notes](./en/Release-0.5.0.md)
 - [API Reference](./en/API-Reference.md)
 - [Operations and Troubleshooting](./en/Operations.md)
+- [Release Process](./en/Releasing.md)
 - [OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper](./en/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [API Refactoring Record (historical)](./en/internal/API_Refactoring_Record.md)
 - [Webhook Forwarding](./en/Webhook-Forwarding.md)
@@ -39,8 +41,10 @@ Select your preferred language:
 
 ### 可用文档
 
+- [OwlMail 0.5.0 发布说明](./zh-CN/Release-0.5.0.md)
 - [API 参考](./zh-CN/API-Reference.md)
 - [运维与排障](./zh-CN/Operations.md)
+- [发布流程](./zh-CN/Releasing.md)
 - [OwlMail × MailDev - 功能与 API 完整对比与迁移白皮书](./zh-CN/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [API 重构记录（历史资料）](./zh-CN/internal/API_Refactoring_Record.md)
 - [Webhook 消息转发](./zh-CN/Webhook-Forwarding.md)
@@ -56,7 +60,7 @@ Select your preferred language:
 
 - [OwlMail × MailDev - Vollständiger Funktions- und API-Vergleich sowie Migrations-Whitepaper](./de/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [API-Refactoring-Aufzeichnung](./de/internal/API_Refactoring_Record.md)
-- Gemeinsame Betriebsreferenzen: [API (English)](./en/API-Reference.md), [Operations (English)](./en/Operations.md), [Webhook (English)](./en/Webhook-Forwarding.md)
+- Gemeinsame Referenzen: [0.5.0 Release Notes (English)](./en/Release-0.5.0.md), [API (English)](./en/API-Reference.md), [Operations (English)](./en/Operations.md), [Webhook (English)](./en/Webhook-Forwarding.md)
 
 ---
 
@@ -68,7 +72,7 @@ Select your preferred language:
 
 - [OwlMail × MailDev : Livre blanc complet sur les fonctionnalités, l'API et la migration](./fr/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [Enregistrement de la refactorisation de l'API](./fr/internal/API_Refactoring_Record.md)
-- Références opérationnelles partagées : [API (English)](./en/API-Reference.md), [Operations (English)](./en/Operations.md), [Webhook (English)](./en/Webhook-Forwarding.md)
+- Références partagées : [Notes de version 0.5.0 (English)](./en/Release-0.5.0.md), [API (English)](./en/API-Reference.md), [Operations (English)](./en/Operations.md), [Webhook (English)](./en/Webhook-Forwarding.md)
 
 ---
 
@@ -80,7 +84,7 @@ Select your preferred language:
 
 - [OwlMail × MailDev: Libro bianco completo su funzionalità, API e migrazione](./it/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [Registro della Refactorizzazione dell'API](./it/internal/API_Refactoring_Record.md)
-- Riferimenti operativi condivisi: [API (English)](./en/API-Reference.md), [Operations (English)](./en/Operations.md), [Webhook (English)](./en/Webhook-Forwarding.md)
+- Riferimenti condivisi: [Note di rilascio 0.5.0 (English)](./en/Release-0.5.0.md), [API (English)](./en/API-Reference.md), [Operations (English)](./en/Operations.md), [Webhook (English)](./en/Webhook-Forwarding.md)
 
 ---
 
@@ -92,7 +96,7 @@ Select your preferred language:
 
 - [OwlMail × MailDev: 完全な機能と API の比較および移行ホワイトペーパー](./ja/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [API リファクタリング記録](./ja/internal/API_Refactoring_Record.md)
-- 共通運用リファレンス：[API (English)](./en/API-Reference.md)、[Operations (English)](./en/Operations.md)、[Webhook (English)](./en/Webhook-Forwarding.md)
+- 共通リファレンス：[0.5.0 リリースノート (English)](./en/Release-0.5.0.md)、[API (English)](./en/API-Reference.md)、[Operations (English)](./en/Operations.md)、[Webhook (English)](./en/Webhook-Forwarding.md)
 
 ---
 
@@ -104,7 +108,7 @@ Select your preferred language:
 
 - [OwlMail × MailDev: 전체 기능 및 API 비교 및 마이그레이션 화이트페이퍼](./ko/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [API 리팩토링 기록](./ko/internal/API_Refactoring_Record.md)
-- 공통 운영 참조: [API (English)](./en/API-Reference.md), [Operations (English)](./en/Operations.md), [Webhook (English)](./en/Webhook-Forwarding.md)
+- 공통 참조: [0.5.0 릴리스 노트 (English)](./en/Release-0.5.0.md), [API (English)](./en/API-Reference.md), [Operations (English)](./en/Operations.md), [Webhook (English)](./en/Webhook-Forwarding.md)
 
 ---
 
@@ -126,7 +130,7 @@ docs/
 
 Each language directory contains:
 - `README.md` - Documentation index for that language
-- Translated documents and links to canonical English/Chinese operational guides
+- Translated documents and links to canonical English/Chinese release and operational guides
 - `internal/` subdirectory - Historical implementation records, not the stable API contract
 
 ## 🔄 Contributing

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -29,6 +29,11 @@ in eigenen Verzeichnissen organisiert.
     die Integration mit `soulteary/webhook`.
 - **[Ausführbare Webhook-Beispiele](../../examples/webhooks/README.md)** (English, [中文](../../examples/webhooks/README.zh-CN.md))
 
+### Veröffentlichungen
+
+- **[Versionshinweise 0.5.0](../en/Release-0.5.0.md)** (English, [中文](../zh-CN/Release-0.5.0.md))
+- **[Veröffentlichungsprozess](../en/Releasing.md)** (English, [中文](../zh-CN/Releasing.md))
+
 ### Vergleich und Migration
 
 - **[OwlMail × MailDev – Vergleich und Migrations-Whitepaper](./OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)**

--- a/docs/en/API-Reference.md
+++ b/docs/en/API-Reference.md
@@ -150,6 +150,24 @@ reported in process logs after the HTTP response.
 | `GET /api/v1/version` | build/version information |
 | `GET /api/v1/ws` | native WebSocket endpoint |
 
+A release build returns version provenance similar to:
+
+```json
+{
+  "version": "0.5.0",
+  "commit": "<full Git commit SHA>",
+  "build_date": "<UTC RFC 3339 timestamp>",
+  "branch": "v0.5.0",
+  "go_version": "go1.27.0",
+  "platform": "linux/amd64",
+  "compiler": "gc"
+}
+```
+
+Release binaries and container images inject the first four values during the
+build and smoke-test the version and commit. An ordinary local `go build` uses
+development defaults for values that were not injected.
+
 The outgoing settings body supports `host`, `port`, `user`, `password`,
 `secure`, `autoRelay`, `autoRelayAddr`, `allowRules`, and `denyRules`. `host` is
 required and `port` must be between 1 and 65535. Changes are in memory; they do

--- a/docs/en/Operations.md
+++ b/docs/en/Operations.md
@@ -45,8 +45,11 @@ docker run -d \
   -p 127.0.0.1:1025:1025 \
   -p 127.0.0.1:1080:1080 \
   -v owlmail-data:/app/mail \
-  ghcr.io/soulteary/owlmail:latest
+  ghcr.io/soulteary/owlmail:0.5.0
 ```
+
+This guide pins the `0.5.0` release image. The `main` and `latest` tags move with
+default-branch builds and should not be used for a repeatable deployment.
 
 The image configures OwlMail to listen on `0.0.0.0` inside the container. Bind
 published ports to `127.0.0.1` as shown unless other machines must connect. The
@@ -62,7 +65,7 @@ docker run -d \
   -e OWLMAIL_WEB_USER=admin \
   -e OWLMAIL_WEB_PASSWORD='replace-with-a-secret' \
   -v owlmail-data:/app/mail \
-  ghcr.io/soulteary/owlmail:latest
+  ghcr.io/soulteary/owlmail:0.5.0
 ```
 
 Configure both values for stable automation. A username alone causes OwlMail to
@@ -109,7 +112,7 @@ docker run -d \
   -e OWLMAIL_TLS_ENABLED=true \
   -e OWLMAIL_TLS_CERT=/certs/smtp-cert.pem \
   -e OWLMAIL_TLS_KEY=/certs/smtp-key.pem \
-  ghcr.io/soulteary/owlmail:latest
+  ghcr.io/soulteary/owlmail:0.5.0
 ```
 
 Verify that the container runtime permits the non-root process to bind port 465.

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -20,6 +20,11 @@ Welcome to the OwlMail documentation directory. This directory contains technica
 
 ### Main Documents
 
+- **[OwlMail 0.5.0 Release Notes](./Release-0.5.0.md)**
+  - Highlights, upgrade-sensitive behavior, installation commands, asset names,
+    known limitations, and links to the detailed references.
+  - **Other languages**: [简体中文](../zh-CN/Release-0.5.0.md)
+
 - **[API Reference](./API-Reference.md)**
   - Complete route inventory, request/response conventions, authentication,
     native WebSocket events, curl examples, and the current MailDev migration boundary.
@@ -47,6 +52,13 @@ Welcome to the OwlMail documentation directory. This directory contains technica
     Use the API Reference above as the current contract.
   - **Other languages**: [简体中文](../zh-CN/internal/API_Refactoring_Record.md) | [Deutsch](../de/internal/API_Refactoring_Record.md) | [Français](../fr/internal/API_Refactoring_Record.md) | [Italiano](../it/internal/API_Refactoring_Record.md) | [日本語](../ja/internal/API_Refactoring_Record.md) | [한국어](../ko/internal/API_Refactoring_Record.md)
 
+### Maintainer Documentation
+
+- **[Release Process](./Releasing.md)**
+  - Tagging, binary/checksum and container verification, smoke tests, and the
+    pre/post-release checklist.
+  - **Other languages**: [简体中文](../zh-CN/Releasing.md)
+
 ## 📖 How to Read Documentation
 
 Documents are organized by language in separate directories. Each language directory contains:
@@ -68,6 +80,8 @@ When adding new documentation:
 ## 📝 Document Categories
 
 - **Migration Guides**: Help users migrate from MailDev to OwlMail
+- **Release Notes**: Summarize versioned changes, upgrade behavior, and known limitations
+- **Operations**: Cover deployment, troubleshooting, and the maintainer release process
 - **API Documentation**: Current technical contract and historical refactoring records
 - **Internal Documentation**: Development notes and internal processes
 

--- a/docs/en/Release-0.5.0.md
+++ b/docs/en/Release-0.5.0.md
@@ -1,0 +1,144 @@
+# OwlMail 0.5.0 release notes
+
+OwlMail 0.5.0 expands the server from a local inbox into a more complete
+integration endpoint while retaining its single-binary deployment model. The
+release adds configurable outgoing webhooks, embedded help, opt-in browser
+notifications, explicit webhook capacity controls, and safer partial Web Basic
+Auth behavior.
+
+Commands that reference `v0.5.0` or the `0.5.0` container tag work only after
+the release tag has been published.
+
+## Highlights
+
+### Webhook forwarding
+
+Newly stored messages can be delivered to generic HTTP endpoints. A version 1
+configuration supports 1–32 named targets with:
+
+- case-insensitive wildcard filters for sender, recipient, and subject;
+- default, custom JSON-safe, or plain-text request bodies;
+- values loaded from environment variables;
+- configurable headers, HMAC-SHA256 signatures, timeouts, and retries;
+- multiple independent targets; and
+- a runnable `soulteary/webhook` Compose integration.
+
+Use `-webhook-config` or `OWLMAIL_WEBHOOK_CONFIG` to select the JSON file. The
+process-wide `-webhook-max-concurrency` /
+`OWLMAIL_WEBHOOK_MAX_CONCURRENCY` setting defaults to `8`; set it to `0` only
+when unlimited delivery is intentional.
+
+### Embedded operator help
+
+The inbox now links to a bilingual local guide at `/help`. The HTML, CSS, and
+JavaScript are embedded in the executable, so binary and container deployments
+do not need a separate `web` directory.
+
+### Browser notifications
+
+Notifications remain off by default and require an explicit click in each
+browser. They apply only to new messages received through the live WebSocket,
+require HTTPS or a trusted local origin, and never include the message body.
+
+### Web authentication defaults
+
+Partial Web Basic Auth configuration no longer disables authentication:
+
+| Configured values | Effective behavior |
+|---|---|
+| neither | authentication disabled |
+| username only | keep the username, generate a random 32-character password, and print it once to stderr |
+| password only | use username `admin` and the configured password |
+| both | use both configured values unchanged |
+
+Authenticated requests carrying a browser `Origin` header must come from
+OwlMail's own origin. Basic Auth should still be used only on localhost or over
+HTTPS.
+
+## Behavior to review before upgrading
+
+| Area | 0.5.0 behavior | Operator action |
+|---|---|---|
+| Webhook saturation | A finite limit applies backpressure before handler goroutines start and can delay SMTP `DATA` completion | Start with `8`; size timeouts, retries, and concurrency together |
+| Webhook shutdown | In-flight delivery is not drained before process exit | Stop new SMTP traffic and allow the longest retry window before termination |
+| Web credentials | One configured value now produces usable credentials instead of silently disabling auth | Read generated credentials from stderr or configure both values explicitly |
+| Browser notifications | Permission and preference are browser-local | Enable per browser under HTTPS or localhost |
+| MailDev clients | OwlMail keeps MailDev-style workflow routes but does not implement the current MailDev API or Socket.IO protocol exactly | Validate paths, payloads, read side effects, and WebSocket clients |
+
+Back up the complete mail directory before changing versions. Test an important
+archive against a copy first.
+
+## Installation after publication
+
+### Release binaries
+
+The release workflow publishes five executables and `checksums.txt`:
+
+| Platform | Asset |
+|---|---|
+| Linux amd64 | `owlmail-linux-amd64` |
+| Linux arm64 | `owlmail-linux-arm64` |
+| macOS amd64 | `owlmail-darwin-amd64` |
+| macOS arm64 | `owlmail-darwin-arm64` |
+| Windows amd64 | `owlmail-windows-amd64.exe` |
+
+Linux amd64 example:
+
+```bash
+curl -fLO https://github.com/soulteary/owlmail/releases/download/v0.5.0/owlmail-linux-amd64
+curl -fLO https://github.com/soulteary/owlmail/releases/download/v0.5.0/checksums.txt
+grep ' owlmail-linux-amd64$' checksums.txt | sha256sum -c -
+chmod +x owlmail-linux-amd64
+./owlmail-linux-amd64
+```
+
+### Go install
+
+Source installation requires Go 1.27.0 or newer:
+
+```bash
+go install github.com/soulteary/owlmail/cmd/owlmail@v0.5.0
+```
+
+Downloaded release binaries do not require Go or Node.js at runtime.
+
+Release binaries and images embed `version`, `commit`, `build_date`, and the
+source tag. Inspect them through `GET /api/v1/version`; the release workflow
+smoke-tests the embedded version and commit before uploading assets.
+
+### Container image
+
+Use the release tag for a release deployment:
+
+```bash
+docker pull ghcr.io/soulteary/owlmail:0.5.0
+docker run -d \
+  --name owlmail \
+  -p 127.0.0.1:1025:1025 \
+  -p 127.0.0.1:1080:1080 \
+  ghcr.io/soulteary/owlmail:0.5.0
+```
+
+The `main` and `latest` tags move whenever the default branch is built; they are
+not stable-release selectors. `0.5.0` selects this release, while
+`sha-<short-commit>` selects one repository commit.
+
+## Known limitations
+
+- Incoming SMTP username/password settings are present but unauthenticated
+  senders are not rejected. Keep the SMTP listener on a trusted network.
+- Webhook forwarding is an integration notification mechanism, not a durable
+  queue. Receivers should be idempotent.
+- Health endpoints remain public when Web Basic Auth is enabled so probes can
+  run without credentials.
+- The compiled SMTP defaults are 1 MiB per message, 50 recipients, and
+  10-second read/write timeouts.
+
+## Documentation
+
+- [Webhook forwarding reference](./Webhook-Forwarding.md)
+- [Webhook scenarios](../../examples/webhooks/README.md)
+- [API reference](./API-Reference.md)
+- [Operations and troubleshooting](./Operations.md)
+- [MailDev comparison and migration guide](./OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
+- [Full changelog](../../CHANGELOG.md)

--- a/docs/en/Releasing.md
+++ b/docs/en/Releasing.md
@@ -1,0 +1,107 @@
+# Release process
+
+This guide is for OwlMail maintainers. A release is identified by a signed or
+annotated semantic-version tag such as `v0.5.0`. GitHub release binaries and
+container images must be built from that same tag.
+
+## Sources of truth
+
+- `CHANGELOG.md` records user-visible changes.
+- `docs/en/Release-X.Y.Z.md` is the curated English release body.
+- `docs/zh-CN/Release-X.Y.Z.md` is the corresponding Chinese release note.
+- `.github/workflows/release.yml` builds binaries and checksums.
+- `.github/workflows/docker.yml` publishes multi-architecture images.
+
+The release workflow prepends the curated English note to GitHub's generated
+change list. It refuses manual runs for a missing tag or missing release-note
+file.
+
+## Pre-release checklist
+
+- [ ] All feature, fix, dependency, report-card, and release-documentation PRs are merged.
+- [ ] `CHANGELOG.md` and both language release notes describe the final diff from the previous tag.
+- [ ] No release note contains unresolved placeholders or unsupported compatibility claims.
+- [ ] Required checks on the exact `main` commit are green.
+- [ ] `go test -race ./...`, `go vet ./...`, `go mod verify`, browser tests, and documentation tests pass.
+- [ ] `govulncheck ./...` reports no reachable vulnerability, or every exception is documented.
+- [ ] A multi-architecture Docker build succeeds.
+- [ ] The complete mail directory has been backed up for any upgrade smoke test using persistent data.
+
+For 0.5.0, also confirm the Go 1.27 dependency upgrade and repository-local Go
+Report Card changes are merged before tagging.
+
+## Create the release tag
+
+Update local `main`, record the exact commit, then create one annotated tag:
+
+```bash
+git switch main
+git pull --ff-only
+git status --short
+git rev-parse HEAD
+git tag -a v0.5.0 -m "OwlMail v0.5.0"
+git push origin v0.5.0
+```
+
+Do not move or reuse a published release tag. If a release needs a correction,
+make a new patch version.
+
+The tag push starts both release workflows. A manual run of the binary release
+workflow is only a retry mechanism: provide an existing tag, and the workflow
+checks out that tag before building.
+
+## Verify published artifacts
+
+The GitHub release must contain these six uploaded assets for 0.5.0 (in addition
+to GitHub's automatic source archives):
+
+- `checksums.txt`
+- `owlmail-linux-amd64`
+- `owlmail-linux-arm64`
+- `owlmail-darwin-amd64`
+- `owlmail-darwin-arm64`
+- `owlmail-windows-amd64.exe`
+
+Download all files into an empty directory and verify them:
+
+```bash
+sha256sum -c checksums.txt
+```
+
+Smoke-test at least one binary:
+
+```bash
+chmod +x owlmail-linux-amd64
+./owlmail-linux-amd64 -smtp 11025 -web 11080
+curl --fail http://localhost:11080/healthz
+curl --fail http://localhost:11080/api/v1/version
+```
+
+Stop the smoke-test process after both endpoints and one SMTP receipt succeed.
+
+## Verify container publication
+
+For `v0.5.0`, verify the `0.5.0`, `0.5`, `0`, and commit-SHA tags and both target
+architectures. `main` and `latest` are moving default-branch tags and must not be
+used to prove release reproducibility.
+
+```bash
+docker buildx imagetools inspect ghcr.io/soulteary/owlmail:0.5.0
+docker run --rm \
+  -p 127.0.0.1:11025:1025 \
+  -p 127.0.0.1:11080:1080 \
+  ghcr.io/soulteary/owlmail:0.5.0
+```
+
+Confirm the manifest lists `linux/amd64` and `linux/arm64`, then repeat the
+health, version, and SMTP smoke tests against the container.
+
+## Post-release checklist
+
+- [ ] GitHub marks `v0.5.0` as the latest non-prerelease release.
+- [ ] The curated note appears before the generated pull-request list.
+- [ ] Every binary and `checksums.txt` is downloadable and verified.
+- [ ] Container version and commit tags resolve to the expected manifest.
+- [ ] Go installation with `@v0.5.0` succeeds on the documented Go version.
+- [ ] README and release-note installation commands resolve.
+- [ ] Any release failure or known limitation is added to the release body and changelog.

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -29,6 +29,11 @@ langue dans des répertoires distincts.
     intégration avec `soulteary/webhook`.
 - **[Exemples Webhook exécutables](../../examples/webhooks/README.md)** (English, [中文](../../examples/webhooks/README.zh-CN.md))
 
+### Versions
+
+- **[Notes de version 0.5.0](../en/Release-0.5.0.md)** (English, [中文](../zh-CN/Release-0.5.0.md))
+- **[Processus de publication](../en/Releasing.md)** (English, [中文](../zh-CN/Releasing.md))
+
 ### Comparaison et migration
 
 - **[OwlMail × MailDev – Comparaison et guide de migration](./OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)**

--- a/docs/it/README.md
+++ b/docs/it/README.md
@@ -29,6 +29,11 @@ lingua in directory separate.
     con `soulteary/webhook`.
 - **[Esempi Webhook eseguibili](../../examples/webhooks/README.md)** (English, [中文](../../examples/webhooks/README.zh-CN.md))
 
+### Release
+
+- **[Note di rilascio 0.5.0](../en/Release-0.5.0.md)** (English, [中文](../zh-CN/Release-0.5.0.md))
+- **[Processo di rilascio](../en/Releasing.md)** (English, [中文](../zh-CN/Releasing.md))
+
 ### Confronto e migrazione
 
 - **[OwlMail × MailDev – Confronto e guida alla migrazione](./OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)**

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -26,6 +26,11 @@ OwlMail のドキュメントへようこそ。文書は言語別のディレク
   - フィルター、カスタムペイロード、HMAC 署名、再試行、`soulteary/webhook` 連携。
 - **[実行可能な Webhook 例](../../examples/webhooks/README.md)** (English、[中文](../../examples/webhooks/README.zh-CN.md))
 
+### リリース
+
+- **[0.5.0 リリースノート](../en/Release-0.5.0.md)** (English、[中文](../zh-CN/Release-0.5.0.md))
+- **[リリース手順](../en/Releasing.md)** (English、[中文](../zh-CN/Releasing.md))
+
 ### 比較と移行
 
 - **[OwlMail × MailDev – 比較・移行ガイド](./OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)**

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -26,6 +26,11 @@ OwlMail 문서에 오신 것을 환영합니다. 문서는 언어별 디렉터�
   - 필터, 사용자 지정 페이로드, HMAC 서명, 재시도 및 `soulteary/webhook` 연동.
 - **[실행 가능한 Webhook 예제](../../examples/webhooks/README.md)** (English, [中文](../../examples/webhooks/README.zh-CN.md))
 
+### 릴리스
+
+- **[0.5.0 릴리스 노트](../en/Release-0.5.0.md)** (English, [中文](../zh-CN/Release-0.5.0.md))
+- **[릴리스 절차](../en/Releasing.md)** (English, [中文](../zh-CN/Releasing.md))
+
 ### 비교 및 마이그레이션
 
 - **[OwlMail × MailDev – 비교 및 마이그레이션 가이드](./OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)**

--- a/docs/zh-CN/API-Reference.md
+++ b/docs/zh-CN/API-Reference.md
@@ -143,6 +143,23 @@ curl -u admin:secret http://localhost:1080/api/v1/emails
 | `GET /api/v1/version` | 构建/版本信息 |
 | `GET /api/v1/ws` | 原生 WebSocket 端点 |
 
+发布构建会返回类似以下的版本来源信息：
+
+```json
+{
+  "version": "0.5.0",
+  "commit": "<完整 Git 提交 SHA>",
+  "build_date": "<UTC RFC 3339 时间>",
+  "branch": "v0.5.0",
+  "go_version": "go1.27.0",
+  "platform": "linux/amd64",
+  "compiler": "gc"
+}
+```
+
+发布二进制与容器镜像会在构建时注入前四项，并冒烟验证版本与提交。普通本地
+`go build` 对未注入字段使用开发默认值。
+
 出站设置请求体支持 `host`、`port`、`user`、`password`、`secure`、
 `autoRelay`、`autoRelayAddr`、`allowRules`、`denyRules`。`host` 必填，`port`
 必须在 1 到 65535 之间。API 修改仅保存在内存，不会改写进程参数或环境变量。

--- a/docs/zh-CN/Operations.md
+++ b/docs/zh-CN/Operations.md
@@ -41,8 +41,11 @@ docker run -d \
   -p 127.0.0.1:1025:1025 \
   -p 127.0.0.1:1080:1080 \
   -v owlmail-data:/app/mail \
-  ghcr.io/soulteary/owlmail:latest
+  ghcr.io/soulteary/owlmail:0.5.0
 ```
+
+本文固定使用 `0.5.0` 发布镜像。`main` 与 `latest` 会随默认分支构建移动，不应用于
+可复现部署。
 
 镜像内部默认绑定 `0.0.0.0`。除非其他机器必须访问，否则应像示例一样把宿主机
 端口限制到 `127.0.0.1`。Dockerfile 使用非 root 用户，邮件目录为 `/app/mail`。
@@ -57,7 +60,7 @@ docker run -d \
   -e OWLMAIL_WEB_USER=admin \
   -e OWLMAIL_WEB_PASSWORD='replace-with-a-secret' \
   -v owlmail-data:/app/mail \
-  ghcr.io/soulteary/owlmail:latest
+  ghcr.io/soulteary/owlmail:0.5.0
 ```
 
 自动化场景应同时配置用户名和密码。只配置用户名时，每次启动会生成新密码并只在
@@ -101,7 +104,7 @@ docker run -d \
   -e OWLMAIL_TLS_ENABLED=true \
   -e OWLMAIL_TLS_CERT=/certs/smtp-cert.pem \
   -e OWLMAIL_TLS_KEY=/certs/smtp-key.pem \
-  ghcr.io/soulteary/owlmail:latest
+  ghcr.io/soulteary/owlmail:0.5.0
 ```
 
 确认容器运行时允许非 root 进程绑定 465；如不允许，应按运行时安全策略只授予所需

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -20,6 +20,10 @@
 
 ### 主要文档
 
+- **[OwlMail 0.5.0 发布说明](./Release-0.5.0.md)**
+  - 版本亮点、升级敏感行为、安装命令、发布文件、已知限制和详细参考链接。
+  - **其他语言**：[English](../en/Release-0.5.0.md)
+
 - **[API 参考](./API-Reference.md)**
   - 完整路由清单、请求与响应约定、鉴权、原生 WebSocket 事件、curl 示例，以及
     当前 MailDev 迁移边界。
@@ -45,6 +49,12 @@
   - 记录无版本路由迁移到 `/api/v1/` 的历史实现过程；当前契约以 API 参考为准。
   - **其他语言**: [English](../en/internal/API_Refactoring_Record.md) | [Deutsch](../de/internal/API_Refactoring_Record.md) | [Français](../fr/internal/API_Refactoring_Record.md) | [Italiano](../it/internal/API_Refactoring_Record.md) | [日本語](../ja/internal/API_Refactoring_Record.md) | [한국어](../ko/internal/API_Refactoring_Record.md)
 
+### 维护者文档
+
+- **[发布流程](./Releasing.md)**
+  - 标签、二进制/校验和与容器验证、冒烟测试，以及发布前后检查清单。
+  - **其他语言**：[English](../en/Releasing.md)
+
 ## 📖 如何阅读文档
 
 文档按语言组织在不同的目录中。每个语言目录包含：
@@ -66,6 +76,8 @@
 ## 📝 文档分类
 
 - **迁移指南**：帮助用户从 MailDev 迁移到 OwlMail
+- **发布说明**：汇总版本改动、升级行为和已知限制
+- **运维文档**：覆盖部署、故障定位和维护者发布流程
 - **API 文档**：当前技术契约与历史重构记录
 - **内部文档**：开发笔记和内部流程
 

--- a/docs/zh-CN/Release-0.5.0.md
+++ b/docs/zh-CN/Release-0.5.0.md
@@ -1,0 +1,130 @@
+# OwlMail 0.5.0 发布说明
+
+OwlMail 0.5.0 在保持单一二进制部署方式的同时，把本地收件箱扩展为更完整的
+集成端点。本版本新增可配置 Webhook 转发、内置帮助、按需浏览器通知、明确的
+Webhook 容量控制，并改进了 Web Basic Auth 只配置一项凭据时的行为。
+
+只有在发布 `v0.5.0` 标签后，引用 `v0.5.0` 或容器标签 `0.5.0` 的命令才会生效。
+
+## 主要更新
+
+### Webhook 消息转发
+
+新存储的邮件可发送到通用 HTTP 端点。版本 1 配置支持 1～32 个具名目标，包括：
+
+- 针对发件人、收件人和主题的不区分大小写通配符过滤；
+- 默认载荷、自定义 JSON 安全模板或纯文本请求体；
+- 从环境变量加载值；
+- 自定义请求头、HMAC-SHA256 签名、超时与重试；
+- 多个相互独立的目标；
+- 可直接运行的 `soulteary/webhook` Compose 联动示例。
+
+使用 `-webhook-config` 或 `OWLMAIL_WEBHOOK_CONFIG` 指定 JSON 文件。进程级
+`-webhook-max-concurrency` / `OWLMAIL_WEBHOOK_MAX_CONCURRENCY` 默认值为 `8`；
+只有明确需要无限投递并发时才设置为 `0`。
+
+### 内置运维帮助
+
+收件箱新增入口，可打开 `/help` 的中英文本地指南。HTML、CSS 与 JavaScript
+均嵌入可执行文件，二进制和容器部署无需额外携带 `web` 目录。
+
+### 浏览器通知
+
+通知默认关闭，每个浏览器都必须由用户点击开启。只有通过实时 WebSocket 到达的
+新邮件会触发通知；功能要求 HTTPS 或可信本地来源，且通知不会包含邮件正文。
+
+### Web 鉴权默认策略
+
+Web Basic Auth 只配置一项时不再静默关闭鉴权：
+
+| 已配置内容 | 最终行为 |
+|---|---|
+| 两项均未配置 | 关闭鉴权 |
+| 只配置用户名 | 保留用户名，生成 32 字符随机密码，并在 stderr 输出一次 |
+| 只配置密码 | 使用用户名 `admin` 和已配置密码 |
+| 两项均配置 | 原样使用两项配置 |
+
+带浏览器 `Origin` 请求头的已鉴权请求必须来自 OwlMail 自身源。Basic Auth 仍只应
+用于 localhost 或 HTTPS。
+
+## 升级前需要确认的行为
+
+| 范围 | 0.5.0 行为 | 运维建议 |
+|---|---|---|
+| Webhook 饱和 | 有限并发会在创建处理 goroutine 前施加背压，可能延迟 SMTP `DATA` 完成 | 从 `8` 开始，并一起评估超时、重试和并发 |
+| Webhook 关闭 | 进程退出前不会排空正在进行的投递 | 先停止新 SMTP 流量，再等待最长重试窗口 |
+| Web 凭据 | 只配置一项会生成可用凭据，不再静默关闭鉴权 | 从 stderr 读取临时凭据，或明确配置两项 |
+| 浏览器通知 | 权限与偏好保存在单个浏览器 | 在 HTTPS 或 localhost 下逐个浏览器开启 |
+| MailDev 客户端 | 保留 MailDev 风格工作流路由，但不完全实现当前 MailDev API 或 Socket.IO 协议 | 验证路径、载荷、已读副作用和 WebSocket 客户端 |
+
+更换版本前应备份完整邮件目录；重要归档应先使用副本验证。
+
+## 发布后的安装方式
+
+### 发布二进制
+
+发布工作流会上传 5 个可执行文件与 `checksums.txt`：
+
+| 平台 | 文件 |
+|---|---|
+| Linux amd64 | `owlmail-linux-amd64` |
+| Linux arm64 | `owlmail-linux-arm64` |
+| macOS amd64 | `owlmail-darwin-amd64` |
+| macOS arm64 | `owlmail-darwin-arm64` |
+| Windows amd64 | `owlmail-windows-amd64.exe` |
+
+Linux amd64 示例：
+
+```bash
+curl -fLO https://github.com/soulteary/owlmail/releases/download/v0.5.0/owlmail-linux-amd64
+curl -fLO https://github.com/soulteary/owlmail/releases/download/v0.5.0/checksums.txt
+grep ' owlmail-linux-amd64$' checksums.txt | sha256sum -c -
+chmod +x owlmail-linux-amd64
+./owlmail-linux-amd64
+```
+
+### Go 安装
+
+从源码安装需要 Go 1.27.0 或更高版本：
+
+```bash
+go install github.com/soulteary/owlmail/cmd/owlmail@v0.5.0
+```
+
+下载的发布二进制在运行时不需要 Go 或 Node.js。
+
+发布二进制与镜像会嵌入 `version`、`commit`、`build_date` 和来源标签，可通过
+`GET /api/v1/version` 检查；发布工作流会在上传文件前冒烟验证版本与提交。
+
+### 容器镜像
+
+发布部署应使用对应版本标签：
+
+```bash
+docker pull ghcr.io/soulteary/owlmail:0.5.0
+docker run -d \
+  --name owlmail \
+  -p 127.0.0.1:1025:1025 \
+  -p 127.0.0.1:1080:1080 \
+  ghcr.io/soulteary/owlmail:0.5.0
+```
+
+`main` 与 `latest` 会随默认分支构建而移动，不是稳定版本选择器。`0.5.0` 指向本次
+发布，`sha-<short-commit>` 指向一个仓库提交。
+
+## 已知限制
+
+- 入站 SMTP 用户名/密码设置已经存在，但不会拒绝未认证发送方；请将 SMTP
+  监听器限制在可信网络。
+- Webhook 转发是集成通知机制，不是持久消息队列；接收器应实现幂等。
+- 启用 Web Basic Auth 后，健康检查端点仍保持公开，便于无凭据探针使用。
+- SMTP 编译默认值为：单封邮件 1 MiB、最多 50 个收件人、读写超时 10 秒。
+
+## 相关文档
+
+- [Webhook 消息转发参考](./Webhook-Forwarding.md)
+- [Webhook 场景示例](../../examples/webhooks/README.zh-CN.md)
+- [API 参考](./API-Reference.md)
+- [运维与排障](./Operations.md)
+- [MailDev 对比与迁移指南](./OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
+- [完整变更日志](../../CHANGELOG.md)

--- a/docs/zh-CN/Releasing.md
+++ b/docs/zh-CN/Releasing.md
@@ -1,0 +1,101 @@
+# 发布流程
+
+本文面向 OwlMail 维护者。每个发布版本由签名或附注的语义化版本标签标识，例如
+`v0.5.0`。GitHub Release 二进制与容器镜像必须从同一个标签构建。
+
+## 事实来源
+
+- `CHANGELOG.md` 记录用户可感知的改动。
+- `docs/en/Release-X.Y.Z.md` 是 GitHub Release 使用的英文发布正文。
+- `docs/zh-CN/Release-X.Y.Z.md` 是对应的中文发布说明。
+- `.github/workflows/release.yml` 构建二进制与校验和。
+- `.github/workflows/docker.yml` 发布多架构镜像。
+
+发布工作流会把英文策划版说明放在 GitHub 自动生成的变更列表之前。手动运行时，
+如果版本标签或对应发布说明文件不存在，工作流会失败。
+
+## 发布前检查
+
+- [ ] 功能、修复、依赖、Go Report Card 与发布文档 PR 均已合并。
+- [ ] `CHANGELOG.md` 及中英文发布说明覆盖从上一个标签开始的最终差异。
+- [ ] 发布说明中没有未处理占位符或未经验证的兼容性承诺。
+- [ ] 精确 `main` 提交上的必要检查均通过。
+- [ ] `go test -race ./...`、`go vet ./...`、`go mod verify`、浏览器与文档测试通过。
+- [ ] `govulncheck ./...` 没有可达漏洞，或每个例外都已记录。
+- [ ] 多架构 Docker 构建成功。
+- [ ] 使用持久数据进行升级冒烟测试前，已备份完整邮件目录。
+
+对于 0.5.0，还需要确认 Go 1.27 依赖升级与仓库本地 Go Report Card 改动已在
+打标签前合并。
+
+## 创建发布标签
+
+更新本地 `main`，记录准确提交，然后创建一个附注标签：
+
+```bash
+git switch main
+git pull --ff-only
+git status --short
+git rev-parse HEAD
+git tag -a v0.5.0 -m "OwlMail v0.5.0"
+git push origin v0.5.0
+```
+
+不要移动或复用已经发布的标签。如需修正，应创建新的补丁版本。
+
+推送标签会启动二进制与容器发布工作流。手动运行二进制发布工作流只用于重试：
+必须提供已存在标签，工作流会先检出该标签再构建。
+
+## 验证发布文件
+
+除 GitHub 自动生成的源码归档外，0.5.0 的 GitHub Release 应包含以下 6 个上传文件：
+
+- `checksums.txt`
+- `owlmail-linux-amd64`
+- `owlmail-linux-arm64`
+- `owlmail-darwin-amd64`
+- `owlmail-darwin-arm64`
+- `owlmail-windows-amd64.exe`
+
+将全部文件下载到空目录并校验：
+
+```bash
+sha256sum -c checksums.txt
+```
+
+至少冒烟测试一个二进制：
+
+```bash
+chmod +x owlmail-linux-amd64
+./owlmail-linux-amd64 -smtp 11025 -web 11080
+curl --fail http://localhost:11080/healthz
+curl --fail http://localhost:11080/api/v1/version
+```
+
+两个端点及一次 SMTP 收件均成功后，停止冒烟测试进程。
+
+## 验证容器发布
+
+对于 `v0.5.0`，检查 `0.5.0`、`0.5`、`0` 与提交 SHA 标签，以及两个目标架构。
+`main` 和 `latest` 是随默认分支移动的标签，不能用于证明发布可复现性。
+
+```bash
+docker buildx imagetools inspect ghcr.io/soulteary/owlmail:0.5.0
+docker run --rm \
+  -p 127.0.0.1:11025:1025 \
+  -p 127.0.0.1:11080:1080 \
+  ghcr.io/soulteary/owlmail:0.5.0
+```
+
+确认清单包含 `linux/amd64` 与 `linux/arm64`，再对容器重复健康、版本和 SMTP
+冒烟测试。
+
+## 发布后检查
+
+- [ ] GitHub 将 `v0.5.0` 标记为最新非预发布版本。
+- [ ] 策划版说明显示在自动生成的 PR 列表之前。
+- [ ] 所有二进制与 `checksums.txt` 均可下载并通过校验。
+- [ ] 容器版本标签和提交标签指向预期清单。
+- [ ] 使用文档要求的 Go 版本执行 `@v0.5.0` 安装成功。
+- [ ] README 与发布说明中的安装命令均可解析。
+- [ ] 所有发布失败或已知限制均已补充到发布正文与变更日志。

--- a/tests/docs/markdown.test.js
+++ b/tests/docs/markdown.test.js
@@ -292,3 +292,75 @@ test("English and Chinese API references cover every registered API route", () =
     assert.deepEqual(missing, [], `${reference} is missing API routes`);
   }
 });
+
+test("0.5.0 release documentation and workflow stay connected", () => {
+  const changelog = fs.readFileSync(path.join(root, "CHANGELOG.md"), "utf8");
+  for (const marker of ["## [0.5.0]", "outgoing webhook delivery", "Go 1.27.0", "[0.5.0]:"]) {
+    assert.ok(changelog.includes(marker), `CHANGELOG.md is missing ${marker}`);
+  }
+
+  const releaseNotes = [
+    [
+      "docs/en/Release-0.5.0.md",
+      ["Webhook forwarding", "Browser notifications", "Known limitations", "owlmail-linux-amd64"],
+    ],
+    [
+      "docs/zh-CN/Release-0.5.0.md",
+      ["Webhook 消息转发", "浏览器通知", "已知限制", "owlmail-linux-amd64"],
+    ],
+  ];
+  for (const [releaseNote, markers] of releaseNotes) {
+    const markdown = fs.readFileSync(path.join(root, releaseNote), "utf8");
+    for (const marker of markers) {
+      assert.ok(markdown.includes(marker), `${releaseNote} is missing ${marker}`);
+    }
+  }
+
+  for (const readme of translatedReadmes) {
+    const markdown = fs.readFileSync(path.join(root, readme), "utf8");
+    assert.ok(markdown.includes("ghcr.io/soulteary/owlmail:0.5.0"), `${readme} does not pin the release image`);
+    assert.ok(markdown.includes("Release-0.5.0.md"), `${readme} does not link the release notes`);
+  }
+
+  for (const operations of ["docs/en/Operations.md", "docs/zh-CN/Operations.md"]) {
+    const markdown = fs.readFileSync(path.join(root, operations), "utf8");
+    assert.ok(markdown.includes("ghcr.io/soulteary/owlmail:0.5.0"), `${operations} does not pin 0.5.0`);
+    assert.ok(!markdown.includes("ghcr.io/soulteary/owlmail:latest"), `${operations} uses a moving image`);
+  }
+
+  for (const reference of ["docs/en/API-Reference.md", "docs/zh-CN/API-Reference.md"]) {
+    const markdown = fs.readFileSync(path.join(root, reference), "utf8");
+    for (const field of ["version", "commit", "build_date", "branch", "go_version", "platform", "compiler"]) {
+      assert.ok(markdown.includes(`"${field}"`), `${reference} is missing version field ${field}`);
+    }
+  }
+
+  const workflow = fs.readFileSync(path.join(root, ".github/workflows/release.yml"), "utf8");
+  for (const marker of [
+    "git rev-parse --verify",
+    "git checkout --detach",
+    'NOTES="docs/en/Release-${VERSION#v}.md"',
+    "github.com/soulteary/version-kit/v2.Version",
+    "Verify embedded release metadata",
+    "body_path: ${{ steps.release.outputs.notes }}",
+    "fail_on_unmatched_files: true",
+  ]) {
+    assert.ok(workflow.includes(marker), `.github/workflows/release.yml is missing ${marker}`);
+  }
+
+  const dockerfile = fs.readFileSync(path.join(root, "Dockerfile"), "utf8");
+  for (const marker of ["ARG VERSION=dev", "version-kit/v2.Version=${VERSION}", "version-kit/v2.Commit=${COMMIT}"]) {
+    assert.ok(dockerfile.includes(marker), `Dockerfile is missing release metadata marker ${marker}`);
+  }
+
+  const dockerWorkflow = fs.readFileSync(path.join(root, ".github/workflows/docker.yml"), "utf8");
+  for (const marker of [
+    "build-args:",
+    "VERSION=${{ steps.meta.outputs.version }}",
+    "COMMIT=${{ github.sha }}",
+    "BUILD_DATE=${{ steps.build-meta.outputs.build-date }}",
+    "BRANCH=${{ github.ref_name }}",
+  ]) {
+    assert.ok(dockerWorkflow.includes(marker), `.github/workflows/docker.yml is missing ${marker}`);
+  }
+});


### PR DESCRIPTION
## Summary

- add a source-checked changelog plus English and Chinese 0.5.0 release notes
- add a bilingual maintainer release process with preflight, artifact, container, smoke-test, and post-release checklists
- update all documentation indexes and localized READMEs
- correct the container tag contract: `0.5.0` is the release image, while `main` and `latest` are moving default-branch images
- pin operations examples to `0.5.0` and document release assets, installation, upgrade behavior, and known limitations

## Release safety

- require a valid, existing semantic-version tag for tag and manual release runs
- check out that exact tag before building
- require `docs/en/Release-X.Y.Z.md` and prepend it to generated GitHub notes
- inject version, commit, build timestamp, and source tag into every release binary and container image
- start the Linux release binary and verify `/healthz`, embedded version, and embedded commit before upload
- fail when an expected release artifact is missing
- add a documentation contract test that keeps release notes, workflows, Docker metadata, and version API docs connected

## Merge and tag order

This PR intentionally remains independent, but the final 0.5.0 tag must be created only after:

1. #25 (Go 1.27.0 and dependency refresh) is merged
2. #26 (repository-local Go Report Card) is merged
3. this PR is merged and the resulting `main` checks are green

Do not create or move `v0.5.0` from an intermediate commit.

## Verification

- Go 1.26.6 current-main toolchain: `go test -race ./...`, `go vet ./...`, and `go mod verify`
- all five release targets cross-compiled with injected 0.5.0 metadata
- Linux release binary smoke-tested; version endpoint returned the expected version and commit
- `govulncheck ./...`: zero reachable vulnerabilities (one required-module advisory is not called)
- all 10 browser/documentation tests and browser syntax checks
- ActionLint and workflow YAML parsing
- Markdown local-link, API-route, configuration-contract, formatting, and whitespace checks

A local Docker daemon is unavailable, so the repository's Docker PR workflow is the final Dockerfile/buildx validation.