### PR TITLE
feat(web): add webhook configuration builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to OwlMail are documented in this file. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- An embedded English/Chinese Webhook Configurator at `/webhooks` for building,
+  importing, validating, copying, and downloading version 1 forwarding rules.
+  Configuration is processed locally in the browser and is not activated until
+  the downloaded file is mounted and OwlMail is restarted.
+
 ## [0.5.0]
 
 ### Added

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -100,6 +100,8 @@ func (api *API) setupRoutes() {
 	app.Get("/app.js", serveWebAsset("app.js", "text/javascript; charset=utf-8"))
 	app.Get("/help.css", serveWebAsset("help.css", "text/css; charset=utf-8"))
 	app.Get("/help.js", serveWebAsset("help.js", "text/javascript; charset=utf-8"))
+	app.Get("/webhooks.css", serveWebAsset("webhooks.css", "text/css; charset=utf-8"))
+	app.Get("/webhooks.js", serveWebAsset("webhooks.js", "text/javascript; charset=utf-8"))
 
 	// ============================================================================
 	// MailDev-compatible API routes (maintains backward compatibility)
@@ -115,6 +117,8 @@ func (api *API) setupRoutes() {
 	app.Get("/", serveWebAsset("index.html", "text/html; charset=utf-8"))
 	app.Get("/help", serveWebAsset("help.html", "text/html; charset=utf-8"))
 	app.Get("/help/", serveWebAsset("help.html", "text/html; charset=utf-8"))
+	app.Get("/webhooks", serveWebAsset("webhooks.html", "text/html; charset=utf-8"))
+	app.Get("/webhooks/", serveWebAsset("webhooks.html", "text/html; charset=utf-8"))
 
 	// Serve index.html for all non-API routes (NoRoute equivalent)
 	app.All("*", func(c fiber.Ctx) error {
@@ -127,7 +131,8 @@ func (api *API) setupRoutes() {
 			strings.HasPrefix(path, "/style.css") ||
 			strings.HasPrefix(path, "/app.js") ||
 			strings.HasPrefix(path, "/help.css") ||
-			strings.HasPrefix(path, "/help.js") {
+			strings.HasPrefix(path, "/help.js") ||
+			strings.HasPrefix(path, "/webhooks") {
 			return c.Next()
 		}
 		return serveWebAsset("index.html", "text/html; charset=utf-8")(c)

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -189,7 +189,7 @@ func TestAPISetupRoutes(t *testing.T) {
 		t.Errorf("API route should work, got status %d", resp3.StatusCode)
 	}
 
-	testCases := []string{"/email", "/config", "/healthz", "/socket.io", "/api/", "/style.css", "/app.js"}
+	testCases := []string{"/email", "/config", "/healthz", "/socket.io", "/api/", "/style.css", "/app.js", "/webhooks", "/webhooks.css", "/webhooks.js"}
 	for _, path := range testCases {
 		req, _ := http.NewRequest("GET", path, nil)
 		_, _ = api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
@@ -221,6 +221,10 @@ func TestEmbeddedWebAssets(t *testing.T) {
 		{path: "/app.js", contentType: "text/javascript", contains: "connectWebSocket"},
 		{path: "/help.css", contentType: "text/css", contains: ".help-shell"},
 		{path: "/help.js", contentType: "text/javascript", contains: "applyLanguage"},
+		{path: "/webhooks", contentType: "text/html", contains: "Webhook Configurator"},
+		{path: "/webhooks/", contentType: "text/html", contains: "生成 Webhook 配置"},
+		{path: "/webhooks.css", contentType: "text/css", contains: ".webhook-workspace"},
+		{path: "/webhooks.js", contentType: "text/javascript", contains: "parseConfigText"},
 	}
 
 	for _, tt := range tests {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -222,7 +222,7 @@ func TestEmbeddedWebAssets(t *testing.T) {
 		{path: "/help.css", contentType: "text/css", contains: ".help-shell"},
 		{path: "/help.js", contentType: "text/javascript", contains: "applyLanguage"},
 		{path: "/webhooks", contentType: "text/html", contains: "Webhook Configurator"},
-		{path: "/webhooks/", contentType: "text/html", contains: "生成 Webhook 配置"},
+		{path: "/webhooks/", contentType: "text/html", contains: `id="targetList"`},
 		{path: "/webhooks.css", contentType: "text/css", contains: ".webhook-workspace"},
 		{path: "/webhooks.js", contentType: "text/javascript", contains: "parseConfigText"},
 	}

--- a/tests/web/webhooks.test.js
+++ b/tests/web/webhooks.test.js
@@ -268,12 +268,24 @@ test('URL validation rejects Go-incompatible authority syntax', () => {
         targets: [
             { name: 'backslash', url: 'https://example.com\\hook' },
             { name: 'empty-user', url: 'https://@example.com/hook' },
-            { name: 'empty-user-password', url: 'https://:@example.com/hook' }
+            { name: 'empty-user-password', url: 'https://:@example.com/hook' },
+            { name: 'opening-brace', url: 'https://example{.com/hook' },
+            { name: 'closing-brace', url: 'https://example}.com/hook' },
+            { name: 'backtick', url: 'https://example`.com/hook' }
         ]
     });
 
-    assert.ok(codes(result).includes('urlInvalid'));
+    assert.equal(codes(result).filter((code) => code === 'urlInvalid').length, 4);
     assert.equal(codes(result).filter((code) => code === 'urlCredentials').length, 2);
+});
+
+test('URL validation accepts Go-compatible IPv6 zone identifiers', () => {
+    const result = configurator.validateConfig({
+        version: 1,
+        targets: [{ name: 'scoped-ipv6', url: 'https://[fe80::1%25eth0]/hook' }]
+    });
+
+    assert.deepEqual(codes(result), []);
 });
 
 test('glob validation follows Go path.Match character-class grammar', () => {

--- a/tests/web/webhooks.test.js
+++ b/tests/web/webhooks.test.js
@@ -260,6 +260,15 @@ test('URL validation rejects escapes that Go net/url cannot parse', () => {
     assert.equal(codes(result).filter((code) => code === 'urlInvalid').length, 2);
 });
 
+test('URL validation preserves opaque raw-query percent values', () => {
+    const result = configurator.validateConfig({
+        version: 1,
+        targets: [{ name: 'raw-query', url: 'https://example.com/hook?token=%zz' }]
+    });
+
+    assert.deepEqual(codes(result), []);
+});
+
 test('URL validation rejects normalized whitespace and opaque HTTP URLs', () => {
     const result = configurator.validateConfig({
         version: 1,
@@ -404,4 +413,24 @@ test('generated header maps preserve Object prototype property names', () => {
 
     assert.equal(Object.prototype.hasOwnProperty.call(headers, '__proto__'), true);
     assert.equal(JSON.parse(JSON.stringify(headers)).__proto__, 'kept');
+});
+
+test('HTTP field values reject control bytes while allowing horizontal tabs', () => {
+    const result = configurator.validateConfig({
+        version: 1,
+        targets: [{
+            name: 'header-controls',
+            url: 'https://example.com/hook',
+            headers: {
+                'X-Nul': 'a\u0000b',
+                'X-Del': 'a\u007Fb',
+                'X-Tab': 'a\tb'
+            },
+            contentType: 'application/json\u0000'
+        }]
+    });
+
+    assert.equal(codes(result).filter((code) => code === 'headerControl').length, 2);
+    assert.equal(codes(result).filter((code) => code === 'contentTypeControl').length, 1);
+    assert.equal(configurator.hasInvalidHTTPFieldValue('a\tb'), false);
 });

--- a/tests/web/webhooks.test.js
+++ b/tests/web/webhooks.test.js
@@ -211,17 +211,29 @@ test('generated configurations use the same 1 MiB limit as OwlMail', () => {
 
 test('URL validation defers environment-backed schemes and ports to runtime', () => {
     const schemePlaceholder = '$' + '{SCHEME}';
+    const hostPlaceholder = '$' + '{HOST}';
     const portPlaceholder = '$' + '{PORT}';
     const result = configurator.validateConfig({
         version: 1,
         targets: [
             { name: 'scheme', url: schemePlaceholder + '://example.com/hook' },
-            { name: 'port', url: 'https://example.com:' + portPlaceholder + '/hook' }
+            { name: 'port', url: 'https://example.com:' + portPlaceholder + '/hook' },
+            { name: 'ipv6', url: 'https://[' + hostPlaceholder + ']:' + portPlaceholder + '/hook' }
         ]
     });
 
     assert.deepEqual(codes(result), []);
-    assert.equal(codes(result, 'warnings').filter((code) => code === 'envRuntime').length, 2);
+    assert.equal(codes(result, 'warnings').filter((code) => code === 'envRuntime').length, 3);
+});
+
+test('URL validation still checks static authority with a placeholder scheme', () => {
+    const schemePlaceholder = '$' + '{SCHEME}';
+    const result = configurator.validateConfig({
+        version: 1,
+        targets: [{ name: 'missing-host', url: schemePlaceholder + ':///hook' }]
+    });
+
+    assert.ok(codes(result).includes('urlHost'));
 });
 
 test('URL validation rejects escapes that Go net/url cannot parse', () => {
@@ -231,6 +243,20 @@ test('URL validation rejects escapes that Go net/url cannot parse', () => {
     });
 
     assert.ok(codes(result).includes('urlInvalid'));
+});
+
+test('URL validation rejects normalized whitespace and opaque HTTP URLs', () => {
+    const result = configurator.validateConfig({
+        version: 1,
+        targets: [
+            { name: 'leading-space', url: ' https://example.com/hook' },
+            { name: 'control', url: 'https://exa\nmple.com/hook' },
+            { name: 'opaque', url: 'https:example.com' }
+        ]
+    });
+
+    assert.equal(codes(result).filter((code) => code === 'urlInvalid').length, 2);
+    assert.ok(codes(result).includes('urlHost'));
 });
 
 test('glob validation follows Go path.Match character-class grammar', () => {
@@ -291,4 +317,12 @@ test('sub-nanosecond timeouts are rejected after Go-compatible quantization', ()
     });
 
     assert.ok(codes(result).includes('timeoutRange'));
+});
+
+test('generated header maps preserve Object prototype property names', () => {
+    const headers = configurator.createHeaderMap();
+    headers.__proto__ = 'kept';
+
+    assert.equal(Object.prototype.hasOwnProperty.call(headers, '__proto__'), true);
+    assert.equal(JSON.parse(JSON.stringify(headers)).__proto__, 'kept');
 });

--- a/tests/web/webhooks.test.js
+++ b/tests/web/webhooks.test.js
@@ -275,9 +275,23 @@ test('URL validation still checks static authority with a placeholder scheme', (
 
 test('base URL placeholders still reject static fragments', () => {
     const basePlaceholder = '$' + '{BASE_URL}';
-    const result = configurator.validateConfig({
+    const fragment = configurator.validateConfig({
         version: 1,
         targets: [{ name: 'fragment', url: basePlaceholder + '/hook#secret' }]
+    });
+    const emptyFragment = configurator.validateConfig({
+        version: 1,
+        targets: [{ name: 'empty-fragment', url: basePlaceholder + '/hook#' }]
+    });
+
+    assert.ok(codes(fragment).includes('urlFragment'));
+    assert.deepEqual(codes(emptyFragment), []);
+});
+
+test('URL validation inspects fragment content before browser normalization', () => {
+    const result = configurator.validateConfig({
+        version: 1,
+        targets: [{ name: 'space-fragment', url: 'https://example.com/hook# ' }]
     });
 
     assert.ok(codes(result).includes('urlFragment'));

--- a/tests/web/webhooks.test.js
+++ b/tests/web/webhooks.test.js
@@ -259,6 +259,20 @@ test('URL validation rejects normalized whitespace and opaque HTTP URLs', () => 
     assert.ok(codes(result).includes('urlHost'));
 });
 
+test('URL validation rejects Go-incompatible authority syntax', () => {
+    const result = configurator.validateConfig({
+        version: 1,
+        targets: [
+            { name: 'backslash', url: 'https://example.com\\hook' },
+            { name: 'empty-user', url: 'https://@example.com/hook' },
+            { name: 'empty-user-password', url: 'https://:@example.com/hook' }
+        ]
+    });
+
+    assert.ok(codes(result).includes('urlInvalid'));
+    assert.equal(codes(result).filter((code) => code === 'urlCredentials').length, 2);
+});
+
 test('glob validation follows Go path.Match character-class grammar', () => {
     for (const pattern of ['[a-]', '[-a]', '[a-b-c]']) {
         assert.equal(configurator.validGlobPattern(pattern), false, pattern + ' should be rejected');
@@ -304,6 +318,15 @@ test('imported match patterns retain significant whitespace and embedded newline
         Array.from(configurator.patternsFromEditorValue(' leading*\ntrailing* ', null)),
         [' leading*', 'trailing* ']
     );
+});
+
+test('unmodified secret and template values survive control normalization', () => {
+    const normalizedDisplay = 'line\nvalue';
+    const originalValue = 'line\r\nvalue';
+    const preserved = { displayValue: normalizedDisplay, value: originalValue };
+
+    assert.equal(configurator.editorValueFromPreserved(normalizedDisplay, preserved), originalValue);
+    assert.equal(configurator.editorValueFromPreserved('edited', preserved), 'edited');
 });
 
 test('sub-nanosecond timeouts are rejected after Go-compatible quantization', () => {

--- a/tests/web/webhooks.test.js
+++ b/tests/web/webhooks.test.js
@@ -262,6 +262,7 @@ test('URL validation defers environment-backed schemes and ports to runtime', ()
     const schemePlaceholder = '$' + '{SCHEME}';
     const schemePrefixPlaceholder = '$' + '{SCHEME_PREFIX}';
     const separatorPlaceholder = '$' + '{URL_SEPARATOR}';
+    const restPlaceholder = '$' + '{URL_REST}';
     const hostPlaceholder = '$' + '{HOST}';
     const openingBracketPlaceholder = '$' + '{OPEN_BRACKET}';
     const closingBracketPlaceholder = '$' + '{CLOSE_BRACKET}';
@@ -274,6 +275,7 @@ test('URL validation defers environment-backed schemes and ports to runtime', ()
             { name: 'scheme', url: schemePlaceholder + '://example.com/hook' },
             { name: 'scheme-composed', url: schemePrefixPlaceholder + 'ps://example.com/hook' },
             { name: 'separator', url: 'https' + separatorPlaceholder + 'example.com/hook' },
+            { name: 'authority', url: 'https' + restPlaceholder + '/hook' },
             { name: 'port', url: 'https://example.com:' + portPlaceholder + '/hook' },
             { name: 'port-composed', url: 'https://example.com:' + portPlaceholder + '000/hook' },
             { name: 'ipv6', url: 'https://[' + hostPlaceholder + ']:' + portPlaceholder + '/hook' },
@@ -285,7 +287,7 @@ test('URL validation defers environment-backed schemes and ports to runtime', ()
     });
 
     assert.deepEqual(codes(result), []);
-    assert.equal(codes(result, 'warnings').filter((code) => code === 'envRuntime').length, 10);
+    assert.equal(codes(result, 'warnings').filter((code) => code === 'envRuntime').length, 11);
 });
 
 test('URL validation still checks static authority with a placeholder scheme', () => {

--- a/tests/web/webhooks.test.js
+++ b/tests/web/webhooks.test.js
@@ -192,3 +192,55 @@ test('pasted configurations use the same 1 MiB limit as OwlMail', () => {
     const oversized = 'x'.repeat(configurator.MAX_CONFIG_BYTES + 1);
     assert.deepEqual(codes(configurator.parseConfigText(oversized)), ['configTooLarge']);
 });
+
+test('generated configurations use the same 1 MiB limit as OwlMail', () => {
+    const result = configurator.validateGeneratedConfig({
+        version: 1,
+        targets: [{
+            name: 'large',
+            url: 'https://example.com/hook',
+            bodyTemplate: 'x'.repeat(configurator.MAX_CONFIG_BYTES)
+        }]
+    });
+
+    assert.ok(codes(result).includes('configTooLarge'));
+});
+
+test('URL validation defers environment-backed schemes and ports to runtime', () => {
+    const schemePlaceholder = '$' + '{SCHEME}';
+    const portPlaceholder = '$' + '{PORT}';
+    const result = configurator.validateConfig({
+        version: 1,
+        targets: [
+            { name: 'scheme', url: schemePlaceholder + '://example.com/hook' },
+            { name: 'port', url: 'https://example.com:' + portPlaceholder + '/hook' }
+        ]
+    });
+
+    assert.deepEqual(codes(result), []);
+    assert.equal(codes(result, 'warnings').filter((code) => code === 'envRuntime').length, 2);
+});
+
+test('glob validation follows Go path.Match character-class grammar', () => {
+    for (const pattern of ['[a-]', '[-a]', '[a-b-c]']) {
+        assert.equal(configurator.validGlobPattern(pattern), false, pattern + ' should be rejected');
+    }
+    for (const pattern of ['[a-z]', '[\\-]']) {
+        assert.equal(configurator.validGlobPattern(pattern), true, pattern + ' should be accepted');
+    }
+});
+
+test('target names use the backend UTF-8 byte limit', () => {
+    const valid = configurator.validateConfig({
+        version: 1,
+        targets: [{ name: '猫'.repeat(33), url: 'https://example.com/hook' }]
+    });
+    const oversized = configurator.validateConfig({
+        version: 1,
+        targets: [{ name: '猫'.repeat(40), url: 'https://example.com/hook' }]
+    });
+
+    assert.deepEqual(codes(valid), []);
+    assert.ok(codes(oversized).includes('nameInvalid'));
+    assert.equal(configurator.utf8ByteLength('猫'.repeat(33)), 99);
+});

--- a/tests/web/webhooks.test.js
+++ b/tests/web/webhooks.test.js
@@ -213,17 +213,19 @@ test('URL validation defers environment-backed schemes and ports to runtime', ()
     const schemePlaceholder = '$' + '{SCHEME}';
     const hostPlaceholder = '$' + '{HOST}';
     const portPlaceholder = '$' + '{PORT}';
+    const basePlaceholder = '$' + '{BASE_URL}';
     const result = configurator.validateConfig({
         version: 1,
         targets: [
             { name: 'scheme', url: schemePlaceholder + '://example.com/hook' },
             { name: 'port', url: 'https://example.com:' + portPlaceholder + '/hook' },
-            { name: 'ipv6', url: 'https://[' + hostPlaceholder + ']:' + portPlaceholder + '/hook' }
+            { name: 'ipv6', url: 'https://[' + hostPlaceholder + ']:' + portPlaceholder + '/hook' },
+            { name: 'base', url: basePlaceholder + '/hook' }
         ]
     });
 
     assert.deepEqual(codes(result), []);
-    assert.equal(codes(result, 'warnings').filter((code) => code === 'envRuntime').length, 3);
+    assert.equal(codes(result, 'warnings').filter((code) => code === 'envRuntime').length, 4);
 });
 
 test('URL validation still checks static authority with a placeholder scheme', () => {
@@ -234,6 +236,16 @@ test('URL validation still checks static authority with a placeholder scheme', (
     });
 
     assert.ok(codes(result).includes('urlHost'));
+});
+
+test('base URL placeholders still reject static fragments', () => {
+    const basePlaceholder = '$' + '{BASE_URL}';
+    const result = configurator.validateConfig({
+        version: 1,
+        targets: [{ name: 'fragment', url: basePlaceholder + '/hook#secret' }]
+    });
+
+    assert.ok(codes(result).includes('urlFragment'));
 });
 
 test('URL validation rejects escapes that Go net/url cannot parse', () => {

--- a/tests/web/webhooks.test.js
+++ b/tests/web/webhooks.test.js
@@ -239,10 +239,13 @@ test('URL validation still checks static authority with a placeholder scheme', (
 test('URL validation rejects escapes that Go net/url cannot parse', () => {
     const result = configurator.validateConfig({
         version: 1,
-        targets: [{ name: 'bad-escape', url: 'https://example.com/%zz' }]
+        targets: [
+            { name: 'bad-escape', url: 'https://example.com/%zz' },
+            { name: 'escaped-host', url: 'https://%65xample.com/hook' }
+        ]
     });
 
-    assert.ok(codes(result).includes('urlInvalid'));
+    assert.equal(codes(result).filter((code) => code === 'urlInvalid').length, 2);
 });
 
 test('URL validation rejects normalized whitespace and opaque HTTP URLs', () => {

--- a/tests/web/webhooks.test.js
+++ b/tests/web/webhooks.test.js
@@ -285,6 +285,18 @@ test('URL validation rejects normalized whitespace and opaque HTTP URLs', () => 
     assert.ok(codes(result).includes('urlHost'));
 });
 
+test('URL validation accepts and preserves trailing spaces in paths', () => {
+    const url = 'https://example.com/hook ';
+    const result = configurator.parseConfigText(JSON.stringify({
+        version: 1,
+        targets: [{ name: 'trailing-space', url }]
+    }));
+
+    assert.deepEqual(codes(result), []);
+    assert.equal(result.config.targets[0].url, url);
+    assert.ok(source.includes("url: value('[data-field=\"url\"]')"));
+});
+
 test('URL validation rejects Go-incompatible authority syntax', () => {
     const result = configurator.validateConfig({
         version: 1,

--- a/tests/web/webhooks.test.js
+++ b/tests/web/webhooks.test.js
@@ -73,6 +73,27 @@ test('minimal configuration imports and normalizes defaults', () => {
     });
 });
 
+test('import matches known JSON field names case-insensitively like Go', () => {
+    const result = configurator.parseConfigText(JSON.stringify({
+        Version: 1,
+        Targets: [{
+            Name: 'primary',
+            URL: 'https://example.com/hooks/owlmail',
+            Match: { Subject: ['build*'] }
+        }]
+    }));
+
+    assert.deepEqual(codes(result), []);
+    assert.deepEqual(JSON.parse(JSON.stringify(result.config)), {
+        version: 1,
+        targets: [{
+            name: 'primary',
+            url: 'https://example.com/hooks/owlmail',
+            match: { subject: ['build*'] }
+        }]
+    });
+});
+
 test('whitespace-only methods normalize to the backend default', () => {
     const result = configurator.parseConfigText(JSON.stringify({
         version: 1,
@@ -242,6 +263,8 @@ test('URL validation defers environment-backed schemes and ports to runtime', ()
     const schemePrefixPlaceholder = '$' + '{SCHEME_PREFIX}';
     const separatorPlaceholder = '$' + '{URL_SEPARATOR}';
     const hostPlaceholder = '$' + '{HOST}';
+    const openingBracketPlaceholder = '$' + '{OPEN_BRACKET}';
+    const closingBracketPlaceholder = '$' + '{CLOSE_BRACKET}';
     const ipv6PrefixPlaceholder = '$' + '{IPV6_PREFIX}';
     const portPlaceholder = '$' + '{PORT}';
     const basePlaceholder = '$' + '{BASE_URL}';
@@ -255,12 +278,14 @@ test('URL validation defers environment-backed schemes and ports to runtime', ()
             { name: 'port-composed', url: 'https://example.com:' + portPlaceholder + '000/hook' },
             { name: 'ipv6', url: 'https://[' + hostPlaceholder + ']:' + portPlaceholder + '/hook' },
             { name: 'ipv6-composed', url: 'https://[' + ipv6PrefixPlaceholder + '1]/hook' },
+            { name: 'ipv6-opening', url: 'https://' + openingBracketPlaceholder + '::1]/hook' },
+            { name: 'ipv6-closing', url: 'https://[::1' + closingBracketPlaceholder + '/hook' },
             { name: 'base', url: basePlaceholder + '/hook' }
         ]
     });
 
     assert.deepEqual(codes(result), []);
-    assert.equal(codes(result, 'warnings').filter((code) => code === 'envRuntime').length, 8);
+    assert.equal(codes(result, 'warnings').filter((code) => code === 'envRuntime').length, 10);
 });
 
 test('URL validation still checks static authority with a placeholder scheme', () => {

--- a/tests/web/webhooks.test.js
+++ b/tests/web/webhooks.test.js
@@ -73,6 +73,34 @@ test('minimal configuration imports and normalizes defaults', () => {
     });
 });
 
+test('whitespace-only methods normalize to the backend default', () => {
+    const result = configurator.parseConfigText(JSON.stringify({
+        version: 1,
+        targets: [{
+            name: 'primary',
+            url: 'https://example.com/hooks/owlmail',
+            method: ' \u0085 '
+        }]
+    }));
+
+    assert.deepEqual(codes(result), []);
+    assert.equal(Object.hasOwn(result.config.targets[0], 'method'), false);
+});
+
+test('content types apply backend whitespace normalization before validation', () => {
+    const result = configurator.parseConfigText(JSON.stringify({
+        version: 1,
+        targets: [{
+            name: 'primary',
+            url: 'https://example.com/hooks/owlmail',
+            contentType: ' text/plain\r\n'
+        }]
+    }));
+
+    assert.deepEqual(codes(result), []);
+    assert.equal(result.config.targets[0].contentType, 'text/plain');
+});
+
 test('full configuration survives import parsing', () => {
     const sourceConfig = {
         version: 1,
@@ -212,6 +240,7 @@ test('generated configurations use the same 1 MiB limit as OwlMail', () => {
 test('URL validation defers environment-backed schemes and ports to runtime', () => {
     const schemePlaceholder = '$' + '{SCHEME}';
     const schemePrefixPlaceholder = '$' + '{SCHEME_PREFIX}';
+    const separatorPlaceholder = '$' + '{URL_SEPARATOR}';
     const hostPlaceholder = '$' + '{HOST}';
     const ipv6PrefixPlaceholder = '$' + '{IPV6_PREFIX}';
     const portPlaceholder = '$' + '{PORT}';
@@ -221,6 +250,7 @@ test('URL validation defers environment-backed schemes and ports to runtime', ()
         targets: [
             { name: 'scheme', url: schemePlaceholder + '://example.com/hook' },
             { name: 'scheme-composed', url: schemePrefixPlaceholder + 'ps://example.com/hook' },
+            { name: 'separator', url: 'https' + separatorPlaceholder + 'example.com/hook' },
             { name: 'port', url: 'https://example.com:' + portPlaceholder + '/hook' },
             { name: 'port-composed', url: 'https://example.com:' + portPlaceholder + '000/hook' },
             { name: 'ipv6', url: 'https://[' + hostPlaceholder + ']:' + portPlaceholder + '/hook' },
@@ -230,7 +260,7 @@ test('URL validation defers environment-backed schemes and ports to runtime', ()
     });
 
     assert.deepEqual(codes(result), []);
-    assert.equal(codes(result, 'warnings').filter((code) => code === 'envRuntime').length, 7);
+    assert.equal(codes(result, 'warnings').filter((code) => code === 'envRuntime').length, 8);
 });
 
 test('URL validation still checks static authority with a placeholder scheme', () => {
@@ -324,6 +354,24 @@ test('URL validation accepts Go-compatible IPv6 zone identifiers', () => {
     });
 
     assert.deepEqual(codes(result), []);
+});
+
+test('IPv6 zone normalization stays inside a balanced URL authority', () => {
+    const malformedAuthority = configurator.validateConfig({
+        version: 1,
+        targets: [{ name: 'unbalanced-zone', url: 'https://[::1%25x#]' }]
+    });
+    const hostPlaceholder = '$' + '{HOST}';
+    const pathFragment = configurator.validateConfig({
+        version: 1,
+        targets: [{
+            name: 'path-fragment',
+            url: 'https://[' + hostPlaceholder + '%25zone]/[path%25x#]'
+        }]
+    });
+
+    assert.ok(codes(malformedAuthority).includes('urlInvalid'));
+    assert.ok(codes(pathFragment).includes('urlFragment'));
 });
 
 test('glob validation follows Go path.Match character-class grammar', () => {

--- a/tests/web/webhooks.test.js
+++ b/tests/web/webhooks.test.js
@@ -406,9 +406,22 @@ test('target names use the backend UTF-8 byte limit', () => {
         version: 1,
         targets: [{ name: '猫'.repeat(40), url: 'https://example.com/hook' }]
     });
+    const surrogateDuplicates = configurator.validateConfig({
+        version: 1,
+        targets: [
+            { name: '\uD800', url: 'https://example.com/one' },
+            { name: '\uD801', url: 'https://example.com/two' }
+        ]
+    });
+    const normalizedSurrogate = configurator.parseConfigText(JSON.stringify({
+        version: 1,
+        targets: [{ name: '\uD800', url: 'https://example.com/hook' }]
+    }));
 
     assert.deepEqual(codes(valid), []);
     assert.ok(codes(oversized).includes('nameInvalid'));
+    assert.ok(codes(surrogateDuplicates).includes('duplicateName'));
+    assert.equal(normalizedSurrogate.config.targets[0].name, '\uFFFD');
     assert.equal(configurator.utf8ByteLength('猫'.repeat(33)), 99);
 });
 

--- a/tests/web/webhooks.test.js
+++ b/tests/web/webhooks.test.js
@@ -164,6 +164,16 @@ test('import parser rejects malformed JSON and unknown fields', () => {
     assert.equal(unknown.config, null);
 });
 
+test('import rejects duplicate JSON keys before alias canonicalization', () => {
+    const result = configurator.parseConfigText(
+        '{"version":1,"targets":[{"name":"primary","url":"https://first.example",' +
+        '"URL":"https://middle.example","url":"https://last.example"}]}'
+    );
+
+    assert.deepEqual(codes(result), ['duplicateJSONKey']);
+    assert.equal(result.config, null);
+});
+
 test('validation follows OwlMail target limits and safety rules', () => {
     const result = configurator.validateConfig({
         version: 1,
@@ -294,10 +304,14 @@ test('URL validation still checks static authority with a placeholder scheme', (
     const schemePlaceholder = '$' + '{SCHEME}';
     const result = configurator.validateConfig({
         version: 1,
-        targets: [{ name: 'missing-host', url: schemePlaceholder + ':///hook' }]
+        targets: [
+            { name: 'missing-host', url: schemePlaceholder + ':///hook' },
+            { name: 'impossible-scheme', url: 'x' + schemePlaceholder + '://example.com/hook' }
+        ]
     });
 
     assert.ok(codes(result).includes('urlHost'));
+    assert.ok(codes(result).includes('urlScheme'));
 });
 
 test('base URL placeholders still reject static fragments', () => {

--- a/tests/web/webhooks.test.js
+++ b/tests/web/webhooks.test.js
@@ -211,6 +211,7 @@ test('generated configurations use the same 1 MiB limit as OwlMail', () => {
 
 test('URL validation defers environment-backed schemes and ports to runtime', () => {
     const schemePlaceholder = '$' + '{SCHEME}';
+    const schemePrefixPlaceholder = '$' + '{SCHEME_PREFIX}';
     const hostPlaceholder = '$' + '{HOST}';
     const ipv6PrefixPlaceholder = '$' + '{IPV6_PREFIX}';
     const portPlaceholder = '$' + '{PORT}';
@@ -219,7 +220,9 @@ test('URL validation defers environment-backed schemes and ports to runtime', ()
         version: 1,
         targets: [
             { name: 'scheme', url: schemePlaceholder + '://example.com/hook' },
+            { name: 'scheme-composed', url: schemePrefixPlaceholder + 'ps://example.com/hook' },
             { name: 'port', url: 'https://example.com:' + portPlaceholder + '/hook' },
+            { name: 'port-composed', url: 'https://example.com:' + portPlaceholder + '000/hook' },
             { name: 'ipv6', url: 'https://[' + hostPlaceholder + ']:' + portPlaceholder + '/hook' },
             { name: 'ipv6-composed', url: 'https://[' + ipv6PrefixPlaceholder + '1]/hook' },
             { name: 'base', url: basePlaceholder + '/hook' }
@@ -227,7 +230,7 @@ test('URL validation defers environment-backed schemes and ports to runtime', ()
     });
 
     assert.deepEqual(codes(result), []);
-    assert.equal(codes(result, 'warnings').filter((code) => code === 'envRuntime').length, 5);
+    assert.equal(codes(result, 'warnings').filter((code) => code === 'envRuntime').length, 7);
 });
 
 test('URL validation still checks static authority with a placeholder scheme', () => {

--- a/tests/web/webhooks.test.js
+++ b/tests/web/webhooks.test.js
@@ -76,10 +76,10 @@ test('minimal configuration imports and normalizes defaults', () => {
 test('import matches known JSON field names case-insensitively like Go', () => {
     const result = configurator.parseConfigText(JSON.stringify({
         Version: 1,
-        Targets: [{
+        'targetſ': [{
             Name: 'primary',
             URL: 'https://example.com/hooks/owlmail',
-            Match: { Subject: ['build*'] }
+            Match: { 'ſubject': ['build*'] }
         }]
     }));
 

--- a/tests/web/webhooks.test.js
+++ b/tests/web/webhooks.test.js
@@ -212,6 +212,7 @@ test('generated configurations use the same 1 MiB limit as OwlMail', () => {
 test('URL validation defers environment-backed schemes and ports to runtime', () => {
     const schemePlaceholder = '$' + '{SCHEME}';
     const hostPlaceholder = '$' + '{HOST}';
+    const ipv6PrefixPlaceholder = '$' + '{IPV6_PREFIX}';
     const portPlaceholder = '$' + '{PORT}';
     const basePlaceholder = '$' + '{BASE_URL}';
     const result = configurator.validateConfig({
@@ -220,12 +221,13 @@ test('URL validation defers environment-backed schemes and ports to runtime', ()
             { name: 'scheme', url: schemePlaceholder + '://example.com/hook' },
             { name: 'port', url: 'https://example.com:' + portPlaceholder + '/hook' },
             { name: 'ipv6', url: 'https://[' + hostPlaceholder + ']:' + portPlaceholder + '/hook' },
+            { name: 'ipv6-composed', url: 'https://[' + ipv6PrefixPlaceholder + '1]/hook' },
             { name: 'base', url: basePlaceholder + '/hook' }
         ]
     });
 
     assert.deepEqual(codes(result), []);
-    assert.equal(codes(result, 'warnings').filter((code) => code === 'envRuntime').length, 4);
+    assert.equal(codes(result, 'warnings').filter((code) => code === 'envRuntime').length, 5);
 });
 
 test('URL validation still checks static authority with a placeholder scheme', () => {

--- a/tests/web/webhooks.test.js
+++ b/tests/web/webhooks.test.js
@@ -312,6 +312,35 @@ test('target names use the backend UTF-8 byte limit', () => {
     assert.equal(configurator.utf8ByteLength('猫'.repeat(33)), 99);
 });
 
+test('name and pattern whitespace normalization follows Go strings.TrimSpace', () => {
+    const nextLine = '\u0085';
+    const invalid = configurator.validateConfig({
+        version: 1,
+        targets: [{
+            name: nextLine,
+            url: 'https://example.com/hook',
+            match: { subject: [nextLine] }
+        }]
+    });
+    const parsed = configurator.parseConfigText(JSON.stringify({
+        version: 1,
+        targets: [{
+            name: nextLine + 'primary' + nextLine,
+            url: 'https://example.com/hook',
+            method: nextLine + 'post' + nextLine,
+            contentType: nextLine + 'application/json' + nextLine
+        }]
+    }));
+
+    assert.ok(codes(invalid).includes('nameRequired'));
+    assert.ok(codes(invalid).includes('matchPattern'));
+    assert.deepEqual(codes(parsed), []);
+    assert.equal(parsed.config.targets[0].name, 'primary');
+    assert.equal(Object.hasOwn(parsed.config.targets[0], 'method'), false);
+    assert.equal(Object.hasOwn(parsed.config.targets[0], 'contentType'), false);
+    assert.equal(configurator.goTrimSpace('\uFEFF'), '\uFEFF');
+});
+
 test('imported match patterns retain significant whitespace and embedded newlines', () => {
     const patterns = [' leading*', 'trailing* ', 'line\nbreak'];
     const parsed = configurator.parseConfigText(JSON.stringify({

--- a/tests/web/webhooks.test.js
+++ b/tests/web/webhooks.test.js
@@ -185,6 +185,9 @@ test('target count and duration helpers enforce backend bounds', () => {
     assert.equal(configurator.parseDurationMilliseconds('1m1s'), 61000);
     assert.equal(configurator.parseDurationMilliseconds('+5s'), 5000);
     assert.equal(configurator.parseDurationMilliseconds('-5s'), -5000);
+    assert.equal(configurator.parseDurationMilliseconds('1μs'), 0.001);
+    assert.equal(configurator.parseDurationMilliseconds('0.000000001s'), 0.000001);
+    assert.equal(configurator.parseDurationMilliseconds('0.0000000001s'), 0);
     assert.equal(Number.isNaN(configurator.parseDurationMilliseconds('soon')), true);
 });
 
@@ -221,6 +224,15 @@ test('URL validation defers environment-backed schemes and ports to runtime', ()
     assert.equal(codes(result, 'warnings').filter((code) => code === 'envRuntime').length, 2);
 });
 
+test('URL validation rejects escapes that Go net/url cannot parse', () => {
+    const result = configurator.validateConfig({
+        version: 1,
+        targets: [{ name: 'bad-escape', url: 'https://example.com/%zz' }]
+    });
+
+    assert.ok(codes(result).includes('urlInvalid'));
+});
+
 test('glob validation follows Go path.Match character-class grammar', () => {
     for (const pattern of ['[a-]', '[-a]', '[a-b-c]']) {
         assert.equal(configurator.validGlobPattern(pattern), false, pattern + ' should be rejected');
@@ -243,4 +255,40 @@ test('target names use the backend UTF-8 byte limit', () => {
     assert.deepEqual(codes(valid), []);
     assert.ok(codes(oversized).includes('nameInvalid'));
     assert.equal(configurator.utf8ByteLength('猫'.repeat(33)), 99);
+});
+
+test('imported match patterns retain significant whitespace and embedded newlines', () => {
+    const patterns = [' leading*', 'trailing* ', 'line\nbreak'];
+    const parsed = configurator.parseConfigText(JSON.stringify({
+        version: 1,
+        targets: [{
+            name: 'preserved',
+            url: 'https://example.com/hook',
+            match: { subject: patterns }
+        }]
+    }));
+    const displayValue = patterns.join('\n');
+
+    assert.deepEqual(Array.from(parsed.config.targets[0].match.subject), patterns);
+    assert.deepEqual(
+        configurator.patternsFromEditorValue(displayValue, { displayValue, patterns }),
+        patterns
+    );
+    assert.deepEqual(
+        Array.from(configurator.patternsFromEditorValue(' leading*\ntrailing* ', null)),
+        [' leading*', 'trailing* ']
+    );
+});
+
+test('sub-nanosecond timeouts are rejected after Go-compatible quantization', () => {
+    const result = configurator.validateConfig({
+        version: 1,
+        targets: [{
+            name: 'tiny-timeout',
+            url: 'https://example.com/hook',
+            timeout: '0.0000000001s'
+        }]
+    });
+
+    assert.ok(codes(result).includes('timeoutRange'));
 });

--- a/tests/web/webhooks.test.js
+++ b/tests/web/webhooks.test.js
@@ -1,0 +1,194 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const source = fs.readFileSync(path.join(__dirname, '../../web/webhooks.js'), 'utf8');
+const page = fs.readFileSync(path.join(__dirname, '../../web/webhooks.html'), 'utf8');
+const styles = fs.readFileSync(path.join(__dirname, '../../web/webhooks.css'), 'utf8');
+
+function loadConfigurator() {
+    const window = {};
+    const document = { addEventListener() {} };
+    const sandbox = {
+        URL,
+        clearTimeout,
+        console,
+        document,
+        navigator: { language: 'en-US' },
+        setTimeout,
+        window
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(source, sandbox, { filename: 'web/webhooks.js' });
+    return window.OwlMailWebhookConfigurator;
+}
+
+const configurator = loadConfigurator();
+
+function codes(result, type = 'errors') {
+    return Array.from(result[type], (item) => item.code);
+}
+
+test('page exposes builder, import, output, and local-only controls', () => {
+    for (const marker of [
+        'id="targetList"',
+        'id="targetTemplate"',
+        'id="importInput"',
+        'id="dropZone"',
+        'id="configOutput"',
+        'id="copyConfig"',
+        'id="downloadConfig"',
+        'Local-only editor.'
+    ]) {
+        assert.ok(page.includes(marker), 'webhooks.html is missing ' + marker);
+    }
+    assert.ok(page.includes('href="/style.css"'));
+    assert.ok(styles.includes('.webhook-workspace'));
+    assert.ok(styles.includes('body.dark-theme'));
+    assert.ok(!page.includes('http://') && !page.includes('https://cdn.'), 'page must not load remote assets');
+});
+
+test('minimal configuration imports and normalizes defaults', () => {
+    const result = configurator.parseConfigText(JSON.stringify({
+        version: 1,
+        targets: [{
+            name: ' primary ',
+            url: 'https://example.com/hooks/owlmail',
+            method: 'post',
+            contentType: 'application/json',
+            timeout: '5s',
+            retries: 0
+        }]
+    }));
+
+    assert.deepEqual(codes(result), []);
+    assert.deepEqual(JSON.parse(JSON.stringify(result.config)), {
+        version: 1,
+        targets: [{
+            name: 'primary',
+            url: 'https://example.com/hooks/owlmail'
+        }]
+    });
+});
+
+test('full configuration survives import parsing', () => {
+    const sourceConfig = {
+        version: 1,
+        targets: [{
+            name: 'alerts',
+            url: 'https://example.com/owlmail',
+            method: 'PATCH',
+            headers: { Authorization: 'Bearer token' },
+            contentType: 'application/vnd.owlmail+json',
+            bodyTemplate: '{"subject":{{ json .Subject }}}',
+            secret: 'test-secret',
+            timeout: '10s',
+            retries: 3,
+            match: {
+                from: ['*@example.com'],
+                to: ['alerts@example.com'],
+                subject: ['[staging]*'],
+                text: ['*failed*']
+            }
+        }]
+    };
+
+    const result = configurator.parseConfigText(JSON.stringify(sourceConfig));
+
+    assert.deepEqual(codes(result), []);
+    assert.deepEqual(JSON.parse(JSON.stringify(result.config)), sourceConfig);
+    assert.ok(codes(result, 'warnings').includes('templateRuntime'));
+});
+
+test('import parser rejects malformed JSON and unknown fields', () => {
+    const malformed = configurator.parseConfigText('{"targets":[]} trailing');
+    assert.deepEqual(codes(malformed), ['invalidJSON']);
+
+    const unknown = configurator.parseConfigText(JSON.stringify({
+        version: 1,
+        targetz: [],
+        targets: [{ name: 'one', url: 'https://example.com', unexpected: true }]
+    }));
+    assert.ok(codes(unknown).filter((code) => code === 'unknownField').length >= 2);
+    assert.equal(unknown.config, null);
+});
+
+test('validation follows OwlMail target limits and safety rules', () => {
+    const result = configurator.validateConfig({
+        version: 1,
+        targets: [
+            {
+                name: 'duplicate',
+                url: 'https://user:pass@example.com/hook#fragment',
+                method: 'GET',
+                headers: {
+                    Host: 'example.com',
+                    'Bad Header': 'value',
+                    'X-Newline': 'first\nsecond'
+                },
+                timeout: '61s',
+                retries: 6,
+                match: { subject: ['['] }
+            },
+            { name: 'duplicate', url: 'file:///tmp/hook' }
+        ]
+    });
+    const resultCodes = codes(result);
+
+    [
+        'duplicateName',
+        'urlCredentials',
+        'urlFragment',
+        'unsupportedMethod',
+        'managedHeader',
+        'headerNameInvalid',
+        'headerNewline',
+        'timeoutRange',
+        'retriesInvalid',
+        'matchGlob',
+        'urlScheme',
+        'urlHost'
+    ].forEach((code) => assert.ok(resultCodes.includes(code), 'missing validation code ' + code));
+});
+
+test('environment placeholders remain editable and produce runtime notes', () => {
+    const hostPlaceholder = '$' + '{OWLMAIL_WEBHOOK_HOST}';
+    const tokenPlaceholder = '$' + '{OWLMAIL_WEBHOOK_TOKEN}';
+    const secretPlaceholder = '$' + '{OWLMAIL_WEBHOOK_SECRET}';
+    const result = configurator.parseConfigText(JSON.stringify({
+        version: 1,
+        targets: [{
+            name: 'secure',
+            url: 'https://' + hostPlaceholder + '/hook',
+            headers: { Authorization: 'Bearer ' + tokenPlaceholder },
+            secret: secretPlaceholder
+        }]
+    }));
+
+    assert.deepEqual(codes(result), []);
+    assert.ok(codes(result, 'warnings').filter((code) => code === 'envRuntime').length >= 3);
+    assert.equal(result.config.targets[0].url, 'https://' + hostPlaceholder + '/hook');
+});
+
+test('target count and duration helpers enforce backend bounds', () => {
+    const targets = Array.from({ length: configurator.MAX_TARGETS + 1 }, (_, index) => ({
+        name: 'target-' + index,
+        url: 'https://example.com/' + index
+    }));
+    const result = configurator.validateConfig({ version: 1, targets });
+
+    assert.ok(codes(result).includes('tooManyTargets'));
+    assert.equal(configurator.parseDurationMilliseconds('500ms'), 500);
+    assert.equal(configurator.parseDurationMilliseconds('1m'), 60000);
+    assert.equal(configurator.parseDurationMilliseconds('1m1s'), 61000);
+    assert.equal(configurator.parseDurationMilliseconds('+5s'), 5000);
+    assert.equal(configurator.parseDurationMilliseconds('-5s'), -5000);
+    assert.equal(Number.isNaN(configurator.parseDurationMilliseconds('soon')), true);
+});
+
+test('pasted configurations use the same 1 MiB limit as OwlMail', () => {
+    const oversized = 'x'.repeat(configurator.MAX_CONFIG_BYTES + 1);
+    assert.deepEqual(codes(configurator.parseConfigText(oversized)), ['configTooLarge']);
+});

--- a/tests/web/webhooks.test.js
+++ b/tests/web/webhooks.test.js
@@ -122,6 +122,20 @@ test('content types apply backend whitespace normalization before validation', (
     assert.equal(result.config.targets[0].contentType, 'text/plain');
 });
 
+test('null header values normalize to empty strings like Go', () => {
+    const result = configurator.parseConfigText(JSON.stringify({
+        version: 1,
+        targets: [{
+            name: 'primary',
+            url: 'https://example.com/hooks/owlmail',
+            headers: { 'X-Optional': null }
+        }]
+    }));
+
+    assert.deepEqual(codes(result), []);
+    assert.equal(result.config.targets[0].headers['X-Optional'], '');
+});
+
 test('full configuration survives import parsing', () => {
     const sourceConfig = {
         version: 1,

--- a/web/app.js
+++ b/web/app.js
@@ -47,6 +47,7 @@ const i18n = {
         hoursAgo: '{hours} 小时前',
         daysAgo: '{days} 天前',
         help: '帮助',
+        webhooks: 'Webhook 配置',
         toggleTheme: '切换主题',
         switchLanguage: '切换语言',
         // API Error Codes
@@ -116,6 +117,7 @@ const i18n = {
         hoursAgo: '{hours} hours ago',
         daysAgo: '{days} days ago',
         help: 'Help',
+        webhooks: 'Webhooks',
         toggleTheme: 'Toggle Theme',
         switchLanguage: 'Switch Language',
         // API Error Codes
@@ -185,6 +187,7 @@ const i18n = {
         hoursAgo: 'vor {hours} Stunden',
         daysAgo: 'vor {days} Tagen',
         help: 'Hilfe',
+        webhooks: 'Webhooks',
         toggleTheme: 'Design umschalten',
         switchLanguage: 'Sprache wechseln',
         // API Error Codes
@@ -254,6 +257,7 @@ const i18n = {
         hoursAgo: '{hours} ore fa',
         daysAgo: '{days} giorni fa',
         help: 'Aiuto',
+        webhooks: 'Webhook',
         toggleTheme: 'Cambia Tema',
         switchLanguage: 'Cambia Lingua',
         // API Error Codes
@@ -323,6 +327,7 @@ const i18n = {
         hoursAgo: 'il y a {hours} heures',
         daysAgo: 'il y a {days} jours',
         help: 'Aide',
+        webhooks: 'Webhooks',
         toggleTheme: 'Changer le Thème',
         switchLanguage: 'Changer la Langue',
         // API Error Codes
@@ -392,6 +397,7 @@ const i18n = {
         hoursAgo: '{hours}시간 전',
         daysAgo: '{days}일 전',
         help: '도움말',
+        webhooks: '웹훅',
         toggleTheme: '테마 전환',
         switchLanguage: '언어 전환',
         // API Error Codes
@@ -461,6 +467,7 @@ const i18n = {
         hoursAgo: '{hours}時間前',
         daysAgo: '{days}日前',
         help: 'ヘルプ',
+        webhooks: 'Webhook',
         toggleTheme: 'テーマを切り替え',
         switchLanguage: '言語を切り替え',
         // API Error Codes
@@ -1062,6 +1069,12 @@ function updateUI() {
     
     const deleteAllBtn = document.getElementById('deleteAllBtn');
     if (deleteAllBtn) deleteAllBtn.textContent = t('deleteAll');
+
+    const webhookBtn = document.getElementById('webhookBtn');
+    if (webhookBtn) {
+        webhookBtn.textContent = t('webhooks');
+        webhookBtn.title = t('webhooks');
+    }
 
     const helpBtn = document.getElementById('helpBtn');
     if (helpBtn) {

--- a/web/assets.go
+++ b/web/assets.go
@@ -3,7 +3,7 @@ package webassets
 
 import "embed"
 
-// files contains every asset required by the inbox and local help pages.
+// files contains every asset required by OwlMail's embedded browser pages.
 //
 //go:embed *.css *.html *.js
 var files embed.FS

--- a/web/assets_test.go
+++ b/web/assets_test.go
@@ -18,6 +18,9 @@ func TestRequiredAssetsAreEmbedded(t *testing.T) {
 		{name: "help.html", contains: []byte("OwlMail Help")},
 		{name: "help.css", contains: []byte(".help-shell")},
 		{name: "help.js", contains: []byte("applyLanguage")},
+		{name: "webhooks.html", contains: []byte("Webhook Configurator")},
+		{name: "webhooks.css", contains: []byte(".webhook-workspace")},
+		{name: "webhooks.js", contains: []byte("parseConfigText")},
 	}
 
 	for _, tt := range tests {

--- a/web/help.html
+++ b/web/help.html
@@ -116,6 +116,7 @@ SMTP_SECURE=false</code></pre>
                         <div><h3>Server-side webhooks</h3><p>Webhook forwarding runs even when no browser is open. Targets can filter mail, send custom JSON or text, add authentication headers and HMAC signatures, and retry transient failures.</p></div>
                     </div>
                     <aside class="note"><strong>Browser requirement:</strong> notifications need HTTPS or a trusted local origin such as <code>http://localhost</code>. If permission was denied, allow OwlMail in the browser's site settings first.</aside>
+                    <p><a href="/webhooks">Open the local Webhook Configurator</a> to build, import, validate, and download this JSON without sending configuration data to a server.</p>
                     <h3>Minimal webhook configuration</h3>
                     <pre><code>{
   "version": 1,
@@ -248,6 +249,7 @@ SMTP_SECURE=false</code></pre>
                         <div><h3>服务端 Webhook</h3><p>即使没有打开浏览器，Webhook 转发也会运行。目标支持过滤邮件、发送自定义 JSON 或文本、添加鉴权请求头与 HMAC 签名，并对临时故障进行有限重试。</p></div>
                     </div>
                     <aside class="note"><strong>浏览器要求：</strong>通知需要 HTTPS 或 <code>http://localhost</code> 等受信任的本地来源。如果曾拒绝权限，应先在浏览器的网站设置中允许 OwlMail。</aside>
+                    <p><a href="/webhooks">打开本地 Webhook 配置生成器</a>，可在不上传配置数据的情况下生成、导入、校验并下载 JSON。</p>
                     <h3>最小 Webhook 配置</h3>
                     <pre><code>{
   "version": 1,

--- a/web/index.html
+++ b/web/index.html
@@ -14,6 +14,7 @@
                 <h1>🦉 OwlMail</h1>
                 <div class="header-actions">
                     <select id="langSelect" class="lang-select" title="Switch Language"></select>
+                    <a id="webhookBtn" class="btn btn-secondary btn-link" href="/webhooks">Webhooks</a>
                     <a id="helpBtn" class="btn btn-secondary btn-link" href="/help" target="_blank" rel="noopener">Help</a>
                     <button id="themeToggle" class="btn btn-secondary" title="Toggle Theme">🌙</button>
                     <button id="notificationToggle" class="btn btn-secondary notification-toggle" type="button" aria-pressed="false" title="Enable browser notifications">🔕 Notifications off</button>

--- a/web/webhooks.css
+++ b/web/webhooks.css
@@ -1,0 +1,626 @@
+.webhook-page {
+    max-width: 1500px;
+}
+
+.webhook-header .header-content {
+    margin-bottom: 0;
+}
+
+.webhook-brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: #2c3e50;
+    font-size: 24px;
+    font-weight: 700;
+    text-decoration: none;
+}
+
+.icon-button {
+    min-width: 44px;
+    padding-inline: 12px;
+}
+
+.webhook-hero,
+.webhook-panel {
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.webhook-hero {
+    margin-bottom: 20px;
+    padding: 28px 30px;
+}
+
+.webhook-eyebrow,
+.panel-kicker {
+    color: #3498db;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+}
+
+.webhook-hero h1 {
+    margin: 5px 0 8px;
+    color: #2c3e50;
+    font-size: clamp(26px, 4vw, 38px);
+    line-height: 1.2;
+}
+
+.webhook-hero > p:not(.webhook-eyebrow) {
+    max-width: 850px;
+    color: #5f6f7f;
+}
+
+.local-note {
+    display: flex;
+    gap: 6px;
+    margin-top: 18px;
+    padding: 12px 14px;
+    border-left: 4px solid #27ae60;
+    border-radius: 4px;
+    background: #edf9f2;
+    color: #285b3d;
+    font-size: 14px;
+}
+
+.webhook-workspace {
+    display: grid;
+    grid-template-columns: minmax(0, 1.35fr) minmax(340px, 0.65fr);
+    gap: 20px;
+    align-items: start;
+}
+
+.webhook-panel {
+    padding: 24px;
+}
+
+.panel-heading,
+.panel-actions,
+.subsection-heading,
+.output-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.panel-heading {
+    justify-content: space-between;
+    margin-bottom: 20px;
+}
+
+.panel-heading h2 {
+    margin-top: 2px;
+    color: #2c3e50;
+    font-size: 22px;
+}
+
+.compact-heading {
+    align-items: flex-start;
+    margin-bottom: 14px;
+}
+
+.count-badge,
+.validation-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 30px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 700;
+    white-space: nowrap;
+}
+
+.count-badge {
+    background: #edf3f7;
+    color: #52677a;
+}
+
+.validation-badge.is-valid {
+    background: #e8f7ef;
+    color: #1e7d4c;
+}
+
+.validation-badge.is-warning {
+    background: #fff5dc;
+    color: #8a6515;
+}
+
+.validation-badge.is-invalid {
+    background: #fdecea;
+    color: #a93226;
+}
+
+.target-list {
+    display: grid;
+    gap: 18px;
+}
+
+.target-card {
+    min-width: 0;
+    padding: 20px;
+    border: 1px solid #dce4ea;
+    border-radius: 8px;
+    background: #fbfcfd;
+}
+
+.target-heading {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 18px;
+}
+
+.target-heading h3 {
+    color: #2c3e50;
+    font-size: 18px;
+}
+
+.remove-target,
+.remove-header {
+    background: transparent;
+    color: #c0392b;
+    border: 1px solid #e5b8b3;
+}
+
+.remove-target:disabled {
+    visibility: hidden;
+}
+
+.field-grid,
+.filter-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px;
+}
+
+.field-wide {
+    grid-column: span 2;
+}
+
+.form-field {
+    display: grid;
+    gap: 6px;
+    min-width: 0;
+    color: #34495e;
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.form-field b {
+    color: #e74c3c;
+}
+
+.form-field input,
+.form-field select,
+.form-field textarea,
+.import-input,
+.config-output,
+.header-row input {
+    width: 100%;
+    padding: 10px 11px;
+    border: 1px solid #ccd6de;
+    border-radius: 4px;
+    background: #fff;
+    color: #2c3e50;
+    font: inherit;
+    font-weight: 400;
+    line-height: 1.45;
+}
+
+.form-field textarea,
+.import-input,
+.config-output {
+    resize: vertical;
+}
+
+.form-field input:focus,
+.form-field select:focus,
+.form-field textarea:focus,
+.import-input:focus,
+.config-output:focus,
+.header-row input:focus {
+    outline: none;
+    border-color: #3498db;
+    box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.16);
+}
+
+.form-field small,
+.subsection-heading p,
+.muted-copy {
+    color: #778899;
+    font-size: 12px;
+    font-weight: 400;
+}
+
+.code-input,
+.activation-hint code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+}
+
+.advanced-options {
+    margin-top: 18px;
+    border-top: 1px solid #e1e7eb;
+}
+
+.advanced-options summary {
+    padding: 16px 0 0;
+    color: #2980b9;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 700;
+}
+
+.advanced-content {
+    display: grid;
+    gap: 20px;
+    padding-top: 18px;
+}
+
+.subsection {
+    padding: 16px;
+    border: 1px solid #e1e7eb;
+    border-radius: 6px;
+    background: #fff;
+}
+
+.subsection-heading {
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 12px;
+}
+
+.subsection-heading h3 {
+    color: #34495e;
+    font-size: 15px;
+}
+
+.header-list {
+    display: grid;
+    gap: 8px;
+}
+
+.header-row {
+    display: grid;
+    grid-template-columns: minmax(130px, 0.75fr) minmax(180px, 1.25fr) auto;
+    gap: 8px;
+}
+
+.remove-header {
+    min-width: 42px;
+    padding-inline: 10px;
+    font-size: 19px;
+    line-height: 1;
+}
+
+.output-column {
+    display: grid;
+    gap: 20px;
+}
+
+.output-panel {
+    position: sticky;
+    top: 20px;
+}
+
+.field-label {
+    display: block;
+    margin-bottom: 6px;
+    color: #34495e;
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.import-input,
+.config-output {
+    display: block;
+    font-size: 12px;
+}
+
+.drop-zone {
+    display: grid;
+    gap: 3px;
+    margin: 12px 0;
+    padding: 16px;
+    border: 2px dashed #bdcbd5;
+    border-radius: 6px;
+    color: #52677a;
+    text-align: center;
+    cursor: pointer;
+    transition: border-color 0.2s, background-color 0.2s;
+}
+
+.drop-zone span {
+    color: #7f8c8d;
+    font-size: 12px;
+}
+
+.drop-zone:hover,
+.drop-zone:focus,
+.drop-zone.is-dragging {
+    outline: none;
+    border-color: #3498db;
+    background: #f0f8fd;
+}
+
+.full-button {
+    width: 100%;
+}
+
+.muted-copy {
+    margin-top: 8px;
+}
+
+.import-status {
+    margin-top: 10px;
+    color: #1e7d4c;
+    font-size: 12px;
+}
+
+.import-status.is-error {
+    color: #a93226;
+}
+
+.import-status ul {
+    margin: 5px 0 0 18px;
+}
+
+.validation-summary {
+    margin-bottom: 12px;
+    padding: 10px 12px;
+    border-radius: 4px;
+    background: #f4f7f9;
+    color: #52677a;
+    font-size: 13px;
+}
+
+.validation-summary:empty {
+    display: none;
+}
+
+.validation-summary ul {
+    margin: 6px 0 0 18px;
+}
+
+.validation-summary.is-invalid {
+    background: #fdecea;
+    color: #922b21;
+}
+
+.validation-summary.is-warning {
+    background: #fff7e6;
+    color: #7d5d16;
+}
+
+.config-output {
+    min-height: 440px;
+    background: #18232d;
+    color: #e8f0f5;
+    line-height: 1.55;
+}
+
+.output-actions {
+    justify-content: flex-end;
+    margin-top: 12px;
+}
+
+.activation-hint {
+    margin-top: 12px;
+    color: #708090;
+    font-size: 12px;
+    text-align: right;
+}
+
+.action-status {
+    min-height: 18px;
+    margin-top: 8px;
+    color: #1e7d4c;
+    font-size: 12px;
+    text-align: right;
+}
+
+.action-status.is-error {
+    color: #a93226;
+}
+
+.activation-hint code {
+    word-break: break-all;
+}
+
+.visually-hidden {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
+}
+
+body.dark-theme .webhook-brand,
+body.dark-theme .webhook-hero h1,
+body.dark-theme .panel-heading h2,
+body.dark-theme .target-heading h3,
+body.dark-theme .subsection-heading h3 {
+    color: #e0e0e0;
+}
+
+body.dark-theme .webhook-hero,
+body.dark-theme .webhook-panel {
+    background: #2d2d2d;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+body.dark-theme .webhook-hero > p:not(.webhook-eyebrow),
+body.dark-theme .form-field small,
+body.dark-theme .subsection-heading p,
+body.dark-theme .muted-copy,
+body.dark-theme .activation-hint,
+body.dark-theme .action-status {
+    color: #aaa;
+}
+
+body.dark-theme .action-status.is-error {
+    color: #ffc5bf;
+}
+
+body.dark-theme .import-status {
+    color: #8be0b2;
+}
+
+body.dark-theme .import-status.is-error {
+    color: #ffc5bf;
+}
+
+body.dark-theme .local-note {
+    border-left-color: #58c888;
+    background: #213a2c;
+    color: #bfe8cf;
+}
+
+body.dark-theme .count-badge {
+    background: #3b4650;
+    color: #d6e0e6;
+}
+
+body.dark-theme .target-card {
+    border-color: #4a4a4a;
+    background: #252525;
+}
+
+body.dark-theme .form-field,
+body.dark-theme .field-label {
+    color: #d0d0d0;
+}
+
+body.dark-theme .form-field input,
+body.dark-theme .form-field select,
+body.dark-theme .form-field textarea,
+body.dark-theme .import-input,
+body.dark-theme .header-row input {
+    border-color: #555;
+    background: #3d3d3d;
+    color: #e0e0e0;
+}
+
+body.dark-theme .advanced-options {
+    border-top-color: #444;
+}
+
+body.dark-theme .subsection {
+    border-color: #454545;
+    background: #2d2d2d;
+}
+
+body.dark-theme .drop-zone {
+    border-color: #596873;
+    color: #d0d0d0;
+}
+
+body.dark-theme .drop-zone:hover,
+body.dark-theme .drop-zone:focus,
+body.dark-theme .drop-zone.is-dragging {
+    border-color: #3498db;
+    background: #283842;
+}
+
+body.dark-theme .drop-zone span {
+    color: #aaa;
+}
+
+body.dark-theme .validation-summary {
+    background: #3a434a;
+    color: #d8e1e6;
+}
+
+body.dark-theme .validation-summary.is-invalid {
+    background: #4a2927;
+    color: #ffc5bf;
+}
+
+body.dark-theme .validation-summary.is-warning {
+    background: #44391f;
+    color: #ffe3a3;
+}
+
+@media (max-width: 1050px) {
+    .webhook-workspace {
+        grid-template-columns: 1fr;
+    }
+
+    .output-panel {
+        position: static;
+    }
+}
+
+@media (max-width: 768px) {
+    .webhook-hero,
+    .webhook-panel {
+        padding: 20px;
+    }
+
+    .panel-heading,
+    .subsection-heading {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .panel-actions {
+        width: 100%;
+        flex-wrap: wrap;
+    }
+
+    .field-grid,
+    .filter-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .field-wide {
+        grid-column: auto;
+    }
+
+    .header-row {
+        grid-template-columns: 1fr auto;
+    }
+
+    .header-row input[data-header="value"] {
+        grid-column: 1 / -1;
+        grid-row: 2;
+    }
+
+    .header-row .remove-header {
+        grid-column: 2;
+        grid-row: 1;
+    }
+
+    .local-note {
+        display: block;
+    }
+}
+
+@media (max-width: 480px) {
+    .webhook-page {
+        padding: 10px;
+    }
+
+    .webhook-hero,
+    .webhook-panel,
+    .target-card {
+        padding: 16px;
+    }
+
+    .output-actions {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .output-actions .btn {
+        width: 100%;
+    }
+}

--- a/web/webhooks.html
+++ b/web/webhooks.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en" data-language="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Build, import, validate, and download OwlMail webhook forwarding configuration.">
+    <title>OwlMail Webhook Configurator</title>
+    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="/webhooks.css">
+</head>
+<body class="light-theme">
+    <div class="container webhook-page">
+        <header class="header webhook-header">
+            <div class="header-content">
+                <a class="webhook-brand" href="/" aria-label="OwlMail inbox">🦉 <span>OwlMail</span></a>
+                <nav class="header-actions" aria-label="Page controls">
+                    <label class="visually-hidden" for="webhookLanguage" data-i18n="language">Language</label>
+                    <select id="webhookLanguage" class="lang-select" aria-label="Language">
+                        <option value="en">English</option>
+                        <option value="zh-CN">简体中文</option>
+                    </select>
+                    <button id="webhookTheme" class="btn btn-secondary icon-button" type="button" data-i18n-title="toggleTheme" aria-label="Toggle theme">🌙</button>
+                    <a class="btn btn-secondary btn-link" href="/help" data-i18n="help">Help</a>
+                    <a class="btn btn-primary btn-link" href="/" data-i18n="backToInbox">Back to inbox</a>
+                </nav>
+            </div>
+        </header>
+
+        <main>
+            <section class="webhook-hero">
+                <p class="webhook-eyebrow" data-i18n="eyebrow">WEBHOOK CONFIGURATION</p>
+                <h1 data-i18n="pageTitle">Build a webhook configuration</h1>
+                <p data-i18n="pageDescription">Create targets visually or import an existing JSON file, inspect every rule, and download a configuration ready for OwlMail.</p>
+                <div class="local-note" role="note">
+                    <strong data-i18n="localOnlyTitle">Local-only editor.</strong>
+                    <span data-i18n="localOnlyBody">Configuration stays in this browser and is never sent to OwlMail. Download the JSON, mount it into the server, and restart OwlMail to activate it.</span>
+                </div>
+            </section>
+
+            <div class="webhook-workspace">
+                <section class="webhook-panel editor-panel" aria-labelledby="targetsHeading">
+                    <div class="panel-heading">
+                        <div>
+                            <p class="panel-kicker" data-i18n="builderKicker">CONFIGURATION BUILDER</p>
+                            <h2 id="targetsHeading" data-i18n="targets">Targets</h2>
+                        </div>
+                        <div class="panel-actions">
+                            <span id="targetCount" class="count-badge">0 / 32</span>
+                            <button id="loadExample" class="btn btn-secondary" type="button" data-i18n="loadExample">Load example</button>
+                            <button id="addTarget" class="btn btn-primary" type="button" data-i18n="addTarget">Add target</button>
+                        </div>
+                    </div>
+                    <div id="targetList" class="target-list"></div>
+                </section>
+
+                <aside class="output-column">
+                    <section class="webhook-panel import-panel" aria-labelledby="importHeading">
+                        <div class="panel-heading compact-heading">
+                            <div>
+                                <p class="panel-kicker" data-i18n="importKicker">EXISTING CONFIGURATION</p>
+                                <h2 id="importHeading" data-i18n="importTitle">Import and inspect</h2>
+                            </div>
+                        </div>
+                        <label class="field-label" for="importInput" data-i18n="importLabel">Paste JSON</label>
+                        <textarea id="importInput" class="import-input code-input" rows="8" spellcheck="false" data-i18n-placeholder="importPlaceholder" placeholder='{"version":1,"targets":[...]}'></textarea>
+                        <input id="configFile" class="visually-hidden" type="file" accept="application/json,.json">
+                        <label id="dropZone" class="drop-zone" for="configFile" tabindex="0">
+                            <strong data-i18n="dropTitle">Drop a JSON file here</strong>
+                            <span data-i18n="dropBody">or choose a file (maximum 1 MiB)</span>
+                        </label>
+                        <button id="parseImport" class="btn btn-primary full-button" type="button" data-i18n="parseImport">Parse and replace targets</button>
+                        <div id="importStatus" class="import-status" role="status" aria-live="polite"></div>
+                        <p class="muted-copy" data-i18n="replaceWarning">A successful import replaces the targets currently shown in the builder.</p>
+                    </section>
+
+                    <section class="webhook-panel output-panel" aria-labelledby="outputHeading">
+                        <div class="panel-heading compact-heading">
+                            <div>
+                                <p class="panel-kicker" data-i18n="outputKicker">LIVE OUTPUT</p>
+                                <h2 id="outputHeading" data-i18n="outputTitle">Generated JSON</h2>
+                            </div>
+                            <span id="validationBadge" class="validation-badge is-invalid" data-i18n="invalid">Needs attention</span>
+                        </div>
+                        <div id="validationSummary" class="validation-summary" role="status" aria-live="polite"></div>
+                        <label class="visually-hidden" for="configOutput" data-i18n="outputTitle">Generated JSON</label>
+                        <textarea id="configOutput" class="config-output code-input" rows="22" readonly spellcheck="false"></textarea>
+                        <div class="output-actions">
+                            <button id="copyConfig" class="btn btn-secondary" type="button" data-i18n="copy">Copy JSON</button>
+                            <button id="downloadConfig" class="btn btn-primary" type="button" data-i18n="download">Download webhooks.json</button>
+                        </div>
+                        <p id="actionStatus" class="action-status" role="status" aria-live="polite"></p>
+                        <p class="activation-hint"><code>./owlmail -webhook-config ./webhooks.json</code></p>
+                    </section>
+                </aside>
+            </div>
+        </main>
+    </div>
+
+    <template id="targetTemplate">
+        <article class="target-card">
+            <div class="target-heading">
+                <h3><span data-i18n="target">Target</span> <span data-role="target-number"></span></h3>
+                <button class="btn btn-danger remove-target" type="button" data-i18n="removeTarget">Remove</button>
+            </div>
+
+            <div class="field-grid">
+                <label class="form-field">
+                    <span><span data-i18n="name">Name</span> <b aria-hidden="true">*</b></span>
+                    <input type="text" data-field="name" maxlength="100" autocomplete="off" placeholder="primary">
+                </label>
+                <label class="form-field field-wide">
+                    <span><span data-i18n="url">Destination URL</span> <b aria-hidden="true">*</b></span>
+                    <input type="text" data-field="url" inputmode="url" autocomplete="url" placeholder="https://example.com/hooks/owlmail">
+                    <small data-i18n="envHint">Environment variables such as ${OWLMAIL_WEBHOOK_HOST} are supported.</small>
+                </label>
+                <label class="form-field">
+                    <span data-i18n="method">HTTP method</span>
+                    <select data-field="method">
+                        <option value="POST">POST</option>
+                        <option value="PUT">PUT</option>
+                        <option value="PATCH">PATCH</option>
+                    </select>
+                </label>
+                <label class="form-field">
+                    <span data-i18n="timeout">Timeout</span>
+                    <input type="text" data-field="timeout" autocomplete="off" placeholder="5s">
+                    <small data-i18n="timeoutHint">Go duration, greater than 0 and at most 1m.</small>
+                </label>
+                <label class="form-field">
+                    <span data-i18n="retries">Retries</span>
+                    <input type="number" data-field="retries" min="0" max="5" step="1" value="0">
+                </label>
+                <label class="form-field">
+                    <span data-i18n="contentType">Content type</span>
+                    <input type="text" data-field="contentType" autocomplete="off" placeholder="application/json">
+                </label>
+            </div>
+
+            <details class="advanced-options">
+                <summary data-i18n="advanced">Authentication, headers, filters, and body template</summary>
+                <div class="advanced-content">
+                    <label class="form-field">
+                        <span data-i18n="secret">HMAC secret</span>
+                        <input type="text" data-field="secret" autocomplete="off" placeholder="${OWLMAIL_WEBHOOK_SECRET}">
+                        <small data-i18n="secretHint">Use an environment variable instead of committing a real secret.</small>
+                    </label>
+
+                    <section class="subsection">
+                        <div class="subsection-heading">
+                            <div>
+                                <h3 data-i18n="headers">Request headers</h3>
+                                <p data-i18n="headersHint">Header values may reference environment variables.</p>
+                            </div>
+                            <button class="btn btn-secondary add-header" type="button" data-i18n="addHeader">Add header</button>
+                        </div>
+                        <div class="header-list" data-role="headers"></div>
+                    </section>
+
+                    <section class="subsection">
+                        <div class="subsection-heading">
+                            <div>
+                                <h3 data-i18n="filters">Match filters</h3>
+                                <p data-i18n="filtersHint">Fields are combined with AND. Put one case-insensitive * or ? wildcard pattern on each line.</p>
+                            </div>
+                        </div>
+                        <div class="filter-grid">
+                            <label class="form-field"><span data-i18n="matchFrom">From</span><textarea data-match="from" rows="3" placeholder="*@example.com"></textarea></label>
+                            <label class="form-field"><span data-i18n="matchTo">To</span><textarea data-match="to" rows="3" placeholder="alerts@example.com"></textarea></label>
+                            <label class="form-field"><span data-i18n="matchSubject">Subject</span><textarea data-match="subject" rows="3" placeholder="[staging]*"></textarea></label>
+                            <label class="form-field"><span data-i18n="matchText">Text body</span><textarea data-match="text" rows="3" placeholder="*build failed*"></textarea></label>
+                        </div>
+                    </section>
+
+                    <label class="form-field">
+                        <span data-i18n="bodyTemplate">Body template</span>
+                        <textarea class="code-input" data-field="bodyTemplate" rows="6" spellcheck="false" placeholder='{"subject":{{ json .Subject }}}'></textarea>
+                        <small data-i18n="templateHint">Leave empty for OwlMail's default JSON payload. Go template syntax is compiled when OwlMail starts.</small>
+                    </label>
+                </div>
+            </details>
+        </article>
+    </template>
+
+    <template id="headerTemplate">
+        <div class="header-row">
+            <input type="text" data-header="name" autocomplete="off" data-i18n-placeholder="headerName" data-i18n-title="headerName" placeholder="Header name" aria-label="Header name">
+            <input type="text" data-header="value" autocomplete="off" data-i18n-placeholder="headerValue" data-i18n-title="headerValue" placeholder="Header value" aria-label="Header value">
+            <button class="btn btn-danger remove-header" type="button" data-i18n-title="removeHeader" aria-label="Remove header">×</button>
+        </div>
+    </template>
+
+    <script src="/webhooks.js"></script>
+</body>
+</html>

--- a/web/webhooks.js
+++ b/web/webhooks.js
@@ -320,6 +320,13 @@
             if (isPlainObject(target) && isPlainObject(target.match)) {
                 target.match = canonicalizeKnownObject(target.match, matchKeys);
             }
+            if (isPlainObject(target) && isPlainObject(target.headers)) {
+                const headers = Object.create(null);
+                Object.entries(target.headers).forEach(([name, value]) => {
+                    headers[name] = value === null ? '' : value;
+                });
+                target.headers = headers;
+            }
             return target;
         });
         return result;

--- a/web/webhooks.js
+++ b/web/webhooks.js
@@ -290,6 +290,27 @@
         return value.replace(goTrimSpacePattern, '');
     }
 
+    function normalizeJSONSurrogates(value) {
+        let normalized = '';
+        for (let index = 0; index < value.length; index++) {
+            const codeUnit = value.charCodeAt(index);
+            if (codeUnit >= 0xD800 && codeUnit <= 0xDBFF) {
+                const next = value.charCodeAt(index + 1);
+                if (next >= 0xDC00 && next <= 0xDFFF) {
+                    normalized += value[index] + value[index + 1];
+                    index++;
+                } else {
+                    normalized += '\uFFFD';
+                }
+            } else if (codeUnit >= 0xDC00 && codeUnit <= 0xDFFF) {
+                normalized += '\uFFFD';
+            } else {
+                normalized += value[index];
+            }
+        }
+        return normalized;
+    }
+
     function addUnknownFieldIssues(value, allowed, path, errors) {
         Object.keys(value).forEach((key) => {
             if (!allowed.has(key)) {
@@ -654,7 +675,7 @@
             if (target.name === undefined || target.name === null || target.name === '') errors.push(issue('nameRequired', path + '.name'));
             else errors.push(issue('fieldString', path + '.name'));
         } else {
-            const name = goTrimSpace(target.name);
+            const name = goTrimSpace(normalizeJSONSurrogates(target.name));
             if (!name) {
                 errors.push(issue('nameRequired', path + '.name'));
             } else if (utf8ByteLength(name) > 100 || /[\r\n]/.test(name)) {
@@ -776,7 +797,7 @@
             version: 1,
             targets: config.targets.map((source) => {
                 const target = {
-                    name: goTrimSpace(source.name),
+                    name: goTrimSpace(normalizeJSONSurrogates(source.name)),
                     url: source.url
                 };
                 const method = typeof source.method === 'string' ? goTrimSpace(source.method).toUpperCase() : '';
@@ -1016,7 +1037,7 @@
     function readTargetCard(card, index, formErrors) {
         const value = (selector) => card.querySelector(selector).value;
         const target = {
-            name: goTrimSpace(value('[data-field="name"]')),
+            name: goTrimSpace(normalizeJSONSurrogates(value('[data-field="name"]'))),
             url: value('[data-field="url"]')
         };
         const method = goTrimSpace(value('[data-field="method"]')).toUpperCase();

--- a/web/webhooks.js
+++ b/web/webhooks.js
@@ -103,6 +103,7 @@
             maxTargets: 'A configuration can contain at most 32 targets.',
             importedVersionNormalized: 'Version 0 or an omitted version is exported as version 1.',
             invalidJSON: 'JSON could not be parsed: {detail}',
+            duplicateJSONKey: 'Duplicate JSON key "{name}" is not allowed.',
             importEmpty: 'Paste JSON or choose a file first.',
             invalidRoot: 'The top-level value must be a JSON object.',
             unknownField: 'Unknown field "{field}".',
@@ -211,6 +212,7 @@
             maxTargets: '一份配置最多包含 32 个目标。',
             importedVersionNormalized: '导入的版本为 0 或未填写时，导出结果会规范为版本 1。',
             invalidJSON: '无法解析 JSON：{detail}',
+            duplicateJSONKey: '不允许重复的 JSON 键“{name}”。',
             importEmpty: '请先粘贴 JSON 或选择文件。',
             invalidRoot: '顶层内容必须是 JSON 对象。',
             unknownField: '存在未知字段“{field}”。',
@@ -349,6 +351,89 @@
             }
         }
         return normalized;
+    }
+
+    function findDuplicateJSONKey(text) {
+        let index = 0;
+        let duplicate = null;
+
+        function skipWhitespace() {
+            while (index < text.length && /[\u0009\u000A\u000D\u0020]/.test(text[index])) index++;
+        }
+
+        function readString() {
+            const start = index++;
+            while (index < text.length) {
+                if (text[index] === '\\') {
+                    index += 2;
+                } else if (text[index] === '"') {
+                    index++;
+                    break;
+                } else {
+                    index++;
+                }
+            }
+            return normalizeJSONSurrogates(JSON.parse(text.slice(start, index)));
+        }
+
+        function scanValue() {
+            skipWhitespace();
+            if (text[index] === '{') {
+                scanObject();
+            } else if (text[index] === '[') {
+                scanArray();
+            } else if (text[index] === '"') {
+                readString();
+            } else {
+                while (index < text.length && !/[\u0009\u000A\u000D\u0020,\]}]/.test(text[index])) index++;
+            }
+        }
+
+        function scanObject() {
+            const names = new Set();
+            index++;
+            skipWhitespace();
+            if (text[index] === '}') {
+                index++;
+                return;
+            }
+            while (index < text.length) {
+                skipWhitespace();
+                const name = readString();
+                if (duplicate === null && names.has(name)) duplicate = name;
+                names.add(name);
+                skipWhitespace();
+                index++;
+                scanValue();
+                skipWhitespace();
+                if (text[index] === '}') {
+                    index++;
+                    return;
+                }
+                index++;
+            }
+        }
+
+        function scanArray() {
+            index++;
+            skipWhitespace();
+            if (text[index] === ']') {
+                index++;
+                return;
+            }
+            while (index < text.length) {
+                scanValue();
+                skipWhitespace();
+                if (text[index] === ']') {
+                    index++;
+                    return;
+                }
+                index++;
+            }
+        }
+
+        scanValue();
+        return duplicate;
     }
 
     function addUnknownFieldIssues(value, allowed, path, errors) {
@@ -526,6 +611,32 @@
             value.slice(authorityEnd);
     }
 
+    function schemeCanResolveHTTP(scheme) {
+        const escapePattern = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const asciiLower = (value) => value.replace(/[A-Z]/g, (character) => character.toLowerCase());
+        const groups = new Map();
+        let groupIndex = 0;
+        let lastIndex = 0;
+        let pattern = '^';
+        environmentPattern.lastIndex = 0;
+        for (const match of scheme.matchAll(environmentPattern)) {
+            pattern += escapePattern(asciiLower(scheme.slice(lastIndex, match.index)));
+            let group = groups.get(match[0]);
+            if (group) {
+                pattern += '\\k<' + group + '>';
+            } else {
+                group = 'environment' + groupIndex++;
+                groups.set(match[0], group);
+                pattern += '(?<' + group + '>.+)';
+            }
+            lastIndex = match.index + match[0].length;
+        }
+        environmentPattern.lastIndex = 0;
+        pattern += escapePattern(asciiLower(scheme.slice(lastIndex))) + '$';
+        const matcher = new RegExp(pattern);
+        return matcher.test('http') || matcher.test('https');
+    }
+
     function validateURL(value, path, errors, warnings) {
         if (typeof value !== 'string') {
             if (value === undefined || value === null || value === '') errors.push(issue('urlRequired', path));
@@ -586,6 +697,10 @@
             const scheme = structuralValue.slice(0, schemeEnd);
             placeholderInScheme = environmentPattern.test(scheme);
             environmentPattern.lastIndex = 0;
+            if (placeholderInScheme && !schemeCanResolveHTTP(scheme)) {
+                errors.push(issue('urlScheme', path));
+                return;
+            }
         }
 
         const authorityStart = schemeEnd >= 0 ? schemeEnd + 3 : -1;
@@ -885,7 +1000,7 @@
         }
         let parsed;
         try {
-            parsed = canonicalizeConfigFields(JSON.parse(text));
+            parsed = JSON.parse(text);
         } catch (error) {
             return {
                 config: null,
@@ -893,6 +1008,24 @@
                 warnings: []
             };
         }
+        let duplicateKey;
+        try {
+            duplicateKey = findDuplicateJSONKey(text);
+        } catch (error) {
+            return {
+                config: null,
+                errors: [issue('invalidJSON', '', { detail: error && error.message ? error.message : String(error) })],
+                warnings: []
+            };
+        }
+        if (duplicateKey !== null) {
+            return {
+                config: null,
+                errors: [issue('duplicateJSONKey', '', { name: duplicateKey })],
+                warnings: []
+            };
+        }
+        parsed = canonicalizeConfigFields(parsed);
         const validation = validateConfig(parsed);
         if (validation.errors.length) return { config: null, ...validation };
         return { config: normalizeConfig(parsed), ...validation };

--- a/web/webhooks.js
+++ b/web/webhooks.js
@@ -571,9 +571,12 @@
                 candidate.startsWith(staticSchemePrefix));
             if (surrogatePrefix) {
                 const token = value.slice(firstEnvironmentOffset).match(leadingEnvironmentPattern)[0];
+                const remainder = value.slice(firstEnvironmentOffset + token.length);
+                const suffixOffset = remainder.search(/[/?#]/);
+                const structuralSuffix = suffixOffset < 0 ? '' : remainder.slice(suffixOffset);
                 structuralValue = value.slice(0, firstEnvironmentOffset) +
                     surrogatePrefix.slice(staticSchemePrefix.length) +
-                    value.slice(firstEnvironmentOffset + token.length);
+                    'placeholder.invalid' + structuralSuffix;
             }
         }
 

--- a/web/webhooks.js
+++ b/web/webhooks.js
@@ -284,6 +284,7 @@
     }
 
     const goTrimSpacePattern = /^[\u0009-\u000D\u0020\u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]+|[\u0009-\u000D\u0020\u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]+$/g;
+    const goLeadingSpacePattern = /^[\u0009-\u000D\u0020\u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]+/;
 
     function goTrimSpace(value) {
         return value.replace(goTrimSpacePattern, '');
@@ -448,7 +449,7 @@
             errors.push(issue('urlRequired', path));
             return;
         }
-        if (value !== value.trim() || value !== goTrimSpace(value) || /[\u0000-\u001F\u007F]/.test(value)) {
+        if (value !== value.trimStart() || goLeadingSpacePattern.test(value) || /[\u0000-\u001F\u007F]/.test(value)) {
             errors.push(issue('urlInvalid', path));
             return;
         }
@@ -943,7 +944,7 @@
         const value = (selector) => card.querySelector(selector).value;
         const target = {
             name: goTrimSpace(value('[data-field="name"]')),
-            url: goTrimSpace(value('[data-field="url"]'))
+            url: value('[data-field="url"]')
         };
         const method = goTrimSpace(value('[data-field="method"]')).toUpperCase();
         const timeout = goTrimSpace(value('[data-field="timeout"]'));

--- a/web/webhooks.js
+++ b/web/webhooks.js
@@ -278,6 +278,12 @@
         return value !== null && typeof value === 'object' && !Array.isArray(value);
     }
 
+    const goTrimSpacePattern = /^[\u0009-\u000D\u0020\u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]+|[\u0009-\u000D\u0020\u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]+$/g;
+
+    function goTrimSpace(value) {
+        return value.replace(goTrimSpacePattern, '');
+    }
+
     function addUnknownFieldIssues(value, allowed, path, errors) {
         Object.keys(value).forEach((key) => {
             if (!allowed.has(key)) {
@@ -433,7 +439,7 @@
             errors.push(issue('urlRequired', path));
             return;
         }
-        if (value !== value.trim() || /[\u0000-\u001F\u007F]/.test(value)) {
+        if (value !== value.trim() || value !== goTrimSpace(value) || /[\u0000-\u001F\u007F]/.test(value)) {
             errors.push(issue('urlInvalid', path));
             return;
         }
@@ -534,7 +540,7 @@
             }
             patterns.forEach((pattern, index) => {
                 const patternPath = path + '.' + field + '[' + index + ']';
-                if (pattern.trim() === '') errors.push(issue('matchPattern', patternPath));
+                if (goTrimSpace(pattern) === '') errors.push(issue('matchPattern', patternPath));
                 else if (!validGlobPattern(pattern.toLowerCase())) errors.push(issue('matchGlob', patternPath, { pattern }));
             });
         });
@@ -552,7 +558,7 @@
             if (target.name === undefined || target.name === null || target.name === '') errors.push(issue('nameRequired', path + '.name'));
             else errors.push(issue('fieldString', path + '.name'));
         } else {
-            const name = target.name.trim();
+            const name = goTrimSpace(target.name);
             if (!name) {
                 errors.push(issue('nameRequired', path + '.name'));
             } else if (utf8ByteLength(name) > 100 || /[\r\n]/.test(name)) {
@@ -566,7 +572,7 @@
         validateURL(target.url, path + '.url', errors, warnings);
 
         if (validateOptionalString(target.method, path + '.method', errors) && target.method) {
-            const method = target.method.trim().toUpperCase();
+            const method = goTrimSpace(target.method).toUpperCase();
             if (!['POST', 'PUT', 'PATCH'].includes(method)) errors.push(issue('unsupportedMethod', path + '.method'));
         }
 
@@ -577,7 +583,7 @@
                 const canonicalNames = new Set();
                 Object.entries(target.headers).forEach(([name, value]) => {
                     const headerPath = path + '.headers.' + name;
-                    const canonicalName = name.trim().toLowerCase();
+                    const canonicalName = goTrimSpace(name).toLowerCase();
                     if (!headerNamePattern.test(name)) errors.push(issue('headerNameInvalid', headerPath, { name }));
                     if (canonicalName === 'host' || canonicalName === 'content-length') {
                         errors.push(issue('managedHeader', headerPath, { name }));
@@ -665,11 +671,11 @@
             version: 1,
             targets: config.targets.map((source) => {
                 const target = {
-                    name: source.name.trim(),
+                    name: goTrimSpace(source.name),
                     url: source.url
                 };
-                const method = typeof source.method === 'string' ? source.method.trim().toUpperCase() : '';
-                const contentType = typeof source.contentType === 'string' ? source.contentType.trim() : '';
+                const method = typeof source.method === 'string' ? goTrimSpace(source.method).toUpperCase() : '';
+                const contentType = typeof source.contentType === 'string' ? goTrimSpace(source.contentType) : '';
                 if (method && method !== 'POST') target.method = method;
                 if (source.headers && Object.keys(source.headers).length) target.headers = { ...source.headers };
                 if (contentType && contentType !== 'application/json') target.contentType = contentType;
@@ -713,7 +719,7 @@
     }
 
     function splitPatternLines(value) {
-        return value.split(/\r?\n/).filter((line) => line.trim() !== '');
+        return value.split(/\r?\n/).filter((line) => goTrimSpace(line) !== '');
     }
 
     function patternsFromEditorValue(value, preserved) {
@@ -905,13 +911,13 @@
     function readTargetCard(card, index, formErrors) {
         const value = (selector) => card.querySelector(selector).value;
         const target = {
-            name: value('[data-field="name"]').trim(),
-            url: value('[data-field="url"]').trim()
+            name: goTrimSpace(value('[data-field="name"]')),
+            url: goTrimSpace(value('[data-field="url"]'))
         };
-        const method = value('[data-field="method"]').trim().toUpperCase();
-        const timeout = value('[data-field="timeout"]').trim();
-        const retriesText = value('[data-field="retries"]').trim();
-        const contentType = value('[data-field="contentType"]').trim();
+        const method = goTrimSpace(value('[data-field="method"]')).toUpperCase();
+        const timeout = goTrimSpace(value('[data-field="timeout"]'));
+        const retriesText = goTrimSpace(value('[data-field="retries"]'));
+        const contentType = goTrimSpace(value('[data-field="contentType"]'));
         const secretControl = card.querySelector('[data-field="secret"]');
         const bodyTemplateControl = card.querySelector('[data-field="bodyTemplate"]');
         const secret = editorValueFromPreserved(secretControl.value, preservedControlValues.get(secretControl));
@@ -930,7 +936,7 @@
         const headers = createHeaderMap();
         const headerNames = new Set();
         card.querySelectorAll('.header-row').forEach((row) => {
-            const name = row.querySelector('[data-header="name"]').value.trim();
+            const name = goTrimSpace(row.querySelector('[data-header="name"]').value);
             const headerValue = row.querySelector('[data-header="value"]').value;
             if (!name && !headerValue) return;
             const canonical = name.toLowerCase();
@@ -1188,7 +1194,8 @@
         patternsFromEditorValue,
         editorValueFromPreserved,
         createHeaderMap,
-        authorityHasInvalidHost
+        authorityHasInvalidHost,
+        goTrimSpace
     };
     if (typeof window !== 'undefined') window.OwlMailWebhookConfigurator = publicAPI;
     if (typeof document !== 'undefined') document.addEventListener('DOMContentLoaded', initialize);

--- a/web/webhooks.js
+++ b/web/webhooks.js
@@ -127,8 +127,10 @@
             headerNameInvalid: 'Header name "{name}" is invalid.',
             managedHeader: 'Header "{name}" is managed by the HTTP client.',
             headerNewline: 'Header values cannot contain newlines.',
+            headerControl: 'Header values cannot contain ASCII control characters other than horizontal tabs.',
             duplicateHeader: 'Header "{name}" is entered more than once.',
             contentTypeNewline: 'Content type cannot contain newlines.',
+            contentTypeControl: 'Content type cannot contain ASCII control characters other than horizontal tabs.',
             timeoutInvalid: 'Use a Go duration such as 500ms, 5s, or 1m.',
             timeoutRange: 'Timeout must be greater than 0 and no more than 1m.',
             retriesInvalid: 'Retries must be an integer from 0 to 5.',
@@ -233,8 +235,10 @@
             headerNameInvalid: '请求头名称“{name}”无效。',
             managedHeader: '请求头“{name}”由 HTTP 客户端管理。',
             headerNewline: '请求头的值不能包含换行。',
+            headerControl: '请求头的值不能包含横向制表符以外的 ASCII 控制字符。',
             duplicateHeader: '请求头“{name}”被重复填写。',
             contentTypeNewline: '内容类型不能包含换行。',
+            contentTypeControl: '内容类型不能包含横向制表符以外的 ASCII 控制字符。',
             timeoutInvalid: '请使用 500ms、5s 或 1m 这样的 Go duration。',
             timeoutRange: '超时时间必须大于 0 且不超过 1m。',
             retriesInvalid: '重试次数必须是 0 到 5 的整数。',
@@ -385,6 +389,10 @@
         return true;
     }
 
+    function hasInvalidHTTPFieldValue(value) {
+        return /[\u0000-\u0008\u000A-\u001F\u007F]/.test(value);
+    }
+
     const goHostASCIICharacters = new Set(
         "!$&'()*+,-.0123456789:;<=>ABCDEFGHIJKLMNOPQRSTUVWXYZ[]_abcdefghijklmnopqrstuvwxyz~"
     );
@@ -450,7 +458,9 @@
             warnings.push(issue('envRuntime', path));
             if (exactEnvironmentPattern.test(value)) return;
         }
-        const percentValidationValue = value.replace(environmentPattern, '00');
+        const rawQueryOrFragment = value.search(/[?#]/);
+        const percentValidationSource = rawQueryOrFragment < 0 ? value : value.slice(0, rawQueryOrFragment);
+        const percentValidationValue = percentValidationSource.replace(environmentPattern, '00');
         if (/%(?![0-9A-Fa-f]{2})/.test(percentValidationValue)) {
             errors.push(issue('urlInvalid', path));
             return;
@@ -602,6 +612,7 @@
                     if (typeof value !== 'string') errors.push(issue('headerValueString', headerPath));
                     else {
                         if (/[\r\n]/.test(value)) errors.push(issue('headerNewline', headerPath));
+                        else if (hasInvalidHTTPFieldValue(value)) errors.push(issue('headerControl', headerPath));
                         if (environmentPattern.test(value)) warnings.push(issue('envRuntime', headerPath));
                         environmentPattern.lastIndex = 0;
                     }
@@ -610,8 +621,12 @@
         }
 
         if (validateOptionalString(target.contentType, path + '.contentType', errors) &&
-            typeof target.contentType === 'string' && /[\r\n]/.test(target.contentType)) {
-            errors.push(issue('contentTypeNewline', path + '.contentType'));
+            typeof target.contentType === 'string') {
+            if (/[\r\n]/.test(target.contentType)) {
+                errors.push(issue('contentTypeNewline', path + '.contentType'));
+            } else if (hasInvalidHTTPFieldValue(target.contentType)) {
+                errors.push(issue('contentTypeControl', path + '.contentType'));
+            }
         }
 
         if (validateOptionalString(target.secret, path + '.secret', errors) &&
@@ -1202,7 +1217,8 @@
         editorValueFromPreserved,
         createHeaderMap,
         authorityHasInvalidHost,
-        goTrimSpace
+        goTrimSpace,
+        hasInvalidHTTPFieldValue
     };
     if (typeof window !== 'undefined') window.OwlMailWebhookConfigurator = publicAPI;
     if (typeof document !== 'undefined') document.addEventListener('DOMContentLoaded', initialize);

--- a/web/webhooks.js
+++ b/web/webhooks.js
@@ -452,6 +452,19 @@
         return separator < 0 ? -1 : hostPortStart + separator;
     }
 
+    function transformURLAuthority(value, transform) {
+        const schemeEnd = value.indexOf('://');
+        if (schemeEnd < 0) return value;
+        const authorityStart = schemeEnd + 3;
+        const authorityEndOffset = value.slice(authorityStart).search(/[/?#]/);
+        const authorityEnd = authorityEndOffset < 0
+            ? value.length
+            : authorityStart + authorityEndOffset;
+        return value.slice(0, authorityStart) +
+            transform(value.slice(authorityStart, authorityEnd)) +
+            value.slice(authorityEnd);
+    }
+
     function validateURL(value, path, errors, warnings) {
         if (typeof value !== 'string') {
             if (value === undefined || value === null || value === '') errors.push(issue('urlRequired', path));
@@ -486,20 +499,35 @@
             return;
         }
 
-        const schemeEnd = value.indexOf('://');
+        let structuralValue = value;
+        if (!value.includes('://') && environmentMatches) {
+            const firstEnvironmentOffset = value.search(environmentPattern);
+            environmentPattern.lastIndex = 0;
+            const staticSchemePrefix = value.slice(0, firstEnvironmentOffset).toLowerCase();
+            const surrogatePrefix = ['http://', 'https://'].find((candidate) =>
+                candidate.startsWith(staticSchemePrefix));
+            if (surrogatePrefix) {
+                const token = value.slice(firstEnvironmentOffset).match(leadingEnvironmentPattern)[0];
+                structuralValue = value.slice(0, firstEnvironmentOffset) +
+                    surrogatePrefix.slice(staticSchemePrefix.length) +
+                    value.slice(firstEnvironmentOffset + token.length);
+            }
+        }
+
+        const schemeEnd = structuralValue.indexOf('://');
         let placeholderInScheme = false;
         if (environmentMatches && schemeEnd >= 0) {
-            const scheme = value.slice(0, schemeEnd);
+            const scheme = structuralValue.slice(0, schemeEnd);
             placeholderInScheme = environmentPattern.test(scheme);
             environmentPattern.lastIndex = 0;
         }
 
         const authorityStart = schemeEnd >= 0 ? schemeEnd + 3 : -1;
-        const authorityEndOffset = authorityStart >= 0 ? value.slice(authorityStart).search(/[/?#]/) : -1;
+        const authorityEndOffset = authorityStart >= 0 ? structuralValue.slice(authorityStart).search(/[/?#]/) : -1;
         const authorityEnd = authorityStart < 0
             ? -1
-            : (authorityEndOffset < 0 ? value.length : authorityStart + authorityEndOffset);
-        const authority = authorityStart < 0 ? '' : value.slice(authorityStart, authorityEnd);
+            : (authorityEndOffset < 0 ? structuralValue.length : authorityStart + authorityEndOffset);
+        const authority = authorityStart < 0 ? '' : structuralValue.slice(authorityStart, authorityEnd);
         const authorityHasUserInfo = authority.includes('@');
         const authorityIsStaticallyEmpty = authorityStart >= 0 && authorityStart === authorityEnd;
         const bracketStart = authority.indexOf('[');
@@ -507,6 +535,8 @@
         const bracketedHostHasEnvironment = bracketStart >= 0 && bracketEnd > bracketStart &&
             environmentPattern.test(authority.slice(bracketStart + 1, bracketEnd));
         environmentPattern.lastIndex = 0;
+        const bracketedHostHasZone = bracketStart >= 0 && bracketEnd > bracketStart &&
+            authority.slice(bracketStart + 1, bracketEnd).includes('%25');
         const portSeparator = authorityPortSeparator(authority);
         const portHasEnvironment = portSeparator >= 0 && environmentPattern.test(authority.slice(portSeparator + 1));
         environmentPattern.lastIndex = 0;
@@ -522,15 +552,15 @@
         if (authorityIsStaticallyEmpty) {
             errors.push(issue('urlHost', path));
         }
-        const parseableValue = value.replace(environmentPattern, (token, offset) => {
+        const parseableValue = structuralValue.replace(environmentPattern, (token, offset) => {
             if (placeholderInScheme && offset < schemeEnd) return 'https';
             if (offset < authorityStart || offset >= authorityEnd) return 'value';
-            const authorityPrefix = value.slice(authorityStart, offset);
+            const authorityPrefix = structuralValue.slice(authorityStart, offset);
             const afterCredentials = authorityPrefix.slice(authorityPrefix.lastIndexOf('@') + 1);
             const openingBracket = afterCredentials.lastIndexOf('[');
             const closingBracket = afterCredentials.lastIndexOf(']');
             if (openingBracket > closingBracket) {
-                const authoritySuffix = value.slice(offset + token.length, authorityEnd);
+                const authoritySuffix = structuralValue.slice(offset + token.length, authorityEnd);
                 const bracketEnd = authoritySuffix.indexOf(']');
                 if (bracketEnd >= 0) {
                     const beforePlaceholder = afterCredentials.slice(openingBracket + 1);
@@ -551,18 +581,24 @@
             browserParseValue = browserParseValue.replace(/\[[^\]]*\]/, '[::1]');
         }
         if (portHasEnvironment) {
-            const browserSchemeEnd = browserParseValue.indexOf('://');
-            const browserAuthorityStart = browserSchemeEnd + 3;
-            const browserAuthorityEndOffset = browserParseValue.slice(browserAuthorityStart).search(/[/?#]/);
-            const browserAuthorityEnd = browserAuthorityEndOffset < 0
-                ? browserParseValue.length
-                : browserAuthorityStart + browserAuthorityEndOffset;
-            const browserAuthority = browserParseValue.slice(browserAuthorityStart, browserAuthorityEnd);
-            const browserPortSeparator = authorityPortSeparator(browserAuthority);
-            browserParseValue = browserParseValue.slice(0, browserAuthorityStart + browserPortSeparator + 1) +
-                '443' + browserParseValue.slice(browserAuthorityEnd);
+            browserParseValue = transformURLAuthority(browserParseValue, (browserAuthority) => {
+                const browserPortSeparator = authorityPortSeparator(browserAuthority);
+                return browserAuthority.slice(0, browserPortSeparator + 1) + '443';
+            });
         }
-        browserParseValue = browserParseValue.replace(/\[([^\]]+?)%25[^\]]*\]/g, '[$1]');
+        if (bracketedHostHasZone) {
+            browserParseValue = transformURLAuthority(browserParseValue, (browserAuthority) => {
+                const browserBracketStart = browserAuthority.indexOf('[');
+                const browserBracketEnd = browserAuthority.indexOf(']', browserBracketStart + 1);
+                if (browserBracketStart < 0 || browserBracketEnd < 0) return browserAuthority;
+                const browserAddress = browserAuthority.slice(browserBracketStart + 1, browserBracketEnd);
+                const zoneDelimiter = browserAddress.indexOf('%25');
+                if (zoneDelimiter < 0) return browserAuthority;
+                return browserAuthority.slice(0, browserBracketStart + 1) +
+                    browserAddress.slice(0, zoneDelimiter) +
+                    browserAuthority.slice(browserBracketEnd);
+            });
+        }
         let parsed;
         try {
             parsed = new URL(browserParseValue);
@@ -630,9 +666,12 @@
 
         validateURL(target.url, path + '.url', errors, warnings);
 
-        if (validateOptionalString(target.method, path + '.method', errors) && target.method) {
+        if (validateOptionalString(target.method, path + '.method', errors) &&
+            typeof target.method === 'string') {
             const method = goTrimSpace(target.method).toUpperCase();
-            if (!['POST', 'PUT', 'PATCH'].includes(method)) errors.push(issue('unsupportedMethod', path + '.method'));
+            if (method && !['POST', 'PUT', 'PATCH'].includes(method)) {
+                errors.push(issue('unsupportedMethod', path + '.method'));
+            }
         }
 
         if (target.headers !== undefined && target.headers !== null) {
@@ -664,9 +703,10 @@
 
         if (validateOptionalString(target.contentType, path + '.contentType', errors) &&
             typeof target.contentType === 'string') {
-            if (/[\r\n]/.test(target.contentType)) {
+            const contentType = goTrimSpace(target.contentType);
+            if (/[\r\n]/.test(contentType)) {
                 errors.push(issue('contentTypeNewline', path + '.contentType'));
-            } else if (hasInvalidHTTPFieldValue(target.contentType)) {
+            } else if (hasInvalidHTTPFieldValue(contentType)) {
                 errors.push(issue('contentTypeControl', path + '.contentType'));
             }
         }

--- a/web/webhooks.js
+++ b/web/webhooks.js
@@ -253,6 +253,7 @@
     const headerNamePattern = /^[!#$%&'*+\-.^_\`|~0-9A-Za-z]+$/;
     const environmentPattern = /\$\{[A-Za-z_][A-Za-z0-9_]*\}/g;
     const exactEnvironmentPattern = /^\$\{[A-Za-z_][A-Za-z0-9_]*\}$/;
+    const leadingEnvironmentPattern = /^\$\{[A-Za-z_][A-Za-z0-9_]*\}/;
 
     let currentLanguage = 'en';
     let lastGeneratedJSON = '';
@@ -452,6 +453,12 @@
         const percentValidationValue = value.replace(environmentPattern, '00');
         if (/%(?![0-9A-Fa-f]{2})/.test(percentValidationValue)) {
             errors.push(issue('urlInvalid', path));
+            return;
+        }
+
+        const leadingEnvironment = value.match(leadingEnvironmentPattern);
+        if (leadingEnvironment && !value.slice(leadingEnvironment[0].length).startsWith('://')) {
+            if (value.includes('#')) errors.push(issue('urlFragment', path));
             return;
         }
 

--- a/web/webhooks.js
+++ b/web/webhooks.js
@@ -378,6 +378,21 @@
         return true;
     }
 
+    function authorityHasInvalidHostEscape(authority) {
+        const hostPort = authority.slice(authority.lastIndexOf('@') + 1);
+        if (hostPort.startsWith('[')) {
+            const bracketEnd = hostPort.indexOf(']');
+            if (bracketEnd < 0) return false;
+            const address = hostPort.slice(1, bracketEnd);
+            const zoneDelimiter = address.indexOf('%25');
+            const addressWithoutZone = zoneDelimiter < 0 ? address : address.slice(0, zoneDelimiter);
+            return addressWithoutZone.includes('%');
+        }
+        const portSeparator = hostPort.lastIndexOf(':');
+        const host = portSeparator < 0 ? hostPort : hostPort.slice(0, portSeparator);
+        return host.includes('%');
+    }
+
     function validateURL(value, path, errors, warnings) {
         if (typeof value !== 'string') {
             if (value === undefined || value === null || value === '') errors.push(issue('urlRequired', path));
@@ -421,6 +436,10 @@
         const authorityHasUserInfo = authority.includes('@');
         const authorityIsStaticallyEmpty = authorityStart >= 0 && authorityStart === authorityEnd;
         if (authorityHasUserInfo) errors.push(issue('urlCredentials', path));
+        if (authorityHasInvalidHostEscape(authority)) {
+            errors.push(issue('urlInvalid', path));
+            return;
+        }
         if (authority.includes('\\')) {
             errors.push(issue('urlInvalid', path));
             return;
@@ -1137,7 +1156,8 @@
         validGlobPattern,
         patternsFromEditorValue,
         editorValueFromPreserved,
-        createHeaderMap
+        createHeaderMap,
+        authorityHasInvalidHostEscape
     };
     if (typeof window !== 'undefined') window.OwlMailWebhookConfigurator = publicAPI;
     if (typeof document !== 'undefined') document.addEventListener('DOMContentLoaded', initialize);

--- a/web/webhooks.js
+++ b/web/webhooks.js
@@ -113,7 +113,7 @@
             targetObject: 'Each target must be an object.',
             fieldString: 'This field must be a string.',
             nameRequired: 'A target name is required.',
-            nameInvalid: 'The name must be at most 100 characters and contain no newlines.',
+            nameInvalid: 'The name must be at most 100 UTF-8 bytes and contain no newlines.',
             duplicateName: 'Target name "{name}" is duplicated.',
             urlRequired: 'A destination URL is required.',
             urlInvalid: 'The destination URL is invalid.',
@@ -219,7 +219,7 @@
             targetObject: '每个目标必须是对象。',
             fieldString: '该字段必须是字符串。',
             nameRequired: '必须填写目标名称。',
-            nameInvalid: '名称不能超过 100 个字符，也不能包含换行。',
+            nameInvalid: '名称不能超过 100 个 UTF-8 字节，也不能包含换行。',
             duplicateName: '目标名称“{name}”重复。',
             urlRequired: '必须填写目标 URL。',
             urlInvalid: '目标 URL 无效。',
@@ -313,31 +313,54 @@
         return position === duration.length && position > 0 ? sign * total : Number.NaN;
     }
 
+    function nextCodePointIndex(value, index) {
+        const codePoint = value.codePointAt(index);
+        return index + (codePoint > 0xFFFF ? 2 : 1);
+    }
+
+    function readClassCharacter(pattern, index) {
+        if (index >= pattern.length || pattern[index] === '-' || pattern[index] === ']') return -1;
+        if (pattern[index] === '\\') {
+            index++;
+            if (index >= pattern.length) return -1;
+        }
+        return nextCodePointIndex(pattern, index);
+    }
+
     function validGlobPattern(pattern) {
-        let inClass = false;
-        let classCharacters = 0;
-        for (let index = 0; index < pattern.length; index++) {
+        for (let index = 0; index < pattern.length;) {
             const character = pattern[index];
             if (character === '\\') {
                 if (index + 1 >= pattern.length) return false;
-                index++;
-                if (inClass) classCharacters++;
+                index = nextCodePointIndex(pattern, index + 1);
                 continue;
             }
-            if (!inClass && character === '[') {
-                inClass = true;
-                classCharacters = 0;
-                if (pattern[index + 1] === '^') index++;
+            if (character !== '[') {
+                index = nextCodePointIndex(pattern, index);
                 continue;
             }
-            if (inClass && character === ']') {
-                if (classCharacters === 0) return false;
-                inClass = false;
-                continue;
+
+            index++;
+            if (pattern[index] === '^') index++;
+            let ranges = 0;
+            let closed = false;
+            while (index < pattern.length) {
+                if (pattern[index] === ']' && ranges > 0) {
+                    index++;
+                    closed = true;
+                    break;
+                }
+                index = readClassCharacter(pattern, index);
+                if (index < 0) return false;
+                if (pattern[index] === '-') {
+                    index = readClassCharacter(pattern, index + 1);
+                    if (index < 0) return false;
+                }
+                ranges++;
             }
-            if (inClass) classCharacters++;
+            if (!closed) return false;
         }
-        return !inClass;
+        return true;
     }
 
     function validateOptionalString(value, path, errors) {
@@ -365,7 +388,36 @@
             if (exactEnvironmentPattern.test(value)) return;
         }
 
-        const parseableValue = value.replace(environmentPattern, 'placeholder.invalid');
+        const schemeEnd = value.indexOf('://');
+        if (environmentMatches && schemeEnd >= 0) {
+            const scheme = value.slice(0, schemeEnd);
+            const placeholderInScheme = environmentPattern.test(scheme);
+            environmentPattern.lastIndex = 0;
+            if (placeholderInScheme) {
+                const authorityStart = schemeEnd + 3;
+                const authorityEndOffset = value.slice(authorityStart).search(/[/?#]/);
+                const authorityEnd = authorityEndOffset < 0 ? value.length : authorityStart + authorityEndOffset;
+                const authority = value.slice(authorityStart, authorityEnd);
+                if (authority.includes('@')) errors.push(issue('urlCredentials', path));
+                if (value.includes('#')) errors.push(issue('urlFragment', path));
+                return;
+            }
+        }
+
+        const authorityStart = schemeEnd >= 0 ? schemeEnd + 3 : -1;
+        const authorityEndOffset = authorityStart >= 0 ? value.slice(authorityStart).search(/[/?#]/) : -1;
+        const authorityEnd = authorityStart < 0
+            ? -1
+            : (authorityEndOffset < 0 ? value.length : authorityStart + authorityEndOffset);
+        const parseableValue = value.replace(environmentPattern, (token, offset) => {
+            if (offset < authorityStart || offset >= authorityEnd) return 'value';
+            const authorityPrefix = value.slice(authorityStart, offset);
+            const afterCredentials = authorityPrefix.slice(authorityPrefix.lastIndexOf('@') + 1);
+            const closingBracket = afterCredentials.lastIndexOf(']');
+            const lastColon = afterCredentials.lastIndexOf(':');
+            if (lastColon > closingBracket) return '443';
+            return 'placeholder.invalid';
+        });
         let parsed;
         try {
             parsed = new URL(parseableValue);
@@ -416,7 +468,7 @@
             const name = target.name.trim();
             if (!name) {
                 errors.push(issue('nameRequired', path + '.name'));
-            } else if (Array.from(name).length > 100 || /[\r\n]/.test(name)) {
+            } else if (utf8ByteLength(name) > 100 || /[\r\n]/.test(name)) {
                 errors.push(issue('nameInvalid', path + '.name'));
             } else {
                 if (names.has(name)) errors.push(issue('duplicateName', path + '.name', { name }));
@@ -555,10 +607,7 @@
         if (typeof text !== 'string' || text.trim() === '') {
             return { config: null, errors: [issue('importEmpty')], warnings: [] };
         }
-        const byteLength = typeof TextEncoder === 'function'
-            ? new TextEncoder().encode(text).byteLength
-            : unescape(encodeURIComponent(text)).length;
-        if (byteLength > MAX_CONFIG_BYTES) {
+        if (utf8ByteLength(text) > MAX_CONFIG_BYTES) {
             return { config: null, errors: [issue('configTooLarge')], warnings: [] };
         }
         let parsed;
@@ -578,6 +627,21 @@
 
     function splitPatternLines(value) {
         return value.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+    }
+
+    function utf8ByteLength(value) {
+        return typeof TextEncoder === 'function'
+            ? new TextEncoder().encode(value).byteLength
+            : unescape(encodeURIComponent(value)).length;
+    }
+
+    function validateGeneratedConfig(config) {
+        const validation = validateConfig(config);
+        const json = JSON.stringify(config, null, 2) + '\n';
+        if (utf8ByteLength(json) > MAX_CONFIG_BYTES) {
+            validation.errors.push(issue('configTooLarge'));
+        }
+        return { ...validation, json };
     }
 
     function applyTranslations(root) {
@@ -821,9 +885,9 @@
     function renderOutput() {
         if (!elements.targetList) return;
         const collected = collectConfig();
-        const validation = validateConfig(collected.config);
+        const validation = validateGeneratedConfig(collected.config);
         const errors = collected.errors.concat(validation.errors);
-        lastGeneratedJSON = JSON.stringify(collected.config, null, 2) + '\n';
+        lastGeneratedJSON = validation.json;
         elements.output.value = lastGeneratedJSON;
         renderValidation(errors, validation.warnings);
     }
@@ -999,6 +1063,8 @@
         parseDurationMilliseconds,
         validateConfig,
         normalizeConfig,
+        validateGeneratedConfig,
+        utf8ByteLength,
         validGlobPattern
     };
     if (typeof window !== 'undefined') window.OwlMailWebhookConfigurator = publicAPI;

--- a/web/webhooks.js
+++ b/web/webhooks.js
@@ -378,19 +378,49 @@
         return true;
     }
 
-    function authorityHasInvalidHostEscape(authority) {
-        const hostPort = authority.slice(authority.lastIndexOf('@') + 1);
+    const goHostASCIICharacters = new Set(
+        "!$&'()*+,-.0123456789:;<=>ABCDEFGHIJKLMNOPQRSTUVWXYZ[]_abcdefghijklmnopqrstuvwxyz~"
+    );
+    goHostASCIICharacters.add('"');
+
+    function validGoHostString(value, zone) {
+        for (let index = 0; index < value.length; index++) {
+            const character = value[index];
+            if (character === '%') {
+                const token = value.slice(index, index + 3);
+                if (!/^%[0-9A-Fa-f]{2}$/.test(token)) return false;
+                const decoded = Number.parseInt(token.slice(1), 16);
+                if (zone) {
+                    if (token.toLowerCase() !== '%25' && decoded !== 0x20 &&
+                        decoded < 0x80 && !goHostASCIICharacters.has(String.fromCharCode(decoded))) {
+                        return false;
+                    }
+                } else if (decoded < 0x80 && token.toLowerCase() !== '%25') {
+                    return false;
+                }
+                index += 2;
+                continue;
+            }
+            if (character.charCodeAt(0) < 0x80 && !goHostASCIICharacters.has(character)) return false;
+        }
+        return true;
+    }
+
+    function authorityHasInvalidHost(authority) {
+        const staticAuthority = authority.replace(environmentPattern, 'placeholder');
+        const hostPort = staticAuthority.slice(staticAuthority.lastIndexOf('@') + 1);
         if (hostPort.startsWith('[')) {
             const bracketEnd = hostPort.indexOf(']');
             if (bracketEnd < 0) return false;
             const address = hostPort.slice(1, bracketEnd);
             const zoneDelimiter = address.indexOf('%25');
-            const addressWithoutZone = zoneDelimiter < 0 ? address : address.slice(0, zoneDelimiter);
-            return addressWithoutZone.includes('%');
+            if (zoneDelimiter < 0) return !validGoHostString(address, false);
+            return !validGoHostString(address.slice(0, zoneDelimiter), false) ||
+                !validGoHostString(address.slice(zoneDelimiter), true);
         }
         const portSeparator = hostPort.lastIndexOf(':');
         const host = portSeparator < 0 ? hostPort : hostPort.slice(0, portSeparator);
-        return host.includes('%');
+        return !validGoHostString(host, false);
     }
 
     function validateURL(value, path, errors, warnings) {
@@ -436,7 +466,7 @@
         const authorityHasUserInfo = authority.includes('@');
         const authorityIsStaticallyEmpty = authorityStart >= 0 && authorityStart === authorityEnd;
         if (authorityHasUserInfo) errors.push(issue('urlCredentials', path));
-        if (authorityHasInvalidHostEscape(authority)) {
+        if (authorityHasInvalidHost(authority)) {
             errors.push(issue('urlInvalid', path));
             return;
         }
@@ -467,9 +497,10 @@
             if (lastColon > closingBracket) return '443';
             return 'placeholder.invalid';
         });
+        const browserParseValue = parseableValue.replace(/\[([^\]]+?)%25[^\]]*\]/g, '[$1]');
         let parsed;
         try {
-            parsed = new URL(parseableValue);
+            parsed = new URL(browserParseValue);
         } catch (_) {
             errors.push(issue('urlInvalid', path));
             return;
@@ -1157,7 +1188,7 @@
         patternsFromEditorValue,
         editorValueFromPreserved,
         createHeaderMap,
-        authorityHasInvalidHostEscape
+        authorityHasInvalidHost
     };
     if (typeof window !== 'undefined') window.OwlMailWebhookConfigurator = publicAPI;
     if (typeof document !== 'undefined') document.addEventListener('DOMContentLoaded', initialize);

--- a/web/webhooks.js
+++ b/web/webhooks.js
@@ -387,6 +387,10 @@
             errors.push(issue('urlRequired', path));
             return;
         }
+        if (value !== value.trim() || /[\u0000-\u001F\u007F]/.test(value)) {
+            errors.push(issue('urlInvalid', path));
+            return;
+        }
 
         const environmentMatches = value.match(environmentPattern);
         if (environmentMatches) {
@@ -400,19 +404,11 @@
         }
 
         const schemeEnd = value.indexOf('://');
+        let placeholderInScheme = false;
         if (environmentMatches && schemeEnd >= 0) {
             const scheme = value.slice(0, schemeEnd);
-            const placeholderInScheme = environmentPattern.test(scheme);
+            placeholderInScheme = environmentPattern.test(scheme);
             environmentPattern.lastIndex = 0;
-            if (placeholderInScheme) {
-                const authorityStart = schemeEnd + 3;
-                const authorityEndOffset = value.slice(authorityStart).search(/[/?#]/);
-                const authorityEnd = authorityEndOffset < 0 ? value.length : authorityStart + authorityEndOffset;
-                const authority = value.slice(authorityStart, authorityEnd);
-                if (authority.includes('@')) errors.push(issue('urlCredentials', path));
-                if (value.includes('#')) errors.push(issue('urlFragment', path));
-                return;
-            }
         }
 
         const authorityStart = schemeEnd >= 0 ? schemeEnd + 3 : -1;
@@ -420,11 +416,26 @@
         const authorityEnd = authorityStart < 0
             ? -1
             : (authorityEndOffset < 0 ? value.length : authorityStart + authorityEndOffset);
+        const authorityIsStaticallyEmpty = authorityStart >= 0 && authorityStart === authorityEnd;
+        if (authorityIsStaticallyEmpty) {
+            errors.push(issue('urlHost', path));
+        }
         const parseableValue = value.replace(environmentPattern, (token, offset) => {
+            if (placeholderInScheme && offset < schemeEnd) return 'https';
             if (offset < authorityStart || offset >= authorityEnd) return 'value';
             const authorityPrefix = value.slice(authorityStart, offset);
             const afterCredentials = authorityPrefix.slice(authorityPrefix.lastIndexOf('@') + 1);
+            const openingBracket = afterCredentials.lastIndexOf('[');
             const closingBracket = afterCredentials.lastIndexOf(']');
+            if (openingBracket > closingBracket) {
+                const authoritySuffix = value.slice(offset + token.length, authorityEnd);
+                const bracketEnd = authoritySuffix.indexOf(']');
+                if (bracketEnd >= 0) {
+                    const beforePlaceholder = afterCredentials.slice(openingBracket + 1);
+                    const afterPlaceholder = authoritySuffix.slice(0, bracketEnd);
+                    return beforePlaceholder === '' && afterPlaceholder === '' ? '::1' : '1';
+                }
+            }
             const lastColon = afterCredentials.lastIndexOf(':');
             if (lastColon > closingBracket) return '443';
             return 'placeholder.invalid';
@@ -436,8 +447,13 @@
             errors.push(issue('urlInvalid', path));
             return;
         }
-        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') errors.push(issue('urlScheme', path));
-        if (!parsed.hostname) errors.push(issue('urlHost', path));
+        if (!placeholderInScheme && parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+            errors.push(issue('urlScheme', path));
+        }
+        if (schemeEnd < 0 && (parsed.protocol === 'http:' || parsed.protocol === 'https:')) {
+            errors.push(issue('urlHost', path));
+        }
+        if (!parsed.hostname && !authorityIsStaticallyEmpty) errors.push(issue('urlHost', path));
         if (parsed.username || parsed.password) errors.push(issue('urlCredentials', path));
         if (parsed.hash) errors.push(issue('urlFragment', path));
     }
@@ -645,6 +661,10 @@
         return splitPatternLines(value);
     }
 
+    function createHeaderMap() {
+        return Object.create(null);
+    }
+
     function utf8ByteLength(value) {
         return typeof TextEncoder === 'function'
             ? new TextEncoder().encode(value).byteLength
@@ -830,7 +850,7 @@
         if (secret) target.secret = secret;
         if (bodyTemplate) target.bodyTemplate = bodyTemplate;
 
-        const headers = {};
+        const headers = createHeaderMap();
         const headerNames = new Set();
         card.querySelectorAll('.header-row').forEach((row) => {
             const name = row.querySelector('[data-header="name"]').value.trim();
@@ -1088,7 +1108,8 @@
         validateGeneratedConfig,
         utf8ByteLength,
         validGlobPattern,
-        patternsFromEditorValue
+        patternsFromEditorValue,
+        createHeaderMap
     };
     if (typeof window !== 'undefined') window.OwlMailWebhookConfigurator = publicAPI;
     if (typeof document !== 'undefined') document.addEventListener('DOMContentLoaded', initialize);

--- a/web/webhooks.js
+++ b/web/webhooks.js
@@ -258,6 +258,7 @@
     let lastGeneratedJSON = '';
     let actionStatusTimer = null;
     let elements = {};
+    const preservedMatchPatterns = new WeakMap();
 
     function tr(key, params) {
         const table = translations[currentLanguage] || translations.en;
@@ -286,14 +287,15 @@
 
     function parseDurationMilliseconds(value) {
         if (typeof value !== 'string' || value === '') return null;
-        const unitMilliseconds = {
-            ns: 0.000001,
-            us: 0.001,
-            'µs': 0.001,
-            ms: 1,
-            s: 1000,
-            m: 60000,
-            h: 3600000
+        const unitNanoseconds = {
+            ns: 1,
+            us: 1000,
+            'µs': 1000,
+            'μs': 1000,
+            ms: 1000000,
+            s: 1000000000,
+            m: 60000000000,
+            h: 3600000000000
         };
         let sign = 1;
         let duration = value;
@@ -301,16 +303,20 @@
             sign = duration[0] === '-' ? -1 : 1;
             duration = duration.slice(1);
         }
-        const partPattern = /(\d+(?:\.\d*)?|\.\d+)(ns|us|µs|ms|s|m|h)/gy;
-        let total = 0;
+        const partPattern = /(\d+(?:\.\d*)?|\.\d+)(ns|us|µs|μs|ms|s|m|h)/gy;
+        let totalNanoseconds = 0;
         let position = 0;
         let match;
         while ((match = partPattern.exec(duration)) !== null) {
             if (match.index !== position) return Number.NaN;
-            total += Number(match[1]) * unitMilliseconds[match[2]];
+            const partNanoseconds = Math.trunc(Number(match[1]) * unitNanoseconds[match[2]]);
+            if (!Number.isFinite(partNanoseconds)) return sign * Number.POSITIVE_INFINITY;
+            totalNanoseconds += partNanoseconds;
             position = partPattern.lastIndex;
         }
-        return position === duration.length && position > 0 ? sign * total : Number.NaN;
+        return position === duration.length && position > 0
+            ? sign * totalNanoseconds / 1000000
+            : Number.NaN;
     }
 
     function nextCodePointIndex(value, index) {
@@ -386,6 +392,11 @@
         if (environmentMatches) {
             warnings.push(issue('envRuntime', path));
             if (exactEnvironmentPattern.test(value)) return;
+        }
+        const percentValidationValue = value.replace(environmentPattern, '00');
+        if (/%(?![0-9A-Fa-f]{2})/.test(percentValidationValue)) {
+            errors.push(issue('urlInvalid', path));
+            return;
         }
 
         const schemeEnd = value.indexOf('://');
@@ -626,7 +637,12 @@
     }
 
     function splitPatternLines(value) {
-        return value.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+        return value.split(/\r?\n/).filter((line) => line.trim() !== '');
+    }
+
+    function patternsFromEditorValue(value, preserved) {
+        if (preserved && value === preserved.displayValue) return preserved.patterns.slice();
+        return splitPatternLines(value);
     }
 
     function utf8ByteLength(value) {
@@ -750,7 +766,12 @@
 
         matchKeys.forEach((field) => {
             const patterns = source.match && Array.isArray(source.match[field]) ? source.match[field] : [];
-            card.querySelector('[data-match="' + field + '"]').value = patterns.join('\n');
+            const control = card.querySelector('[data-match="' + field + '"]');
+            control.value = patterns.join('\n');
+            preservedMatchPatterns.set(control, {
+                displayValue: control.value,
+                patterns: patterns.slice()
+            });
         });
 
         const headerContainer = card.querySelector('[data-role="headers"]');
@@ -826,7 +847,8 @@
 
         const match = {};
         matchKeys.forEach((field) => {
-            const patterns = splitPatternLines(card.querySelector('[data-match="' + field + '"]').value);
+            const control = card.querySelector('[data-match="' + field + '"]');
+            const patterns = patternsFromEditorValue(control.value, preservedMatchPatterns.get(control));
             if (patterns.length) match[field] = patterns;
         });
         if (Object.keys(match).length) target.match = match;
@@ -1065,7 +1087,8 @@
         normalizeConfig,
         validateGeneratedConfig,
         utf8ByteLength,
-        validGlobPattern
+        validGlobPattern,
+        patternsFromEditorValue
     };
     if (typeof window !== 'undefined') window.OwlMailWebhookConfigurator = publicAPI;
     if (typeof document !== 'undefined') document.addEventListener('DOMContentLoaded', initialize);

--- a/web/webhooks.js
+++ b/web/webhooks.js
@@ -1,0 +1,1006 @@
+(() => {
+    'use strict';
+
+    const MAX_CONFIG_BYTES = 1024 * 1024;
+    const MAX_TARGETS = 32;
+    const MAX_RETRIES = 5;
+    const MAX_TIMEOUT_MS = 60 * 1000;
+    const DEFAULT_TARGET = {
+        name: 'primary',
+        url: 'https://example.com/hooks/owlmail',
+        method: 'POST',
+        contentType: 'application/json',
+        timeout: '5s',
+        retries: 0
+    };
+    const EXAMPLE_CONFIG = {
+        version: 1,
+        targets: [
+            {
+                name: 'build-alerts',
+                url: 'https://example.com/hooks/owlmail',
+                headers: {
+                    Authorization: 'Bearer ' + '$' + '{OWLMAIL_WEBHOOK_TOKEN}'
+                },
+                timeout: '10s',
+                retries: 2,
+                match: {
+                    to: ['alerts@example.com'],
+                    subject: ['[staging]*', '[production]*']
+                }
+            }
+        ]
+    };
+
+    const translations = {
+        en: {
+            language: 'Language',
+            toggleTheme: 'Toggle theme',
+            help: 'Help',
+            backToInbox: 'Back to inbox',
+            eyebrow: 'WEBHOOK CONFIGURATION',
+            pageTitle: 'Build a webhook configuration',
+            pageDescription: 'Create targets visually or import an existing JSON file, inspect every rule, and download a configuration ready for OwlMail.',
+            localOnlyTitle: 'Local-only editor.',
+            localOnlyBody: 'Configuration stays in this browser and is never sent to OwlMail. Download the JSON, mount it into the server, and restart OwlMail to activate it.',
+            builderKicker: 'CONFIGURATION BUILDER',
+            targets: 'Targets',
+            loadExample: 'Load example',
+            addTarget: 'Add target',
+            importKicker: 'EXISTING CONFIGURATION',
+            importTitle: 'Import and inspect',
+            importLabel: 'Paste JSON',
+            importPlaceholder: '{"version":1,"targets":[...]}',
+            dropTitle: 'Drop a JSON file here',
+            dropBody: 'or choose a file (maximum 1 MiB)',
+            parseImport: 'Parse and replace targets',
+            replaceWarning: 'A successful import replaces the targets currently shown in the builder.',
+            outputKicker: 'LIVE OUTPUT',
+            outputTitle: 'Generated JSON',
+            valid: 'Valid',
+            warning: 'Valid with notes',
+            invalid: 'Needs attention',
+            copy: 'Copy JSON',
+            download: 'Download webhooks.json',
+            target: 'Target',
+            removeTarget: 'Remove',
+            name: 'Name',
+            url: 'Destination URL',
+            envHint: 'Environment variables such as ' + '$' + '{OWLMAIL_WEBHOOK_HOST} are supported.',
+            method: 'HTTP method',
+            timeout: 'Timeout',
+            timeoutHint: 'Go duration, greater than 0 and at most 1m.',
+            retries: 'Retries',
+            contentType: 'Content type',
+            advanced: 'Authentication, headers, filters, and body template',
+            secret: 'HMAC secret',
+            secretHint: 'Use an environment variable instead of committing a real secret.',
+            headers: 'Request headers',
+            headersHint: 'Header values may reference environment variables.',
+            addHeader: 'Add header',
+            filters: 'Match filters',
+            filtersHint: 'Fields are combined with AND. Put one case-insensitive * or ? wildcard pattern on each line.',
+            matchFrom: 'From',
+            matchTo: 'To',
+            matchSubject: 'Subject',
+            matchText: 'Text body',
+            bodyTemplate: 'Body template',
+            templateHint: "Leave empty for OwlMail's default JSON payload. Go template syntax is compiled when OwlMail starts.",
+            headerName: 'Header name',
+            headerValue: 'Header value',
+            removeHeader: 'Remove header',
+            configReady: 'The configuration is ready to download.',
+            errorCount: '{count} error(s) must be fixed.',
+            warningCount: '{count} runtime note(s).',
+            importSuccess: 'Imported {count} target(s).',
+            importSuccessWithWarnings: 'Imported {count} target(s) with {warnings} runtime note(s).',
+            copied: 'Configuration copied.',
+            copyFailed: 'Could not copy automatically. Select the JSON and copy it manually.',
+            downloaded: 'Downloaded webhooks.json.',
+            fileTooLarge: 'The selected file exceeds 1 MiB.',
+            fileReadFailed: 'The selected file could not be read.',
+            configTooLarge: 'The configuration exceeds OwlMail’s 1 MiB limit.',
+            maxTargets: 'A configuration can contain at most 32 targets.',
+            importedVersionNormalized: 'Version 0 or an omitted version is exported as version 1.',
+            invalidJSON: 'JSON could not be parsed: {detail}',
+            importEmpty: 'Paste JSON or choose a file first.',
+            invalidRoot: 'The top-level value must be a JSON object.',
+            unknownField: 'Unknown field "{field}".',
+            invalidVersion: 'Version must be 0, 1, or omitted.',
+            targetsRequired: 'At least one target is required.',
+            targetsArray: 'Targets must be an array.',
+            tooManyTargets: 'No more than 32 targets are allowed.',
+            targetObject: 'Each target must be an object.',
+            fieldString: 'This field must be a string.',
+            nameRequired: 'A target name is required.',
+            nameInvalid: 'The name must be at most 100 characters and contain no newlines.',
+            duplicateName: 'Target name "{name}" is duplicated.',
+            urlRequired: 'A destination URL is required.',
+            urlInvalid: 'The destination URL is invalid.',
+            urlScheme: 'The URL scheme must be http or https.',
+            urlHost: 'The URL must contain a host.',
+            urlCredentials: 'URL credentials are not allowed; use request headers.',
+            urlFragment: 'URL fragments are not allowed.',
+            unsupportedMethod: 'Only POST, PUT, and PATCH are supported.',
+            headersObject: 'Headers must be a JSON object.',
+            headerValueString: 'Every header value must be a string.',
+            headerNameInvalid: 'Header name "{name}" is invalid.',
+            managedHeader: 'Header "{name}" is managed by the HTTP client.',
+            headerNewline: 'Header values cannot contain newlines.',
+            duplicateHeader: 'Header "{name}" is entered more than once.',
+            contentTypeNewline: 'Content type cannot contain newlines.',
+            timeoutInvalid: 'Use a Go duration such as 500ms, 5s, or 1m.',
+            timeoutRange: 'Timeout must be greater than 0 and no more than 1m.',
+            retriesInvalid: 'Retries must be an integer from 0 to 5.',
+            matchObject: 'Match must be a JSON object.',
+            matchArray: 'Each match field must be an array of strings.',
+            matchPattern: 'Match patterns cannot be empty.',
+            matchGlob: 'Wildcard pattern "{pattern}" is malformed.',
+            envRuntime: 'Environment placeholders are resolved and checked when OwlMail starts.',
+            templateRuntime: 'The Go body template is compiled and checked when OwlMail starts.'
+        },
+        'zh-CN': {
+            language: '语言',
+            toggleTheme: '切换主题',
+            help: '帮助',
+            backToInbox: '返回收件箱',
+            eyebrow: 'WEBHOOK 配置',
+            pageTitle: '生成 Webhook 配置',
+            pageDescription: '可视化创建目标，或导入已有 JSON 文件，检查每条规则，并下载可供 OwlMail 使用的配置。',
+            localOnlyTitle: '仅在本地编辑。',
+            localOnlyBody: '配置只在当前浏览器中处理，不会发送给 OwlMail。下载 JSON、挂载到服务器并重启 OwlMail 后才会生效。',
+            builderKicker: '配置生成器',
+            targets: '转发目标',
+            loadExample: '载入示例',
+            addTarget: '增加目标',
+            importKicker: '已有配置',
+            importTitle: '导入并解析',
+            importLabel: '粘贴 JSON',
+            importPlaceholder: '{"version":1,"targets":[...]}',
+            dropTitle: '拖入 JSON 文件',
+            dropBody: '或点击选择文件（最大 1 MiB）',
+            parseImport: '解析并替换当前目标',
+            replaceWarning: '导入成功后，将替换生成器中当前显示的全部目标。',
+            outputKicker: '实时输出',
+            outputTitle: '生成的 JSON',
+            valid: '配置有效',
+            warning: '有效，但有提示',
+            invalid: '需要修正',
+            copy: '复制 JSON',
+            download: '下载 webhooks.json',
+            target: '目标',
+            removeTarget: '移除',
+            name: '名称',
+            url: '目标 URL',
+            envHint: '支持 ' + '$' + '{OWLMAIL_WEBHOOK_HOST} 形式的环境变量。',
+            method: 'HTTP 方法',
+            timeout: '超时时间',
+            timeoutHint: '使用 Go duration 格式，必须大于 0 且不超过 1m。',
+            retries: '重试次数',
+            contentType: '内容类型',
+            advanced: '鉴权、请求头、过滤规则和正文模板',
+            secret: 'HMAC 密钥',
+            secretHint: '建议引用环境变量，不要把真实密钥提交到配置仓库。',
+            headers: '请求头',
+            headersHint: '请求头的值可以引用环境变量。',
+            addHeader: '增加请求头',
+            filters: '匹配过滤器',
+            filtersHint: '不同字段之间为 AND；每行一个不区分大小写的 * 或 ? 通配模式。',
+            matchFrom: '发件人',
+            matchTo: '收件人',
+            matchSubject: '主题',
+            matchText: '文本正文',
+            bodyTemplate: '正文模板',
+            templateHint: '留空将使用 OwlMail 默认 JSON；Go 模板语法会在 OwlMail 启动时编译检查。',
+            headerName: '请求头名称',
+            headerValue: '请求头值',
+            removeHeader: '移除请求头',
+            configReady: '配置有效，可以复制或下载。',
+            errorCount: '需要修正 {count} 个错误。',
+            warningCount: '有 {count} 条运行时提示。',
+            importSuccess: '已导入 {count} 个目标。',
+            importSuccessWithWarnings: '已导入 {count} 个目标，并有 {warnings} 条运行时提示。',
+            copied: '配置已复制。',
+            copyFailed: '无法自动复制，请选中 JSON 后手动复制。',
+            downloaded: '已下载 webhooks.json。',
+            fileTooLarge: '所选文件超过 1 MiB。',
+            fileReadFailed: '无法读取所选文件。',
+            configTooLarge: '配置超过 OwlMail 的 1 MiB 限制。',
+            maxTargets: '一份配置最多包含 32 个目标。',
+            importedVersionNormalized: '导入的版本为 0 或未填写时，导出结果会规范为版本 1。',
+            invalidJSON: '无法解析 JSON：{detail}',
+            importEmpty: '请先粘贴 JSON 或选择文件。',
+            invalidRoot: '顶层内容必须是 JSON 对象。',
+            unknownField: '存在未知字段“{field}”。',
+            invalidVersion: 'version 只能是 0、1，或省略。',
+            targetsRequired: '至少需要一个目标。',
+            targetsArray: 'targets 必须是数组。',
+            tooManyTargets: '最多允许 32 个目标。',
+            targetObject: '每个目标必须是对象。',
+            fieldString: '该字段必须是字符串。',
+            nameRequired: '必须填写目标名称。',
+            nameInvalid: '名称不能超过 100 个字符，也不能包含换行。',
+            duplicateName: '目标名称“{name}”重复。',
+            urlRequired: '必须填写目标 URL。',
+            urlInvalid: '目标 URL 无效。',
+            urlScheme: 'URL 协议必须是 http 或 https。',
+            urlHost: 'URL 必须包含主机名。',
+            urlCredentials: 'URL 中不能包含用户名或密码，请改用请求头。',
+            urlFragment: 'URL 不能包含 fragment。',
+            unsupportedMethod: '仅支持 POST、PUT 和 PATCH。',
+            headersObject: 'headers 必须是 JSON 对象。',
+            headerValueString: '每个请求头的值都必须是字符串。',
+            headerNameInvalid: '请求头名称“{name}”无效。',
+            managedHeader: '请求头“{name}”由 HTTP 客户端管理。',
+            headerNewline: '请求头的值不能包含换行。',
+            duplicateHeader: '请求头“{name}”被重复填写。',
+            contentTypeNewline: '内容类型不能包含换行。',
+            timeoutInvalid: '请使用 500ms、5s 或 1m 这样的 Go duration。',
+            timeoutRange: '超时时间必须大于 0 且不超过 1m。',
+            retriesInvalid: '重试次数必须是 0 到 5 的整数。',
+            matchObject: 'match 必须是 JSON 对象。',
+            matchArray: '每个匹配字段都必须是字符串数组。',
+            matchPattern: '匹配模式不能为空。',
+            matchGlob: '通配模式“{pattern}”格式错误。',
+            envRuntime: '环境变量占位符会在 OwlMail 启动时解析并检查。',
+            templateRuntime: 'Go 正文模板会在 OwlMail 启动时编译并检查。'
+        }
+    };
+
+    const rootKeys = new Set(['version', 'targets']);
+    const targetKeys = new Set(['name', 'url', 'method', 'headers', 'contentType', 'bodyTemplate', 'secret', 'timeout', 'retries', 'match']);
+    const matchKeys = new Set(['from', 'to', 'subject', 'text']);
+    const headerNamePattern = /^[!#$%&'*+\-.^_\`|~0-9A-Za-z]+$/;
+    const environmentPattern = /\$\{[A-Za-z_][A-Za-z0-9_]*\}/g;
+    const exactEnvironmentPattern = /^\$\{[A-Za-z_][A-Za-z0-9_]*\}$/;
+
+    let currentLanguage = 'en';
+    let lastGeneratedJSON = '';
+    let actionStatusTimer = null;
+    let elements = {};
+
+    function tr(key, params) {
+        const table = translations[currentLanguage] || translations.en;
+        let value = table[key] || translations.en[key] || key;
+        Object.entries(params || {}).forEach(([name, replacement]) => {
+            value = value.replaceAll('{' + name + '}', String(replacement));
+        });
+        return value;
+    }
+
+    function issue(code, path, params) {
+        return { code, path: path || '', params: params || {} };
+    }
+
+    function isPlainObject(value) {
+        return value !== null && typeof value === 'object' && !Array.isArray(value);
+    }
+
+    function addUnknownFieldIssues(value, allowed, path, errors) {
+        Object.keys(value).forEach((key) => {
+            if (!allowed.has(key)) {
+                errors.push(issue('unknownField', path ? path + '.' + key : key, { field: key }));
+            }
+        });
+    }
+
+    function parseDurationMilliseconds(value) {
+        if (typeof value !== 'string' || value === '') return null;
+        const unitMilliseconds = {
+            ns: 0.000001,
+            us: 0.001,
+            'µs': 0.001,
+            ms: 1,
+            s: 1000,
+            m: 60000,
+            h: 3600000
+        };
+        let sign = 1;
+        let duration = value;
+        if (duration[0] === '+' || duration[0] === '-') {
+            sign = duration[0] === '-' ? -1 : 1;
+            duration = duration.slice(1);
+        }
+        const partPattern = /(\d+(?:\.\d*)?|\.\d+)(ns|us|µs|ms|s|m|h)/gy;
+        let total = 0;
+        let position = 0;
+        let match;
+        while ((match = partPattern.exec(duration)) !== null) {
+            if (match.index !== position) return Number.NaN;
+            total += Number(match[1]) * unitMilliseconds[match[2]];
+            position = partPattern.lastIndex;
+        }
+        return position === duration.length && position > 0 ? sign * total : Number.NaN;
+    }
+
+    function validGlobPattern(pattern) {
+        let inClass = false;
+        let classCharacters = 0;
+        for (let index = 0; index < pattern.length; index++) {
+            const character = pattern[index];
+            if (character === '\\') {
+                if (index + 1 >= pattern.length) return false;
+                index++;
+                if (inClass) classCharacters++;
+                continue;
+            }
+            if (!inClass && character === '[') {
+                inClass = true;
+                classCharacters = 0;
+                if (pattern[index + 1] === '^') index++;
+                continue;
+            }
+            if (inClass && character === ']') {
+                if (classCharacters === 0) return false;
+                inClass = false;
+                continue;
+            }
+            if (inClass) classCharacters++;
+        }
+        return !inClass;
+    }
+
+    function validateOptionalString(value, path, errors) {
+        if (value !== undefined && value !== null && typeof value !== 'string') {
+            errors.push(issue('fieldString', path));
+            return false;
+        }
+        return true;
+    }
+
+    function validateURL(value, path, errors, warnings) {
+        if (typeof value !== 'string') {
+            if (value === undefined || value === null || value === '') errors.push(issue('urlRequired', path));
+            else errors.push(issue('fieldString', path));
+            return;
+        }
+        if (value === '') {
+            errors.push(issue('urlRequired', path));
+            return;
+        }
+
+        const environmentMatches = value.match(environmentPattern);
+        if (environmentMatches) {
+            warnings.push(issue('envRuntime', path));
+            if (exactEnvironmentPattern.test(value)) return;
+        }
+
+        const parseableValue = value.replace(environmentPattern, 'placeholder.invalid');
+        let parsed;
+        try {
+            parsed = new URL(parseableValue);
+        } catch (_) {
+            errors.push(issue('urlInvalid', path));
+            return;
+        }
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') errors.push(issue('urlScheme', path));
+        if (!parsed.hostname) errors.push(issue('urlHost', path));
+        if (parsed.username || parsed.password) errors.push(issue('urlCredentials', path));
+        if (parsed.hash) errors.push(issue('urlFragment', path));
+    }
+
+    function validateMatch(match, path, errors) {
+        if (match === undefined || match === null) return;
+        if (!isPlainObject(match)) {
+            errors.push(issue('matchObject', path));
+            return;
+        }
+        addUnknownFieldIssues(match, matchKeys, path, errors);
+        matchKeys.forEach((field) => {
+            const patterns = match[field];
+            if (patterns === undefined || patterns === null) return;
+            if (!Array.isArray(patterns) || patterns.some((pattern) => typeof pattern !== 'string')) {
+                errors.push(issue('matchArray', path + '.' + field));
+                return;
+            }
+            patterns.forEach((pattern, index) => {
+                const patternPath = path + '.' + field + '[' + index + ']';
+                if (pattern.trim() === '') errors.push(issue('matchPattern', patternPath));
+                else if (!validGlobPattern(pattern.toLowerCase())) errors.push(issue('matchGlob', patternPath, { pattern }));
+            });
+        });
+    }
+
+    function validateTarget(target, index, names, errors, warnings) {
+        const path = 'targets[' + index + ']';
+        if (!isPlainObject(target)) {
+            errors.push(issue('targetObject', path));
+            return;
+        }
+        addUnknownFieldIssues(target, targetKeys, path, errors);
+
+        if (typeof target.name !== 'string') {
+            if (target.name === undefined || target.name === null || target.name === '') errors.push(issue('nameRequired', path + '.name'));
+            else errors.push(issue('fieldString', path + '.name'));
+        } else {
+            const name = target.name.trim();
+            if (!name) {
+                errors.push(issue('nameRequired', path + '.name'));
+            } else if (Array.from(name).length > 100 || /[\r\n]/.test(name)) {
+                errors.push(issue('nameInvalid', path + '.name'));
+            } else {
+                if (names.has(name)) errors.push(issue('duplicateName', path + '.name', { name }));
+                names.add(name);
+            }
+        }
+
+        validateURL(target.url, path + '.url', errors, warnings);
+
+        if (validateOptionalString(target.method, path + '.method', errors) && target.method) {
+            const method = target.method.trim().toUpperCase();
+            if (!['POST', 'PUT', 'PATCH'].includes(method)) errors.push(issue('unsupportedMethod', path + '.method'));
+        }
+
+        if (target.headers !== undefined && target.headers !== null) {
+            if (!isPlainObject(target.headers)) {
+                errors.push(issue('headersObject', path + '.headers'));
+            } else {
+                const canonicalNames = new Set();
+                Object.entries(target.headers).forEach(([name, value]) => {
+                    const headerPath = path + '.headers.' + name;
+                    const canonicalName = name.trim().toLowerCase();
+                    if (!headerNamePattern.test(name)) errors.push(issue('headerNameInvalid', headerPath, { name }));
+                    if (canonicalName === 'host' || canonicalName === 'content-length') {
+                        errors.push(issue('managedHeader', headerPath, { name }));
+                    }
+                    if (canonicalNames.has(canonicalName)) {
+                        errors.push(issue('duplicateHeader', headerPath, { name }));
+                    }
+                    canonicalNames.add(canonicalName);
+                    if (typeof value !== 'string') errors.push(issue('headerValueString', headerPath));
+                    else {
+                        if (/[\r\n]/.test(value)) errors.push(issue('headerNewline', headerPath));
+                        if (environmentPattern.test(value)) warnings.push(issue('envRuntime', headerPath));
+                        environmentPattern.lastIndex = 0;
+                    }
+                });
+            }
+        }
+
+        if (validateOptionalString(target.contentType, path + '.contentType', errors) &&
+            typeof target.contentType === 'string' && /[\r\n]/.test(target.contentType)) {
+            errors.push(issue('contentTypeNewline', path + '.contentType'));
+        }
+
+        if (validateOptionalString(target.secret, path + '.secret', errors) &&
+            typeof target.secret === 'string' && environmentPattern.test(target.secret)) {
+            warnings.push(issue('envRuntime', path + '.secret'));
+        }
+        environmentPattern.lastIndex = 0;
+
+        if (validateOptionalString(target.bodyTemplate, path + '.bodyTemplate', errors) && target.bodyTemplate) {
+            warnings.push(issue('templateRuntime', path + '.bodyTemplate'));
+        }
+
+        if (validateOptionalString(target.timeout, path + '.timeout', errors) && target.timeout) {
+            const milliseconds = parseDurationMilliseconds(target.timeout);
+            if (Number.isNaN(milliseconds)) errors.push(issue('timeoutInvalid', path + '.timeout'));
+            else if (milliseconds <= 0 || milliseconds > MAX_TIMEOUT_MS) errors.push(issue('timeoutRange', path + '.timeout'));
+        }
+
+        if (target.retries !== undefined && target.retries !== null) {
+            if (!Number.isInteger(target.retries) || target.retries < 0 || target.retries > MAX_RETRIES) {
+                errors.push(issue('retriesInvalid', path + '.retries'));
+            }
+        }
+
+        validateMatch(target.match, path + '.match', errors);
+    }
+
+    function validateConfig(config) {
+        const errors = [];
+        const warnings = [];
+        if (!isPlainObject(config)) {
+            errors.push(issue('invalidRoot'));
+            return { errors, warnings };
+        }
+        addUnknownFieldIssues(config, rootKeys, '', errors);
+
+        if (config.version !== undefined && config.version !== null &&
+            config.version !== 0 && config.version !== 1) {
+            errors.push(issue('invalidVersion', 'version'));
+        } else if (config.version === undefined || config.version === 0) {
+            warnings.push(issue('importedVersionNormalized', 'version'));
+        }
+
+        if (!Array.isArray(config.targets)) {
+            if (config.targets === undefined || config.targets === null) errors.push(issue('targetsRequired', 'targets'));
+            else errors.push(issue('targetsArray', 'targets'));
+            return { errors, warnings };
+        }
+        if (config.targets.length === 0) errors.push(issue('targetsRequired', 'targets'));
+        if (config.targets.length > MAX_TARGETS) errors.push(issue('tooManyTargets', 'targets'));
+
+        const names = new Set();
+        config.targets.forEach((target, index) => validateTarget(target, index, names, errors, warnings));
+        return { errors, warnings };
+    }
+
+    function normalizedPatterns(value) {
+        if (!Array.isArray(value)) return [];
+        return value.slice();
+    }
+
+    function normalizeConfig(config) {
+        return {
+            version: 1,
+            targets: config.targets.map((source) => {
+                const target = {
+                    name: source.name.trim(),
+                    url: source.url
+                };
+                const method = typeof source.method === 'string' ? source.method.trim().toUpperCase() : '';
+                const contentType = typeof source.contentType === 'string' ? source.contentType.trim() : '';
+                if (method && method !== 'POST') target.method = method;
+                if (source.headers && Object.keys(source.headers).length) target.headers = { ...source.headers };
+                if (contentType && contentType !== 'application/json') target.contentType = contentType;
+                if (source.bodyTemplate) target.bodyTemplate = source.bodyTemplate;
+                if (source.secret) target.secret = source.secret;
+                if (source.timeout && source.timeout !== '5s') target.timeout = source.timeout;
+                if (source.retries) target.retries = source.retries;
+                if (source.match) {
+                    const match = {};
+                    matchKeys.forEach((field) => {
+                        const patterns = normalizedPatterns(source.match[field]);
+                        if (patterns.length) match[field] = patterns;
+                    });
+                    if (Object.keys(match).length) target.match = match;
+                }
+                return target;
+            })
+        };
+    }
+
+    function parseConfigText(text) {
+        if (typeof text !== 'string' || text.trim() === '') {
+            return { config: null, errors: [issue('importEmpty')], warnings: [] };
+        }
+        const byteLength = typeof TextEncoder === 'function'
+            ? new TextEncoder().encode(text).byteLength
+            : unescape(encodeURIComponent(text)).length;
+        if (byteLength > MAX_CONFIG_BYTES) {
+            return { config: null, errors: [issue('configTooLarge')], warnings: [] };
+        }
+        let parsed;
+        try {
+            parsed = JSON.parse(text);
+        } catch (error) {
+            return {
+                config: null,
+                errors: [issue('invalidJSON', '', { detail: error && error.message ? error.message : String(error) })],
+                warnings: []
+            };
+        }
+        const validation = validateConfig(parsed);
+        if (validation.errors.length) return { config: null, ...validation };
+        return { config: normalizeConfig(parsed), ...validation };
+    }
+
+    function splitPatternLines(value) {
+        return value.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+    }
+
+    function applyTranslations(root) {
+        const scope = root || document;
+        scope.querySelectorAll('[data-i18n]').forEach((node) => {
+            node.textContent = tr(node.dataset.i18n);
+        });
+        scope.querySelectorAll('[data-i18n-title]').forEach((node) => {
+            const value = tr(node.dataset.i18nTitle);
+            node.title = value;
+            if (node.hasAttribute('aria-label')) node.setAttribute('aria-label', value);
+        });
+        scope.querySelectorAll('[data-i18n-placeholder]').forEach((node) => {
+            node.placeholder = tr(node.dataset.i18nPlaceholder);
+        });
+    }
+
+    function detectLanguage() {
+        try {
+            const saved = localStorage.getItem('language');
+            if (translations[saved]) return saved;
+        } catch (_) {
+            // Continue with browser language when storage is unavailable.
+        }
+        return (navigator.language || '').toLowerCase().startsWith('zh') ? 'zh-CN' : 'en';
+    }
+
+    function setLanguage(language) {
+        currentLanguage = translations[language] ? language : 'en';
+        document.documentElement.lang = currentLanguage;
+        document.documentElement.dataset.language = currentLanguage;
+        document.title = currentLanguage === 'zh-CN' ? 'OwlMail Webhook 配置生成器' : 'OwlMail Webhook Configurator';
+        elements.language.value = currentLanguage;
+        applyTranslations(document);
+        try {
+            localStorage.setItem('language', currentLanguage);
+        } catch (_) {
+            // Language still applies when storage is unavailable.
+        }
+        refreshTargetLabels();
+        renderOutput();
+    }
+
+    function applyTheme(theme) {
+        const dark = theme === 'dark';
+        document.body.classList.toggle('dark-theme', dark);
+        document.body.classList.toggle('light-theme', !dark);
+        elements.theme.textContent = dark ? '☀️' : '🌙';
+        const label = tr('toggleTheme');
+        elements.theme.title = label;
+        elements.theme.setAttribute('aria-label', label);
+        try {
+            localStorage.setItem('theme', dark ? 'dark' : 'light');
+        } catch (_) {
+            // Theme still applies when storage is unavailable.
+        }
+    }
+
+    function initialTheme() {
+        try {
+            return localStorage.getItem('theme') === 'dark' ? 'dark' : 'light';
+        } catch (_) {
+            return 'light';
+        }
+    }
+
+    function addHeaderRow(container, name, value) {
+        const row = elements.headerTemplate.content.firstElementChild.cloneNode(true);
+        applyTranslations(row);
+        row.querySelector('[data-header="name"]').value = name || '';
+        row.querySelector('[data-header="value"]').value = value || '';
+        row.querySelectorAll('input').forEach((input) => input.addEventListener('input', renderOutput));
+        row.querySelector('.remove-header').addEventListener('click', () => {
+            row.remove();
+            renderOutput();
+        });
+        container.appendChild(row);
+        return row;
+    }
+
+    function targetHasAdvancedFields(target) {
+        return Boolean(
+            target.secret ||
+            target.bodyTemplate ||
+            (target.headers && Object.keys(target.headers).length) ||
+            (target.match && Object.values(target.match).some((patterns) => Array.isArray(patterns) && patterns.length))
+        );
+    }
+
+    function addTarget(target, options) {
+        if (elements.targetList.children.length >= MAX_TARGETS) {
+            setActionStatus(tr('maxTargets'), true);
+            return null;
+        }
+        const source = { ...DEFAULT_TARGET, ...(target || {}) };
+        const card = elements.targetTemplate.content.firstElementChild.cloneNode(true);
+        applyTranslations(card);
+        card.querySelector('[data-field="name"]').value = source.name || '';
+        card.querySelector('[data-field="url"]').value = source.url || '';
+        card.querySelector('[data-field="method"]').value = (source.method || 'POST').toUpperCase();
+        card.querySelector('[data-field="timeout"]').value = source.timeout || '5s';
+        card.querySelector('[data-field="retries"]').value = source.retries === undefined || source.retries === null ? '0' : String(source.retries);
+        card.querySelector('[data-field="contentType"]').value = source.contentType || 'application/json';
+        card.querySelector('[data-field="secret"]').value = source.secret || '';
+        card.querySelector('[data-field="bodyTemplate"]').value = source.bodyTemplate || '';
+
+        matchKeys.forEach((field) => {
+            const patterns = source.match && Array.isArray(source.match[field]) ? source.match[field] : [];
+            card.querySelector('[data-match="' + field + '"]').value = patterns.join('\n');
+        });
+
+        const headerContainer = card.querySelector('[data-role="headers"]');
+        Object.entries(source.headers || {}).forEach(([name, value]) => addHeaderRow(headerContainer, name, value));
+
+        card.querySelector('.add-header').addEventListener('click', () => {
+            const row = addHeaderRow(headerContainer, '', '');
+            row.querySelector('[data-header="name"]').focus();
+            renderOutput();
+        });
+        card.querySelector('.remove-target').addEventListener('click', () => {
+            card.remove();
+            refreshTargetLabels();
+            renderOutput();
+        });
+        card.querySelectorAll('input, select, textarea').forEach((control) => {
+            control.addEventListener('input', renderOutput);
+            control.addEventListener('change', renderOutput);
+        });
+        if (targetHasAdvancedFields(source)) card.querySelector('.advanced-options').open = true;
+
+        elements.targetList.appendChild(card);
+        refreshTargetLabels();
+        if (!(options && options.silent)) renderOutput();
+        return card;
+    }
+
+    function refreshTargetLabels() {
+        if (!elements.targetList) return;
+        const cards = Array.from(elements.targetList.querySelectorAll('.target-card'));
+        cards.forEach((card, index) => {
+            card.querySelector('[data-role="target-number"]').textContent = String(index + 1);
+            card.querySelector('.remove-target').disabled = cards.length === 1;
+        });
+        elements.targetCount.textContent = cards.length + ' / ' + MAX_TARGETS;
+        elements.addTarget.disabled = cards.length >= MAX_TARGETS;
+    }
+
+    function readTargetCard(card, index, formErrors) {
+        const value = (selector) => card.querySelector(selector).value;
+        const target = {
+            name: value('[data-field="name"]').trim(),
+            url: value('[data-field="url"]').trim()
+        };
+        const method = value('[data-field="method"]').trim().toUpperCase();
+        const timeout = value('[data-field="timeout"]').trim();
+        const retriesText = value('[data-field="retries"]').trim();
+        const contentType = value('[data-field="contentType"]').trim();
+        const secret = value('[data-field="secret"]');
+        const bodyTemplate = value('[data-field="bodyTemplate"]');
+
+        if (method && method !== 'POST') target.method = method;
+        if (timeout && timeout !== '5s') target.timeout = timeout;
+        if (retriesText !== '' && Number(retriesText) !== 0) target.retries = Number(retriesText);
+        if (contentType && contentType !== 'application/json') target.contentType = contentType;
+        if (secret) target.secret = secret;
+        if (bodyTemplate) target.bodyTemplate = bodyTemplate;
+
+        const headers = {};
+        const headerNames = new Set();
+        card.querySelectorAll('.header-row').forEach((row) => {
+            const name = row.querySelector('[data-header="name"]').value.trim();
+            const headerValue = row.querySelector('[data-header="value"]').value;
+            if (!name && !headerValue) return;
+            const canonical = name.toLowerCase();
+            if (headerNames.has(canonical)) {
+                formErrors.push(issue('duplicateHeader', 'targets[' + index + '].headers.' + name, { name }));
+            }
+            headerNames.add(canonical);
+            headers[name] = headerValue;
+        });
+        if (Object.keys(headers).length) target.headers = headers;
+
+        const match = {};
+        matchKeys.forEach((field) => {
+            const patterns = splitPatternLines(card.querySelector('[data-match="' + field + '"]').value);
+            if (patterns.length) match[field] = patterns;
+        });
+        if (Object.keys(match).length) target.match = match;
+        return target;
+    }
+
+    function collectConfig() {
+        const errors = [];
+        const targets = Array.from(elements.targetList.querySelectorAll('.target-card'))
+            .map((card, index) => readTargetCard(card, index, errors));
+        return { config: { version: 1, targets }, errors };
+    }
+
+    function formatIssue(item) {
+        const message = tr(item.code, item.params);
+        return item.path ? item.path + ': ' + message : message;
+    }
+
+    function renderIssueList(container, heading, issues, className) {
+        container.replaceChildren();
+        container.className = className || '';
+        const strong = document.createElement('strong');
+        strong.textContent = heading;
+        container.appendChild(strong);
+        if (issues.length) {
+            const list = document.createElement('ul');
+            issues.forEach((item) => {
+                const row = document.createElement('li');
+                row.textContent = formatIssue(item);
+                list.appendChild(row);
+            });
+            container.appendChild(list);
+        }
+    }
+
+    function renderValidation(errors, warnings) {
+        const badge = elements.validationBadge;
+        badge.classList.toggle('is-valid', errors.length === 0 && warnings.length === 0);
+        badge.classList.toggle('is-warning', errors.length === 0 && warnings.length > 0);
+        badge.classList.toggle('is-invalid', errors.length > 0);
+
+        if (errors.length) {
+            badge.textContent = tr('invalid');
+            renderIssueList(elements.validationSummary, tr('errorCount', { count: errors.length }), errors, 'validation-summary is-invalid');
+        } else if (warnings.length) {
+            badge.textContent = tr('warning');
+            renderIssueList(elements.validationSummary, tr('warningCount', { count: warnings.length }), warnings, 'validation-summary is-warning');
+        } else {
+            badge.textContent = tr('valid');
+            renderIssueList(elements.validationSummary, tr('configReady'), [], 'validation-summary');
+        }
+        elements.copy.disabled = errors.length > 0;
+        elements.download.disabled = errors.length > 0;
+    }
+
+    function renderOutput() {
+        if (!elements.targetList) return;
+        const collected = collectConfig();
+        const validation = validateConfig(collected.config);
+        const errors = collected.errors.concat(validation.errors);
+        lastGeneratedJSON = JSON.stringify(collected.config, null, 2) + '\n';
+        elements.output.value = lastGeneratedJSON;
+        renderValidation(errors, validation.warnings);
+    }
+
+    function replaceTargets(config) {
+        elements.targetList.replaceChildren();
+        config.targets.forEach((target) => addTarget(target, { silent: true }));
+        refreshTargetLabels();
+        renderOutput();
+    }
+
+    function showImportResult(result) {
+        if (result.errors.length) {
+            renderIssueList(elements.importStatus, tr('errorCount', { count: result.errors.length }), result.errors, 'import-status is-error');
+            return false;
+        }
+        replaceTargets(result.config);
+        const message = result.warnings.length
+            ? tr('importSuccessWithWarnings', { count: result.config.targets.length, warnings: result.warnings.length })
+            : tr('importSuccess', { count: result.config.targets.length });
+        renderIssueList(elements.importStatus, message, result.warnings, 'import-status');
+        return true;
+    }
+
+    function importCurrentText() {
+        return showImportResult(parseConfigText(elements.importInput.value));
+    }
+
+    function setActionStatus(message, error) {
+        if (!elements.actionStatus) return;
+        clearTimeout(actionStatusTimer);
+        elements.actionStatus.textContent = message;
+        elements.actionStatus.classList.toggle('is-error', Boolean(error));
+        actionStatusTimer = setTimeout(() => {
+            elements.actionStatus.textContent = '';
+            elements.actionStatus.classList.remove('is-error');
+        }, 5000);
+    }
+
+    async function copyConfiguration() {
+        try {
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                await navigator.clipboard.writeText(lastGeneratedJSON);
+            } else {
+                elements.output.focus();
+                elements.output.select();
+                if (!document.execCommand('copy')) throw new Error('copy command failed');
+            }
+            setActionStatus(tr('copied'), false);
+        } catch (_) {
+            elements.output.focus();
+            elements.output.select();
+            setActionStatus(tr('copyFailed'), true);
+        }
+    }
+
+    function downloadConfiguration() {
+        const blob = new Blob([lastGeneratedJSON], { type: 'application/json;charset=utf-8' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = 'webhooks.json';
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        URL.revokeObjectURL(url);
+        setActionStatus(tr('downloaded'), false);
+    }
+
+    function readConfigFile(file) {
+        if (!file) return;
+        if (file.size > MAX_CONFIG_BYTES) {
+            renderIssueList(elements.importStatus, tr('fileTooLarge'), [], 'import-status is-error');
+            return;
+        }
+        const reader = new FileReader();
+        reader.addEventListener('load', () => {
+            elements.importInput.value = typeof reader.result === 'string' ? reader.result : '';
+            importCurrentText();
+        });
+        reader.addEventListener('error', () => {
+            renderIssueList(elements.importStatus, tr('fileReadFailed'), [], 'import-status is-error');
+        });
+        reader.readAsText(file);
+    }
+
+    function initializeDragAndDrop() {
+        ['dragenter', 'dragover'].forEach((eventName) => {
+            elements.dropZone.addEventListener(eventName, (event) => {
+                event.preventDefault();
+                elements.dropZone.classList.add('is-dragging');
+            });
+        });
+        ['dragleave', 'drop'].forEach((eventName) => {
+            elements.dropZone.addEventListener(eventName, (event) => {
+                event.preventDefault();
+                elements.dropZone.classList.remove('is-dragging');
+            });
+        });
+        elements.dropZone.addEventListener('drop', (event) => {
+            readConfigFile(event.dataTransfer && event.dataTransfer.files ? event.dataTransfer.files[0] : null);
+        });
+        elements.dropZone.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                elements.file.click();
+            }
+        });
+    }
+
+    function initialize() {
+        elements = {
+            language: document.getElementById('webhookLanguage'),
+            theme: document.getElementById('webhookTheme'),
+            targetList: document.getElementById('targetList'),
+            targetTemplate: document.getElementById('targetTemplate'),
+            headerTemplate: document.getElementById('headerTemplate'),
+            targetCount: document.getElementById('targetCount'),
+            addTarget: document.getElementById('addTarget'),
+            loadExample: document.getElementById('loadExample'),
+            importInput: document.getElementById('importInput'),
+            importStatus: document.getElementById('importStatus'),
+            parseImport: document.getElementById('parseImport'),
+            file: document.getElementById('configFile'),
+            dropZone: document.getElementById('dropZone'),
+            output: document.getElementById('configOutput'),
+            validationBadge: document.getElementById('validationBadge'),
+            validationSummary: document.getElementById('validationSummary'),
+            copy: document.getElementById('copyConfig'),
+            download: document.getElementById('downloadConfig'),
+            actionStatus: document.getElementById('actionStatus')
+        };
+        if (!elements.targetList || !elements.targetTemplate || !elements.headerTemplate) return;
+
+        currentLanguage = detectLanguage();
+        elements.language.value = currentLanguage;
+        document.documentElement.lang = currentLanguage;
+        document.documentElement.dataset.language = currentLanguage;
+        document.title = currentLanguage === 'zh-CN' ? 'OwlMail Webhook 配置生成器' : 'OwlMail Webhook Configurator';
+        applyTranslations(document);
+        applyTheme(initialTheme());
+
+        elements.language.addEventListener('change', (event) => setLanguage(event.target.value));
+        elements.theme.addEventListener('click', () => {
+            applyTheme(document.body.classList.contains('dark-theme') ? 'light' : 'dark');
+        });
+        elements.addTarget.addEventListener('click', () => {
+            const card = addTarget({ name: 'target-' + (elements.targetList.children.length + 1), url: '' });
+            if (card) card.querySelector('[data-field="url"]').focus();
+        });
+        elements.loadExample.addEventListener('click', () => {
+            replaceTargets(EXAMPLE_CONFIG);
+            elements.importStatus.replaceChildren();
+        });
+        elements.parseImport.addEventListener('click', importCurrentText);
+        elements.file.addEventListener('change', (event) => {
+            readConfigFile(event.target.files && event.target.files[0]);
+            event.target.value = '';
+        });
+        elements.copy.addEventListener('click', copyConfiguration);
+        elements.download.addEventListener('click', downloadConfiguration);
+        initializeDragAndDrop();
+
+        addTarget(DEFAULT_TARGET, { silent: true });
+        refreshTargetLabels();
+        renderOutput();
+    }
+
+    const publicAPI = {
+        MAX_CONFIG_BYTES,
+        MAX_TARGETS,
+        parseConfigText,
+        parseDurationMilliseconds,
+        validateConfig,
+        normalizeConfig,
+        validGlobPattern
+    };
+    if (typeof window !== 'undefined') window.OwlMailWebhookConfigurator = publicAPI;
+    if (typeof document !== 'undefined') document.addEventListener('DOMContentLoaded', initialize);
+})();

--- a/web/webhooks.js
+++ b/web/webhooks.js
@@ -486,6 +486,9 @@
             if (exactEnvironmentPattern.test(value)) return;
         }
         const rawQueryOrFragment = value.search(/[?#]/);
+        const rawFragmentOffset = value.indexOf('#');
+        const hasNonEmptyRawFragment = rawFragmentOffset >= 0 && rawFragmentOffset < value.length - 1;
+        if (hasNonEmptyRawFragment) errors.push(issue('urlFragment', path));
         const percentValidationSource = rawQueryOrFragment < 0 ? value : value.slice(0, rawQueryOrFragment);
         const percentValidationValue = percentValidationSource.replace(environmentPattern, '00');
         if (/%(?![0-9A-Fa-f]{2})/.test(percentValidationValue)) {
@@ -495,7 +498,6 @@
 
         const leadingEnvironment = value.match(leadingEnvironmentPattern);
         if (leadingEnvironment && !value.slice(leadingEnvironment[0].length).startsWith('://')) {
-            if (value.includes('#')) errors.push(issue('urlFragment', path));
             return;
         }
 
@@ -616,7 +618,6 @@
         if ((parsed.username || parsed.password) && !authorityHasUserInfo) {
             errors.push(issue('urlCredentials', path));
         }
-        if (parsed.hash) errors.push(issue('urlFragment', path));
     }
 
     function validateMatch(match, path, errors) {

--- a/web/webhooks.js
+++ b/web/webhooks.js
@@ -283,12 +283,29 @@
         return value !== null && typeof value === 'object' && !Array.isArray(value);
     }
 
+    function foldJSONFieldName(value) {
+        let folded = '';
+        for (const character of value) {
+            const codePoint = character.codePointAt(0);
+            if (codePoint >= 0x61 && codePoint <= 0x7A) {
+                folded += String.fromCharCode(codePoint - 0x20);
+            } else if (codePoint === 0x017F) {
+                folded += 'S';
+            } else if (codePoint === 0x212A) {
+                folded += 'K';
+            } else {
+                folded += character;
+            }
+        }
+        return folded;
+    }
+
     function canonicalizeKnownObject(value, allowed) {
         if (!isPlainObject(value)) return value;
-        const canonicalNames = new Map(Array.from(allowed, (name) => [name.toLowerCase(), name]));
+        const canonicalNames = new Map(Array.from(allowed, (name) => [foldJSONFieldName(name), name]));
         const result = Object.create(null);
         Object.entries(value).forEach(([name, item]) => {
-            result[canonicalNames.get(name.toLowerCase()) || name] = item;
+            result[canonicalNames.get(foldJSONFieldName(name)) || name] = item;
         });
         return result;
     }

--- a/web/webhooks.js
+++ b/web/webhooks.js
@@ -283,6 +283,29 @@
         return value !== null && typeof value === 'object' && !Array.isArray(value);
     }
 
+    function canonicalizeKnownObject(value, allowed) {
+        if (!isPlainObject(value)) return value;
+        const canonicalNames = new Map(Array.from(allowed, (name) => [name.toLowerCase(), name]));
+        const result = Object.create(null);
+        Object.entries(value).forEach(([name, item]) => {
+            result[canonicalNames.get(name.toLowerCase()) || name] = item;
+        });
+        return result;
+    }
+
+    function canonicalizeConfigFields(config) {
+        const result = canonicalizeKnownObject(config, rootKeys);
+        if (!isPlainObject(result) || !Array.isArray(result.targets)) return result;
+        result.targets = result.targets.map((source) => {
+            const target = canonicalizeKnownObject(source, targetKeys);
+            if (isPlainObject(target) && isPlainObject(target.match)) {
+                target.match = canonicalizeKnownObject(target.match, matchKeys);
+            }
+            return target;
+        });
+        return result;
+    }
+
     const goTrimSpacePattern = /^[\u0009-\u000D\u0020\u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]+|[\u0009-\u000D\u0020\u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]+$/g;
     const goLeadingSpacePattern = /^[\u0009-\u000D\u0020\u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]+/;
 
@@ -555,13 +578,22 @@
         const authorityIsStaticallyEmpty = authorityStart >= 0 && authorityStart === authorityEnd;
         const bracketStart = authority.indexOf('[');
         const bracketEnd = authority.lastIndexOf(']');
+        const openingBrackets = Array.from(authority).filter((character) => character === '[').length;
+        const closingBrackets = Array.from(authority).filter((character) => character === ']').length;
+        const authorityEnvironmentOffset = authority.search(environmentPattern);
+        environmentPattern.lastIndex = 0;
+        const unbalancedBracketedHostHasEnvironment =
+            (openingBrackets === 1 && closingBrackets === 0 && authorityEnvironmentOffset > bracketStart) ||
+            (openingBrackets === 0 && closingBrackets === 1 &&
+                authorityEnvironmentOffset >= 0 && authorityEnvironmentOffset < bracketEnd);
         const bracketedHostHasEnvironment = bracketStart >= 0 && bracketEnd > bracketStart &&
             environmentPattern.test(authority.slice(bracketStart + 1, bracketEnd));
         environmentPattern.lastIndex = 0;
         const bracketedHostHasZone = bracketStart >= 0 && bracketEnd > bracketStart &&
             authority.slice(bracketStart + 1, bracketEnd).includes('%25');
         const portSeparator = authorityPortSeparator(authority);
-        const portHasEnvironment = portSeparator >= 0 && environmentPattern.test(authority.slice(portSeparator + 1));
+        const portHasEnvironment = !unbalancedBracketedHostHasEnvironment && portSeparator >= 0 &&
+            environmentPattern.test(authority.slice(portSeparator + 1));
         environmentPattern.lastIndex = 0;
         if (authorityHasUserInfo) errors.push(issue('urlCredentials', path));
         if (authorityHasInvalidHost(authority)) {
@@ -600,7 +632,9 @@
             const browserSchemeEnd = browserParseValue.indexOf('://');
             browserParseValue = 'https' + browserParseValue.slice(browserSchemeEnd);
         }
-        if (bracketedHostHasEnvironment) {
+        if (unbalancedBracketedHostHasEnvironment) {
+            browserParseValue = transformURLAuthority(browserParseValue, () => '[::1]');
+        } else if (bracketedHostHasEnvironment) {
             browserParseValue = browserParseValue.replace(/\[[^\]]*\]/, '[::1]');
         }
         if (portHasEnvironment) {
@@ -831,7 +865,7 @@
         }
         let parsed;
         try {
-            parsed = JSON.parse(text);
+            parsed = canonicalizeConfigFields(JSON.parse(text));
         } catch (error) {
             return {
                 config: null,

--- a/web/webhooks.js
+++ b/web/webhooks.js
@@ -488,6 +488,11 @@
         const authority = authorityStart < 0 ? '' : value.slice(authorityStart, authorityEnd);
         const authorityHasUserInfo = authority.includes('@');
         const authorityIsStaticallyEmpty = authorityStart >= 0 && authorityStart === authorityEnd;
+        const bracketStart = authority.indexOf('[');
+        const bracketEnd = authority.lastIndexOf(']');
+        const bracketedHostHasEnvironment = bracketStart >= 0 && bracketEnd > bracketStart &&
+            environmentPattern.test(authority.slice(bracketStart + 1, bracketEnd));
+        environmentPattern.lastIndex = 0;
         if (authorityHasUserInfo) errors.push(issue('urlCredentials', path));
         if (authorityHasInvalidHost(authority)) {
             errors.push(issue('urlInvalid', path));
@@ -520,7 +525,11 @@
             if (lastColon > closingBracket) return '443';
             return 'placeholder.invalid';
         });
-        const browserParseValue = parseableValue.replace(/\[([^\]]+?)%25[^\]]*\]/g, '[$1]');
+        let browserParseValue = parseableValue;
+        if (bracketedHostHasEnvironment) {
+            browserParseValue = browserParseValue.replace(/\[[^\]]*\]/, '[::1]');
+        }
+        browserParseValue = browserParseValue.replace(/\[([^\]]+?)%25[^\]]*\]/g, '[$1]');
         let parsed;
         try {
             parsed = new URL(browserParseValue);

--- a/web/webhooks.js
+++ b/web/webhooks.js
@@ -259,6 +259,7 @@
     let actionStatusTimer = null;
     let elements = {};
     const preservedMatchPatterns = new WeakMap();
+    const preservedControlValues = new WeakMap();
 
     function tr(key, params) {
         const table = translations[currentLanguage] || translations.en;
@@ -416,7 +417,14 @@
         const authorityEnd = authorityStart < 0
             ? -1
             : (authorityEndOffset < 0 ? value.length : authorityStart + authorityEndOffset);
+        const authority = authorityStart < 0 ? '' : value.slice(authorityStart, authorityEnd);
+        const authorityHasUserInfo = authority.includes('@');
         const authorityIsStaticallyEmpty = authorityStart >= 0 && authorityStart === authorityEnd;
+        if (authorityHasUserInfo) errors.push(issue('urlCredentials', path));
+        if (authority.includes('\\')) {
+            errors.push(issue('urlInvalid', path));
+            return;
+        }
         if (authorityIsStaticallyEmpty) {
             errors.push(issue('urlHost', path));
         }
@@ -454,7 +462,9 @@
             errors.push(issue('urlHost', path));
         }
         if (!parsed.hostname && !authorityIsStaticallyEmpty) errors.push(issue('urlHost', path));
-        if (parsed.username || parsed.password) errors.push(issue('urlCredentials', path));
+        if ((parsed.username || parsed.password) && !authorityHasUserInfo) {
+            errors.push(issue('urlCredentials', path));
+        }
         if (parsed.hash) errors.push(issue('urlFragment', path));
     }
 
@@ -661,6 +671,17 @@
         return splitPatternLines(value);
     }
 
+    function editorValueFromPreserved(value, preserved) {
+        if (preserved && value === preserved.displayValue) return preserved.value;
+        return value;
+    }
+
+    function setPreservedControlValue(control, value) {
+        control.value = value;
+        preservedControlValues.set(control, { displayValue: control.value, value });
+        control.addEventListener('input', () => preservedControlValues.delete(control), { once: true });
+    }
+
     function createHeaderMap() {
         return Object.create(null);
     }
@@ -781,8 +802,8 @@
         card.querySelector('[data-field="timeout"]').value = source.timeout || '5s';
         card.querySelector('[data-field="retries"]').value = source.retries === undefined || source.retries === null ? '0' : String(source.retries);
         card.querySelector('[data-field="contentType"]').value = source.contentType || 'application/json';
-        card.querySelector('[data-field="secret"]').value = source.secret || '';
-        card.querySelector('[data-field="bodyTemplate"]').value = source.bodyTemplate || '';
+        setPreservedControlValue(card.querySelector('[data-field="secret"]'), source.secret || '');
+        setPreservedControlValue(card.querySelector('[data-field="bodyTemplate"]'), source.bodyTemplate || '');
 
         matchKeys.forEach((field) => {
             const patterns = source.match && Array.isArray(source.match[field]) ? source.match[field] : [];
@@ -792,6 +813,7 @@
                 displayValue: control.value,
                 patterns: patterns.slice()
             });
+            control.addEventListener('input', () => preservedMatchPatterns.delete(control), { once: true });
         });
 
         const headerContainer = card.querySelector('[data-role="headers"]');
@@ -840,8 +862,13 @@
         const timeout = value('[data-field="timeout"]').trim();
         const retriesText = value('[data-field="retries"]').trim();
         const contentType = value('[data-field="contentType"]').trim();
-        const secret = value('[data-field="secret"]');
-        const bodyTemplate = value('[data-field="bodyTemplate"]');
+        const secretControl = card.querySelector('[data-field="secret"]');
+        const bodyTemplateControl = card.querySelector('[data-field="bodyTemplate"]');
+        const secret = editorValueFromPreserved(secretControl.value, preservedControlValues.get(secretControl));
+        const bodyTemplate = editorValueFromPreserved(
+            bodyTemplateControl.value,
+            preservedControlValues.get(bodyTemplateControl)
+        );
 
         if (method && method !== 'POST') target.method = method;
         if (timeout && timeout !== '5s') target.timeout = timeout;
@@ -1109,6 +1136,7 @@
         utf8ByteLength,
         validGlobPattern,
         patternsFromEditorValue,
+        editorValueFromPreserved,
         createHeaderMap
     };
     if (typeof window !== 'undefined') window.OwlMailWebhookConfigurator = publicAPI;

--- a/web/webhooks.js
+++ b/web/webhooks.js
@@ -439,6 +439,19 @@
         return !validGoHostString(host, false);
     }
 
+    function authorityPortSeparator(authority) {
+        const hostPortStart = authority.lastIndexOf('@') + 1;
+        const hostPort = authority.slice(hostPortStart);
+        if (hostPort.startsWith('[')) {
+            const bracketEnd = hostPort.indexOf(']');
+            return bracketEnd >= 0 && hostPort[bracketEnd + 1] === ':'
+                ? hostPortStart + bracketEnd + 1
+                : -1;
+        }
+        const separator = hostPort.lastIndexOf(':');
+        return separator < 0 ? -1 : hostPortStart + separator;
+    }
+
     function validateURL(value, path, errors, warnings) {
         if (typeof value !== 'string') {
             if (value === undefined || value === null || value === '') errors.push(issue('urlRequired', path));
@@ -494,6 +507,9 @@
         const bracketedHostHasEnvironment = bracketStart >= 0 && bracketEnd > bracketStart &&
             environmentPattern.test(authority.slice(bracketStart + 1, bracketEnd));
         environmentPattern.lastIndex = 0;
+        const portSeparator = authorityPortSeparator(authority);
+        const portHasEnvironment = portSeparator >= 0 && environmentPattern.test(authority.slice(portSeparator + 1));
+        environmentPattern.lastIndex = 0;
         if (authorityHasUserInfo) errors.push(issue('urlCredentials', path));
         if (authorityHasInvalidHost(authority)) {
             errors.push(issue('urlInvalid', path));
@@ -527,8 +543,24 @@
             return 'placeholder.invalid';
         });
         let browserParseValue = parseableValue;
+        if (placeholderInScheme) {
+            const browserSchemeEnd = browserParseValue.indexOf('://');
+            browserParseValue = 'https' + browserParseValue.slice(browserSchemeEnd);
+        }
         if (bracketedHostHasEnvironment) {
             browserParseValue = browserParseValue.replace(/\[[^\]]*\]/, '[::1]');
+        }
+        if (portHasEnvironment) {
+            const browserSchemeEnd = browserParseValue.indexOf('://');
+            const browserAuthorityStart = browserSchemeEnd + 3;
+            const browserAuthorityEndOffset = browserParseValue.slice(browserAuthorityStart).search(/[/?#]/);
+            const browserAuthorityEnd = browserAuthorityEndOffset < 0
+                ? browserParseValue.length
+                : browserAuthorityStart + browserAuthorityEndOffset;
+            const browserAuthority = browserParseValue.slice(browserAuthorityStart, browserAuthorityEnd);
+            const browserPortSeparator = authorityPortSeparator(browserAuthority);
+            browserParseValue = browserParseValue.slice(0, browserAuthorityStart + browserPortSeparator + 1) +
+                '443' + browserParseValue.slice(browserAuthorityEnd);
         }
         browserParseValue = browserParseValue.replace(/\[([^\]]+?)%25[^\]]*\]/g, '[$1]');
         let parsed;


### PR DESCRIPTION
## Pull Request Description

Adds an embedded Webhook Configurator at `/webhooks` that matches OwlMail's existing inbox styling and persists the same language/theme preferences.

The page builds version 1 webhook targets visually, imports existing JSON from paste/file/drop, parses rules back into editable controls, validates the client-visible parts of OwlMail's runtime contract, and provides copy/download actions. All processing stays in the browser; the page does not read or mutate the server's active configuration.

## Type of Change

- [x] ✨ New feature (adds functionality without breaking existing functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests

## Change Details

### New Features

- Add an English/Chinese, light/dark `/webhooks` page with:
  - multiple targets (up to 32);
  - POST/PUT/PATCH method, timeout, retry, and content-type controls;
  - environment-backed headers and HMAC secrets;
  - from/to/subject/text wildcard filters;
  - custom Go body templates;
  - live canonical JSON output;
  - paste, file picker, and drag-and-drop import;
  - copy and `webhooks.json` download actions.
- Validate strict top-level/target/match fields, target names and limits, URL safety and Go-compatible URL/host/query syntax, HTTP header field values, managed headers, Go-duration bounds, retry bounds, wildcard syntax, and the generated file size before download.
- Match Go's UTF-8 byte, duration, wildcard, URL, Unicode whitespace, and HTTP field-value semantics for browser-visible validation.
- Preserve imported URLs, match patterns, secrets, body templates, and valid prototype-like header names until their corresponding controls are edited.
- Treat environment expansion (including environment-backed base URLs) and Go template compilation as explicit runtime notes instead of falsely claiming browser-side validation.
- Add the inbox navigation entry and contextual links from the local help page.
- Embed and serve the new page and assets from the OwlMail binary.

### Behavior and security

- No active server configuration is changed from the browser.
- Imported content is rendered with DOM text nodes; configuration values are not injected as HTML.
- Imported and generated configurations use the same 1 MiB limit as the backend loader.
- Activation still requires mounting the downloaded file through `-webhook-config` / `OWLMAIL_WEBHOOK_CONFIG` and restarting OwlMail.

### Breaking Changes

- None.

## Testing

- [x] I have added new tests to cover my changes
- [x] The new front-end contract tests pass

### Test Commands

```bash
node --check web/webhooks.js
node --test tests/web/webhooks.test.js
```

### Test Results

Thirty-three tests pass, covering page assets, minimal and full round trips, strict JSON/duplicate keys/case-insensitive known fields/unknown fields, backend-aligned validation, preservation of URL path whitespace plus backend default, null-header, and JSON-surrogate normalization, match-pattern whitespace/newlines and normalized secret/template controls, prototype-like header names, HTTP field-value controls, environment placeholders across URL base/scheme/delimiter/host/port components, Go-compatible URL escapes/raw queries/whitespace/authority/userinfo/host handling (including IPv6 placeholders and scoped IPv6 zones), Go Unicode whitespace normalization, `path.Match` character classes, UTF-8 name limits, nanosecond duration behavior, target limits, and the 1 MiB import/generated-output limits. Repository CI runs the complete Go, race, vet, web, and documentation suites.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have updated the relevant documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] No new external dependency or remote browser asset is introduced

## Additional Information

The configurator intentionally generates a file rather than hot-reloading the running process. This preserves OwlMail's current startup-validation model and avoids introducing a write-capable configuration API.