### PR TITLE
docs: sync soulteary/webhook integration demo

### DIFF
--- a/examples/webhooks/soulteary-webhook/README.md
+++ b/examples/webhooks/soulteary-webhook/README.md
@@ -5,6 +5,10 @@ This runnable example sends each new OwlMail message to
 request body with HMAC-SHA256, maps JSON fields into command environment
 variables, and runs `print-email.sh`.
 
+The Compose demo intentionally pins both released components: OwlMail `0.5.0`
+and WebHook `7.0.0`. This keeps the example reproducible instead of rebuilding
+OwlMail from a moving `main` branch.
+
 ## Files
 
 | File | Used by | Purpose |
@@ -12,7 +16,7 @@ variables, and runs `print-email.sh`.
 | [`owlmail.json`](./owlmail.json) | OwlMail | Environment-backed target URL and HMAC secret, retry policy, and custom JSON body. |
 | [`hooks.json.tmpl`](./hooks.json.tmpl) | `soulteary/webhook` | Hook, payload mapping, and `X-OwlMail-Signature` verification. |
 | [`print-email.sh`](./print-email.sh) | `soulteary/webhook` | Side-effect-free demo command that prints mapped fields. |
-| [`compose.yaml`](./compose.yaml) | Docker Compose | Builds OwlMail and starts both services on one private network. |
+| [`compose.yaml`](./compose.yaml) | Docker Compose | Starts released OwlMail and WebHook images on one private network. |
 
 ## Start the stack
 
@@ -20,20 +24,24 @@ From this directory:
 
 ```bash
 cd examples/webhooks/soulteary-webhook
-export OWLMAIL_WEBHOOK_SECRET='replace-with-a-long-random-secret'
-docker compose up --build
+export OWLMAIL_WEBHOOK_SECRET="$(openssl rand -hex 32)"
+docker compose up
 ```
 
 The Compose file has a development-only fallback secret so the demo can start,
-but set your own value whenever the ports are reachable by another machine.
-The same secret is passed to both containers. Compose also supplies the command
-and working-directory paths used inside the `webhook` container.
-`soulteary/webhook` starts in template mode so `getenv` can inject all three
-values into the hook definition. The Hook waits for the demo command and
-captures its output, so command failures become non-2xx responses to OwlMail.
-Debug logging is enabled so the command summary is visible in this demo; turn
-off `DEBUG` (and normally `VERBOSE`) before production because mapped email
-values can appear in logs.
+but set your own random value whenever the ports are reachable by another
+machine. The same secret is passed to both containers.
+
+OwlMail explicitly uses `OWLMAIL_WEBHOOK_MAX_CONCURRENCY=8`, its safe default.
+Keep the limit sized to downstream capacity. Set it to `0` only when unlimited
+webhook delivery is intentional and the receiving system can absorb it.
+
+`soulteary/webhook` starts in template mode so `getenv` can inject the secret,
+command, and working directory into the hook definition. The Hook waits for the
+demo command and captures its output, so command failures become non-2xx
+responses to OwlMail. Debug logging is enabled for this local demo; disable
+`DEBUG` (and normally `VERBOSE`) in production because mapped email values can
+appear in logs.
 
 ## Send a message
 
@@ -47,23 +55,15 @@ printf 'From: monitor@example.test\r\nTo: ops@example.test\r\nSubject: Demo aler
       --upload-file -
 ```
 
-Open `http://localhost:1080` to inspect the stored email. The Compose output for
-the `webhook` service prints a summary similar to:
-
-```text
-OwlMail webhook event
-  event: email.received
-  id: Ab12Cd34
-  title: Demo alert
-  from: monitor@example.test
-  to: ops@example.test
-  received: 2026-08-29T12:00:00Z
-  message: The integration works.
-```
+Open `http://localhost:1080` to inspect the stored email and
+`http://localhost:1080/webhooks` to inspect, import, validate, or generate the
+OwlMail webhook configuration. The Compose output for the `webhook` service
+prints the verified mapped event.
 
 If the secrets differ or the request body changes after signing,
 `soulteary/webhook` rejects the trigger and the command does not run. OwlMail
-logs the non-2xx delivery result and retries according to `owlmail.json`.
+logs the non-2xx delivery result and retries according to `owlmail.json`. Keep
+real handlers idempotent and use the email ID as a deduplication key.
 
 ## Stop and clean up
 
@@ -88,8 +88,14 @@ In another terminal, pass OwlMail the local Hook URL and the same secret:
 ```bash
 export OWLMAIL_WEBHOOK_URL='http://127.0.0.1:9000/hooks/owlmail'
 export OWLMAIL_WEBHOOK_SECRET='replace-with-a-long-random-secret'
+export OWLMAIL_WEBHOOK_MAX_CONCURRENCY=8
 owlmail -webhook-config owlmail.json
 ```
 
+For production, keep WebHook private or behind an authenticated reverse proxy,
+retain HMAC verification, restrict allowed command paths, bound execution and
+concurrency, and avoid logging full email bodies.
+
 [中文说明](./README.zh-CN.md) ·
-[Webhook forwarding reference](../../../docs/en/Webhook-Forwarding.md)
+[Webhook forwarding reference](../../../docs/en/Webhook-Forwarding.md) ·
+[WebHook-side integration guide](https://github.com/soulteary/webhook/blob/main/docs/en-US/OwlMail-Integration.md)

--- a/examples/webhooks/soulteary-webhook/README.zh-CN.md
+++ b/examples/webhooks/soulteary-webhook/README.zh-CN.md
@@ -4,6 +4,9 @@
 [`soulteary/webhook`](https://github.com/soulteary/webhook)，使用 HMAC-SHA256
 校验完整请求体，把 JSON 字段映射为命令环境变量，并执行 `print-email.sh`。
 
+Compose 示例固定使用已经发布的 OwlMail `0.5.0` 和 WebHook `7.0.0`，避免从
+持续变化的 `main` 分支重新构建 OwlMail，使示例更容易复现和长期维护。
+
 ## 文件说明
 
 | 文件 | 使用方 | 作用 |
@@ -11,7 +14,7 @@
 | [`owlmail.json`](./owlmail.json) | OwlMail | 环境变量目标 URL 与 HMAC 密钥、重试策略和自定义 JSON 请求体。 |
 | [`hooks.json.tmpl`](./hooks.json.tmpl) | `soulteary/webhook` | Hook、字段映射和 `X-OwlMail-Signature` 校验。 |
 | [`print-email.sh`](./print-email.sh) | `soulteary/webhook` | 无外部副作用、仅输出映射字段的演示命令。 |
-| [`compose.yaml`](./compose.yaml) | Docker Compose | 构建 OwlMail，并在同一私有网络启动两个服务。 |
+| [`compose.yaml`](./compose.yaml) | Docker Compose | 在同一私有网络启动已发布的 OwlMail 和 WebHook 镜像。 |
 
 ## 启动服务
 
@@ -19,16 +22,20 @@
 
 ```bash
 cd examples/webhooks/soulteary-webhook
-export OWLMAIL_WEBHOOK_SECRET='replace-with-a-long-random-secret'
-docker compose up --build
+export OWLMAIL_WEBHOOK_SECRET="$(openssl rand -hex 32)"
+docker compose up
 ```
 
-Compose 文件提供了仅用于本地演示的默认密钥，因此不设置变量也能启动；只要端口
-可能被其他机器访问，就应设置自己的长随机密钥。同一个密钥会传给两个容器。
-Compose 还会传入 `webhook` 容器内的命令和工作目录路径。`soulteary/webhook`
-使用模板模式启动，使 `getenv` 能把这三个值写入 Hook 定义。Hook 会等待演示命令
-完成并捕获输出，因此命令失败时会向 OwlMail 返回非 2xx 状态。
-本示例开启了调试日志以显示命令摘要；生产环境应关闭 `DEBUG`（通常也关闭
+Compose 文件保留了仅用于本地演示的默认密钥，因此不设置变量也能启动；只要端口
+可能被其他机器访问，就应该使用自己的随机密钥。同一个密钥会传给两个容器。
+
+OwlMail 显式设置 `OWLMAIL_WEBHOOK_MAX_CONCURRENCY=8`，与安全默认值一致。生产
+环境应根据下游处理能力设置上限；只有明确希望不限制并发，并确认接收端能够承受时，
+才应设置为 `0`。
+
+`soulteary/webhook` 使用模板模式启动，使 `getenv` 能把密钥、命令和工作目录写入
+Hook 定义。Hook 会等待演示命令完成并捕获输出，因此命令失败时会向 OwlMail 返回
+非 2xx 状态。本地 Demo 开启了调试日志；生产环境应关闭 `DEBUG`（通常也关闭
 `VERBOSE`），因为日志中可能出现映射后的邮件内容。
 
 ## 发送邮件
@@ -43,22 +50,13 @@ printf 'From: monitor@example.test\r\nTo: ops@example.test\r\nSubject: Demo aler
       --upload-file -
 ```
 
-打开 `http://localhost:1080` 可以查看已保存邮件。`webhook` 服务的 Compose
-日志会输出类似内容：
-
-```text
-OwlMail webhook event
-  event: email.received
-  id: Ab12Cd34
-  title: Demo alert
-  from: monitor@example.test
-  to: ops@example.test
-  received: 2026-08-29T12:00:00Z
-  message: The integration works.
-```
+打开 `http://localhost:1080` 可以查看已保存邮件；打开
+`http://localhost:1080/webhooks` 可以查看、导入、校验或生成 OwlMail Webhook
+配置。`webhook` 服务日志会输出通过签名验证并完成字段映射后的事件。
 
 如果两边密钥不同，或请求体在签名后被修改，`soulteary/webhook` 会拒绝触发，
 命令不会执行。OwlMail 会记录非 2xx 结果，并按照 `owlmail.json` 进行重试。
+实际业务处理器应保持幂等，并使用邮件 ID 作为去重键。
 
 ## 停止并清理
 
@@ -78,13 +76,18 @@ export OWLMAIL_WEBHOOK_WORKDIR="$PWD"
 webhook -template -hooks hooks.json.tmpl -verbose -debug
 ```
 
-在另一个终端传入本机 Hook 地址和相同密钥，再启动 OwlMail：
+在另一个终端传入本机 Hook 地址、相同密钥和并发限制，再启动 OwlMail：
 
 ```bash
 export OWLMAIL_WEBHOOK_URL='http://127.0.0.1:9000/hooks/owlmail'
 export OWLMAIL_WEBHOOK_SECRET='replace-with-a-long-random-secret'
+export OWLMAIL_WEBHOOK_MAX_CONCURRENCY=8
 owlmail -webhook-config owlmail.json
 ```
 
+生产环境建议保持 WebHook 仅内网可访问或放在带鉴权的反向代理之后，继续启用 HMAC
+验证，限制允许执行的命令路径，设置执行时间和并发上限，并避免记录完整邮件正文。
+
 [English](./README.md) ·
-[Webhook 消息转发参考](../../../docs/zh-CN/Webhook-Forwarding.md)
+[Webhook 消息转发参考](../../../docs/zh-CN/Webhook-Forwarding.md) ·
+[WebHook 侧联动指南](https://github.com/soulteary/webhook/blob/main/docs/zh-CN/OwlMail-Integration.md)

--- a/examples/webhooks/soulteary-webhook/compose.yaml
+++ b/examples/webhooks/soulteary-webhook/compose.yaml
@@ -1,6 +1,6 @@
 services:
   webhook:
-    image: soulteary/webhook:extend-5.0.0
+    image: soulteary/webhook:7.0.0
     ports:
       - "9000:9000"
     environment:
@@ -23,8 +23,7 @@ services:
       retries: 15
 
   owlmail:
-    build:
-      context: ../../..
+    image: soulteary/owlmail:0.5.0
     depends_on:
       webhook:
         condition: service_healthy
@@ -37,5 +36,6 @@ services:
       OWLMAIL_WEBHOOK_CONFIG: "/app/config/owlmail.json"
       OWLMAIL_WEBHOOK_URL: "http://webhook:9000/hooks/owlmail"
       OWLMAIL_WEBHOOK_SECRET: "${OWLMAIL_WEBHOOK_SECRET:-local-demo-change-me}"
+      OWLMAIL_WEBHOOK_MAX_CONCURRENCY: "8"
     volumes:
       - ./owlmail.json:/app/config/owlmail.json:ro


### PR DESCRIPTION
## Summary

- pin the reverse integration demo to released `soulteary/owlmail:0.5.0` and `soulteary/webhook:7.0.0` images
- stop rebuilding OwlMail from a moving `main` checkout in the Compose example
- make `OWLMAIL_WEBHOOK_MAX_CONCURRENCY=8` explicit and document `0` as intentional unlimited delivery
- update English and Chinese instructions for the `/webhooks` configurator, retries/idempotency, HMAC verification, and production hardening
- cross-link the WebHook-side integration guides merged in soulteary/webhook#156

## Why

The WebHook repository now ships a v0.5.0-aligned OwlMail integration example. OwlMail's reverse example still referenced the older `extend-5.0.0` WebHook image and locally rebuilt OwlMail. Keeping both repositories aligned makes the two-way documentation reproducible and prevents version drift.

## Usage

```bash
cd examples/webhooks/soulteary-webhook
export OWLMAIL_WEBHOOK_SECRET="$(openssl rand -hex 32)"
docker compose up
```

Then use `http://localhost:1080` for the inbox and `http://localhost:1080/webhooks` for the webhook configurator.