### PR TITLE
feat(webhook): add durable Redis delivery semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ All notable changes to OwlMail are documented in this file. The format follows
 - The in-memory mail store now uses an ID map with ordered IDs and returns deep
   snapshots to API, WebSocket, webhook, and other event consumers.
 
+### Added
+
+- Optional Redis Streams-backed Webhook delivery with restart recovery,
+  dead-letter records, stable delivery IDs, graceful drain, and replay-aware
+  HMAC headers containing a timestamp and nonce.
+
 ## [0.5.0]
 
 ### Added

--- a/README.de.md
+++ b/README.de.md
@@ -215,6 +215,9 @@ docker buildx build \
 | `-auto-relay-rules` | `MAILDEV_AUTO_RELAY_RULES` / `OWLMAIL_AUTO_RELAY_RULES` | - | Auto-Relay-Regeldatei |
 | `-webhook-config` | `OWLMAIL_WEBHOOK_CONFIG` | - | JSON-Konfigurationsdatei für Webhook-Weiterleitung |
 | `-webhook-max-concurrency` | `OWLMAIL_WEBHOOK_MAX_CONCURRENCY` | 8 | Gleichzeitige Webhook-Zustellungen; `0` deaktiviert die Begrenzung |
+| `-webhook-redis-url` | `OWLMAIL_WEBHOOK_REDIS_URL` | - | Redis URL for durable webhook delivery |
+| `-webhook-redis-prefix` | `OWLMAIL_WEBHOOK_REDIS_PREFIX` | owlmail:webhooks | Redis Streams key prefix |
+| `-webhook-shutdown-timeout` | `OWLMAIL_WEBHOOK_SHUTDOWN_TIMEOUT` | 15s | Graceful webhook drain deadline |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | Eingehender SMTP-Benutzername; derzeit nicht erzwungen |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | Eingehendes SMTP-Passwort; derzeit nicht erzwungen |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | SMTP TLS aktivieren |

--- a/README.fr.md
+++ b/README.fr.md
@@ -216,6 +216,9 @@ docker buildx build \
 | `-auto-relay-rules` | `MAILDEV_AUTO_RELAY_RULES` / `OWLMAIL_AUTO_RELAY_RULES` | - | Auto relay rules file |
 | `-webhook-config` | `OWLMAIL_WEBHOOK_CONFIG` | - | JSON webhook forwarding configuration file |
 | `-webhook-max-concurrency` | `OWLMAIL_WEBHOOK_MAX_CONCURRENCY` | 8 | Livraisons Webhook simultanées ; `0` désactive la limite |
+| `-webhook-redis-url` | `OWLMAIL_WEBHOOK_REDIS_URL` | - | Redis URL for durable webhook delivery |
+| `-webhook-redis-prefix` | `OWLMAIL_WEBHOOK_REDIS_PREFIX` | owlmail:webhooks | Redis Streams key prefix |
+| `-webhook-shutdown-timeout` | `OWLMAIL_WEBHOOK_SHUTDOWN_TIMEOUT` | 15s | Graceful webhook drain deadline |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | Nom d’utilisateur SMTP entrant ; pas encore appliqué |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | Mot de passe SMTP entrant ; pas encore appliqué |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | Enable SMTP TLS |

--- a/README.it.md
+++ b/README.it.md
@@ -215,6 +215,9 @@ docker buildx build \
 | `-auto-relay-rules` | `MAILDEV_AUTO_RELAY_RULES` / `OWLMAIL_AUTO_RELAY_RULES` | - | File regole inoltro automatico |
 | `-webhook-config` | `OWLMAIL_WEBHOOK_CONFIG` | - | File JSON di configurazione dell'inoltro webhook |
 | `-webhook-max-concurrency` | `OWLMAIL_WEBHOOK_MAX_CONCURRENCY` | 8 | Consegne Webhook simultanee; `0` disabilita il limite |
+| `-webhook-redis-url` | `OWLMAIL_WEBHOOK_REDIS_URL` | - | Redis URL for durable webhook delivery |
+| `-webhook-redis-prefix` | `OWLMAIL_WEBHOOK_REDIS_PREFIX` | owlmail:webhooks | Redis Streams key prefix |
+| `-webhook-shutdown-timeout` | `OWLMAIL_WEBHOOK_SHUTDOWN_TIMEOUT` | 15s | Graceful webhook drain deadline |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | Nome utente SMTP in ingresso; attualmente non applicato |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | Password SMTP in ingresso; attualmente non applicata |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | Abilita TLS SMTP |

--- a/README.ja.md
+++ b/README.ja.md
@@ -215,6 +215,9 @@ docker buildx build \
 | `-auto-relay-rules` | `MAILDEV_AUTO_RELAY_RULES` / `OWLMAIL_AUTO_RELAY_RULES` | - | Auto relay rules file |
 | `-webhook-config` | `OWLMAIL_WEBHOOK_CONFIG` | - | JSON webhook forwarding configuration file |
 | `-webhook-max-concurrency` | `OWLMAIL_WEBHOOK_MAX_CONCURRENCY` | 8 | 同時 Webhook 配信数。`0` は上限なし |
+| `-webhook-redis-url` | `OWLMAIL_WEBHOOK_REDIS_URL` | - | Redis URL for durable webhook delivery |
+| `-webhook-redis-prefix` | `OWLMAIL_WEBHOOK_REDIS_PREFIX` | owlmail:webhooks | Redis Streams key prefix |
+| `-webhook-shutdown-timeout` | `OWLMAIL_WEBHOOK_SHUTDOWN_TIMEOUT` | 15s | Graceful webhook drain deadline |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | 受信 SMTP ユーザー名。現在は強制されません |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | 受信 SMTP パスワード。現在は強制されません |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | Enable SMTP TLS |

--- a/README.ko.md
+++ b/README.ko.md
@@ -215,6 +215,9 @@ docker buildx build \
 | `-auto-relay-rules` | `MAILDEV_AUTO_RELAY_RULES` / `OWLMAIL_AUTO_RELAY_RULES` | - | Auto relay rules file |
 | `-webhook-config` | `OWLMAIL_WEBHOOK_CONFIG` | - | JSON webhook forwarding configuration file |
 | `-webhook-max-concurrency` | `OWLMAIL_WEBHOOK_MAX_CONCURRENCY` | 8 | 동시 Webhook 전달 수; `0`은 제한 없음 |
+| `-webhook-redis-url` | `OWLMAIL_WEBHOOK_REDIS_URL` | - | Redis URL for durable webhook delivery |
+| `-webhook-redis-prefix` | `OWLMAIL_WEBHOOK_REDIS_PREFIX` | owlmail:webhooks | Redis Streams key prefix |
+| `-webhook-shutdown-timeout` | `OWLMAIL_WEBHOOK_SHUTDOWN_TIMEOUT` | 15s | Graceful webhook drain deadline |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | 인바운드 SMTP 사용자 이름; 현재 강제되지 않음 |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | 인바운드 SMTP 비밀번호; 현재 강제되지 않음 |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | Enable SMTP TLS |

--- a/README.md
+++ b/README.md
@@ -238,6 +238,9 @@ the message body; clicking one focuses OwlMail and opens the message.
 | `-auto-relay-rules` | `MAILDEV_AUTO_RELAY_RULES` / `OWLMAIL_AUTO_RELAY_RULES` | - | Auto relay rules file |
 | `-webhook-config` | `OWLMAIL_WEBHOOK_CONFIG` | - | JSON webhook forwarding configuration file |
 | `-webhook-max-concurrency` | `OWLMAIL_WEBHOOK_MAX_CONCURRENCY` | 8 | Concurrent email webhook deliveries; `0` disables the limit |
+| `-webhook-redis-url` | `OWLMAIL_WEBHOOK_REDIS_URL` | - | Redis URL for durable, restart-safe webhook delivery |
+| `-webhook-redis-prefix` | `OWLMAIL_WEBHOOK_REDIS_PREFIX` | owlmail:webhooks | Redis Streams key prefix |
+| `-webhook-shutdown-timeout` | `OWLMAIL_WEBHOOK_SHUTDOWN_TIMEOUT` | 15s | Graceful webhook drain deadline |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | Inbound SMTP username setting; not currently enforced |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | Inbound SMTP password setting; not currently enforced |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | Enable SMTP TLS |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -231,6 +231,9 @@ Notifications API 需要 HTTPS，或 `http://localhost` 等受信任的本地来
 | `-auto-relay-rules` | `MAILDEV_AUTO_RELAY_RULES` / `OWLMAIL_AUTO_RELAY_RULES` | - | 自动中继规则文件 |
 | `-webhook-config` | `OWLMAIL_WEBHOOK_CONFIG` | - | Webhook 消息转发 JSON 配置文件 |
 | `-webhook-max-concurrency` | `OWLMAIL_WEBHOOK_MAX_CONCURRENCY` | 8 | Webhook 邮件并发投递数；`0` 表示不限制 |
+| `-webhook-redis-url` | `OWLMAIL_WEBHOOK_REDIS_URL` | - | 用于持久、可跨重启投递的 Redis URL |
+| `-webhook-redis-prefix` | `OWLMAIL_WEBHOOK_REDIS_PREFIX` | owlmail:webhooks | Redis Streams 键前缀 |
+| `-webhook-shutdown-timeout` | `OWLMAIL_WEBHOOK_SHUTDOWN_TIMEOUT` | 15s | Webhook 优雅排空截止时间 |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | 入站 SMTP 用户名设置；当前未强制执行 |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | 入站 SMTP 密码设置；当前未强制执行 |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | 启用 SMTP TLS |

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
@@ -10,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/soulteary/owlmail/internal/api"
 	"github.com/soulteary/owlmail/internal/common"
@@ -189,18 +189,20 @@ func registerWebhookHandler(server *mailserver.MailServer, dispatcher *webhookno
 	if server == nil || dispatcher == nil {
 		return nil
 	}
-
-	err := server.OnWithConcurrency("new", maxConcurrency, func(email *mailserver.Email) {
-		for _, result := range dispatcher.Dispatch(context.Background(), email) {
-			if result.Err != nil {
-				common.Error("Webhook delivery to %q failed after %d attempt(s): %v", result.Target, result.Attempts, result.Err)
-				continue
-			}
-			common.Verbose("Webhook delivery to %q succeeded with HTTP %d", result.Target, result.StatusCode)
-		}
+	service, err := webhooknotify.NewService(dispatcher, webhooknotify.ServiceOptions{
+		MaxConcurrency: maxConcurrency,
+		OnResults:      logWebhookResults,
 	})
 	if err != nil {
-		return fmt.Errorf("register webhook handler: %w", err)
+		return fmt.Errorf("create webhook service: %w", err)
+	}
+	if err := registerWebhookService(server, service); err != nil {
+		_ = service.Close()
+		return err
+	}
+	if err := server.AddCloser(service); err != nil {
+		_ = service.Close()
+		return fmt.Errorf("register webhook closer: %w", err)
 	}
 	if maxConcurrency == 0 {
 		common.Log("Webhook forwarding enabled with %d target(s), unlimited concurrency", dispatcher.TargetCount())
@@ -208,6 +210,52 @@ func registerWebhookHandler(server *mailserver.MailServer, dispatcher *webhookno
 		common.Log("Webhook forwarding enabled with %d target(s), concurrency limit %d", dispatcher.TargetCount(), maxConcurrency)
 	}
 	return nil
+}
+
+func setupWebhookService(cfg *config.Config, dispatcher *webhooknotify.Dispatcher) (*webhooknotify.Service, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config is nil")
+	}
+	if dispatcher == nil {
+		return nil, nil
+	}
+	shutdownTimeout, err := time.ParseDuration(cfg.WebhookShutdownTimeout)
+	if err != nil || shutdownTimeout <= 0 {
+		return nil, fmt.Errorf("invalid webhook shutdown timeout %q", cfg.WebhookShutdownTimeout)
+	}
+	service, err := webhooknotify.NewService(dispatcher, webhooknotify.ServiceOptions{
+		RedisURL: cfg.WebhookRedisURL, RedisPrefix: cfg.WebhookRedisPrefix,
+		MaxConcurrency: cfg.WebhookMaxConcurrency, ShutdownTimeout: shutdownTimeout,
+		OnResults: logWebhookResults,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create webhook delivery service: %w", err)
+	}
+	return service, nil
+}
+
+func registerWebhookService(server *mailserver.MailServer, service *webhooknotify.Service) error {
+	if server == nil || service == nil {
+		return nil
+	}
+	if err := server.OnSynchronous("new", func(email *mailserver.Email) {
+		if err := service.Enqueue(email); err != nil {
+			common.Error("Failed to enqueue webhook delivery: %v", err)
+		}
+	}); err != nil {
+		return fmt.Errorf("register webhook queue handoff: %w", err)
+	}
+	return nil
+}
+
+func logWebhookResults(deliveryID string, results []webhooknotify.Result) {
+	for _, result := range results {
+		if result.Err != nil {
+			common.Error("Webhook delivery %q to %q failed after %d attempt(s): %v", deliveryID, result.Target, result.Attempts, result.Err)
+			continue
+		}
+		common.Verbose("Webhook delivery %q to %q succeeded with HTTP %d", deliveryID, result.Target, result.StatusCode)
+	}
 }
 
 // startAPIServer creates and starts the API server
@@ -310,9 +358,27 @@ func createMailServer(cfg *config.Config) (*mailserver.MailServer, error) {
 
 	// Register event handlers
 	registerEventHandlers(server)
-	if err := registerWebhookHandler(server, webhookDispatcher, cfg.WebhookMaxConcurrency); err != nil {
+	webhookService, err := setupWebhookService(cfg, webhookDispatcher)
+	if err != nil {
 		_ = server.Close()
 		return nil, err
+	}
+	if webhookService != nil {
+		if err := registerWebhookService(server, webhookService); err != nil {
+			_ = webhookService.Close()
+			_ = server.Close()
+			return nil, err
+		}
+		if err := server.AddCloser(webhookService); err != nil {
+			_ = webhookService.Close()
+			_ = server.Close()
+			return nil, err
+		}
+		mode := "in-memory"
+		if cfg.WebhookRedisURL != "" {
+			mode = "Redis durable"
+		}
+		common.Log("Webhook forwarding enabled with %d target(s), %s queue, concurrency %d", webhookDispatcher.TargetCount(), mode, cfg.WebhookMaxConcurrency)
 	}
 
 	return server, nil

--- a/docs/en/Webhook-Forwarding.md
+++ b/docs/en/Webhook-Forwarding.md
@@ -46,6 +46,14 @@ export OWLMAIL_WEBHOOK_CONFIG=./webhooks.json
 export OWLMAIL_WEBHOOK_MAX_CONCURRENCY=8
 ```
 
+For durable, restart-safe handoff, add Redis 6.2 or newer:
+
+```bash
+export OWLMAIL_WEBHOOK_REDIS_URL=redis://redis:6379/0
+export OWLMAIL_WEBHOOK_REDIS_PREFIX=owlmail:webhooks
+export OWLMAIL_WEBHOOK_SHUTDOWN_TIMEOUT=15s
+```
+
 If neither the flag nor environment variable is set, webhook forwarding is
 disabled. The configuration is validated once at startup; restart OwlMail after
 editing it.
@@ -108,7 +116,7 @@ loopback-only receiver, exact startup commands, and a test SMTP message.
 | `method` | No | `POST` by default; `POST`, `PUT`, and `PATCH` are accepted. |
 | `headers` | No | Static request headers. Header names and values are validated; `Host` and `Content-Length` cannot be overridden. |
 | `contentType` | No | `application/json` by default. An explicit `Content-Type` header takes precedence. |
-| `secret` | No | Generates `X-OwlMail-Signature: sha256=<hex>` over the exact request body. |
+| `secret` | No | Generates replay-aware `X-OwlMail-Signature-V2` plus a legacy body-only signature. |
 | `timeout` | No | Per-attempt timeout; default `5s`, maximum `1m`. |
 | `retries` | No | Extra attempts from zero to five. Only network errors, 408, 425, 429, and 5xx responses are retried. |
 | `match` | No | Case-insensitive wildcard rules. See the rule semantics below. |
@@ -134,6 +142,27 @@ matching rules, or `bodyTemplate`.
 - All targets and templates are compiled before SMTP and Web servers start, so
   a configuration error fails fast without partially enabling forwarding.
 
+## Durable delivery, dead letters, and shutdown
+
+When `OWLMAIL_WEBHOOK_REDIS_URL` is set, OwlMail writes each stored-email event
+to a Redis Stream before the event handoff returns. Consumer-group workers
+acknowledge and delete an entry only after every matching target succeeds.
+Entries left pending by a crashed process are reclaimed after 30 seconds. If a
+target still fails after its configured retries, OwlMail moves a record with
+the delivery error to `<prefix>:dead-letter` and removes the live entry.
+
+Delivery is at least once: a crash after the receiver accepts a request but
+before Redis is acknowledged can produce a duplicate. Deduplicate the stable
+`X-OwlMail-Delivery-ID`; the email ID alone is not sufficient if future event
+types can create multiple deliveries for one email. Redis must be reachable at
+startup. This consumer setup is intended for one active OwlMail instance per
+prefix.
+
+Shutdown stops SMTP intake, stops accepting queue handoffs, drains queued and
+in-flight deliveries for up to `-webhook-shutdown-timeout`, then cancels the
+shared delivery context. Without Redis, the same drain behavior applies but
+queued jobs do not survive a process or host failure.
+
 ## Concurrency and backpressure
 
 `-webhook-max-concurrency` limits concurrent email delivery jobs across all
@@ -141,13 +170,10 @@ targets. The default of `8` is appropriate for local development and small CI
 environments. A useful starting estimate is peak emails per second multiplied
 by the receiver's p95 response time in seconds, rounded up.
 
-The limit is acquired before OwlMail creates the webhook handler goroutine. If
-all slots are busy, the email is already persisted and event processing waits
-for a slot; lightweight logging and WebSocket listeners are still started
-first. SMTP `DATA` completion can therefore wait for a slot even though the
-message has already been stored. This intentional backpressure prevents slow
-receivers from creating an unbounded goroutine pile. Within one job, matching
-targets are delivered sequentially.
+The limit sizes queue consumers rather than goroutines waiting on a semaphore.
+SMTP `DATA` completion waits only for the queue handoff (including the Redis append in
+durable mode), not for the target HTTP request. Within one job, matching targets
+are delivered sequentially.
 
 Use `0` only when unlimited fan-out is intentional. It preserves the previous
 behavior and can consume large amounts of memory and sockets during a burst.
@@ -252,11 +278,14 @@ local storage paths are never included.
 | `Content-Type` | Target `contentType`, defaulting to `application/json`; an explicit custom header wins. |
 | `User-Agent` | `OwlMail-Webhook/1`, unless overridden by a custom header. |
 | `X-OwlMail-Event` | Always `email.received`. |
-| `X-OwlMail-Email-ID` | Exact OwlMail email ID; use it as an idempotency key. |
-| `X-OwlMail-Signature` | Present only when `secret` is set; `sha256=` plus lowercase hex HMAC over the exact body bytes. |
+| `X-OwlMail-Email-ID` | Exact OwlMail email ID. |
+| `X-OwlMail-Delivery-ID` | Stable queue job ID; use it as the idempotency key. |
+| `X-OwlMail-Timestamp` | UTC RFC 3339 signing time, present when `secret` is set. |
+| `X-OwlMail-Nonce` | Fresh random value for every HTTP attempt, present when `secret` is set. |
+| `X-OwlMail-Signature-V2` | `v2=` plus lowercase HMAC-SHA256 over `timestamp + "." + nonce + "." + exact body`. Receivers should require this header, enforce a short timestamp window, and reject reused nonces. |
+| `X-OwlMail-Signature` | Legacy body-only signature retained for compatibility; it does not provide replay protection. |
 
-Retries send the same body and email ID, so receivers should deduplicate before
-performing a non-idempotent action.
+Retries send the same body and delivery ID but a fresh timestamp and nonce.
 
 ## Send to `soulteary/webhook`
 

--- a/docs/zh-CN/Webhook-Forwarding.md
+++ b/docs/zh-CN/Webhook-Forwarding.md
@@ -42,6 +42,14 @@ export OWLMAIL_WEBHOOK_CONFIG=./webhooks.json
 export OWLMAIL_WEBHOOK_MAX_CONCURRENCY=8
 ```
 
+如需持久且可跨重启恢复的交接，可配置 Redis 6.2 或更高版本：
+
+```bash
+export OWLMAIL_WEBHOOK_REDIS_URL=redis://redis:6379/0
+export OWLMAIL_WEBHOOK_REDIS_PREFIX=owlmail:webhooks
+export OWLMAIL_WEBHOOK_SHUTDOWN_TIMEOUT=15s
+```
+
 没有设置参数或环境变量时，Webhook 转发保持关闭。配置只在启动时校验一次；
 修改文件后需要重启 OwlMail。
 
@@ -101,7 +109,7 @@ export OWLMAIL_WEBHOOK_MAX_CONCURRENCY=8
 | `method` | 否 | 默认 `POST`，支持 `POST`、`PUT`、`PATCH`。 |
 | `headers` | 否 | 静态请求头；名称和值会被校验，不能覆盖 `Host` 和 `Content-Length`。 |
 | `contentType` | 否 | 默认 `application/json`；显式 `Content-Type` 请求头优先。 |
-| `secret` | 否 | 对最终请求体生成 `X-OwlMail-Signature: sha256=<hex>`。 |
+| `secret` | 否 | 生成防重放的 `X-OwlMail-Signature-V2`，同时保留旧版仅正文签名。 |
 | `timeout` | 否 | 每次请求的超时，默认 `5s`，最大 `1m`。 |
 | `retries` | 否 | 0～5 次额外尝试；仅网络错误、408、425、429 和 5xx 会重试。 |
 | `match` | 否 | 不区分大小写的通配符规则，语义见下文。 |
@@ -121,16 +129,30 @@ export OWLMAIL_WEBHOOK_MAX_CONCURRENCY=8
 - `retries` 表示额外尝试次数，例如 `2` 表示最多请求三次；
 - SMTP 和 Web 服务启动前，会先编译全部目标与模板，因此错误配置不会造成部分启用。
 
+## 持久投递、死信与退出排空
+
+设置 `OWLMAIL_WEBHOOK_REDIS_URL` 后，OwlMail 会先把已存储邮件的事件写入 Redis
+Stream，再结束事件交接。consumer group worker 仅在所有匹配目标成功后确认并删除
+条目；进程崩溃遗留的 pending 条目会在 30 秒后被重新认领。目标耗尽自身重试后，
+包含投递错误的记录会写入 `<prefix>:dead-letter`，随后移除活动条目。
+
+该语义是“至少一次”：若接收端已经成功、但进程在确认 Redis 前崩溃，重启后会
+重复投递。接收端应使用稳定的 `X-OwlMail-Delivery-ID` 去重。Redis 必须在启动时
+可访问；当前 consumer 配置面向每个前缀单个活动 OwlMail 实例。
+
+退出时会先停止 SMTP 入口和新的队列交接，在 `-webhook-shutdown-timeout` 内排空排队
+及执行中的投递，超时后再取消共享上下文。未配置 Redis 时同样会排空，但队列
+无法在进程或主机故障后恢复。
+
 ## 并发与背压
 
 `-webhook-max-concurrency` 限制所有目标共享的并发邮件投递任务数。默认值 `8`
 适合本地开发和小型 CI 环境。估算初始值时，可以用“峰值每秒邮件数 × 接收端
 p95 响应秒数”，然后向上取整。
 
-OwlMail 会在创建 Webhook 处理 goroutine 之前获取并发槽位。槽位耗尽时，邮件已经
-持久化，事件处理会等待空闲槽位；轻量日志和 WebSocket 监听器仍会优先启动。
-因此即使邮件已经保存，SMTP `DATA` 命令也可能等待投递槽位后才完成；这种主动
-背压可避免慢接收端制造无限增长的 goroutine。单个任务内的匹配目标仍按顺序投递。
+该限制决定队列 consumer 数量，而不是等待信号量的 goroutine 数量。SMTP `DATA` 命令
+只等待队列交接（持久模式包括 Redis append），不等待目标 HTTP 请求。单个任务内
+的匹配目标仍按顺序投递。
 
 `0` 会保留旧版的无限并发行为，只应在明确需要无限制分发时使用；突发流量下可能
 消耗大量内存和连接。
@@ -231,10 +253,14 @@ OwlMail 会在创建 Webhook 处理 goroutine 之前获取并发槽位。槽位�
 | `Content-Type` | 目标的 `contentType`，默认为 `application/json`；显式自定义请求头优先。 |
 | `User-Agent` | 默认为 `OwlMail-Webhook/1`，可用自定义请求头覆盖。 |
 | `X-OwlMail-Event` | 固定为 `email.received`。 |
-| `X-OwlMail-Email-ID` | OwlMail 邮件 ID，可作为幂等键。 |
-| `X-OwlMail-Signature` | 只在配置 `secret` 时发送；格式为 `sha256=` 加上对原始请求体计算的十六进制小写 HMAC。 |
+| `X-OwlMail-Email-ID` | OwlMail 邮件 ID。 |
+| `X-OwlMail-Delivery-ID` | 稳定的队列任务 ID，接收端应以此作为幂等键。 |
+| `X-OwlMail-Timestamp` | 配置 `secret` 时发送的 UTC RFC 3339 签名时间。 |
+| `X-OwlMail-Nonce` | 每次 HTTP 尝试使用的新随机值。 |
+| `X-OwlMail-Signature-V2` | `v2=` 加上对 `timestamp + "." + nonce + "." + 原始请求体` 计算的 HMAC-SHA256。接收端应要求此头、限制时间窗口并拒绝重复 nonce。 |
+| `X-OwlMail-Signature` | 为兼容旧接收端保留的仅正文签名，不具备防重放能力。 |
 
-重试会使用相同的请求体和邮件 ID。接收端在执行非幂等操作前应先去重。
+重试使用相同请求体和 delivery ID，但每次生成新的时间戳与 nonce。
 
 ## 发送到 `soulteary/webhook`
 

--- a/examples/webhooks/README.md
+++ b/examples/webhooks/README.md
@@ -81,7 +81,8 @@ export OWLMAIL_WEBHOOK_SECRET='replace-this-development-secret'
 ./owlmail -webhook-config ./examples/webhooks/custom-json.json
 ```
 
-The receiver verifies `X-OwlMail-Signature`. It deliberately logs only whether
+The receiver verifies `X-OwlMail-Signature-V2`, enforces a five-minute signing
+window, and rejects reused nonces. It deliberately logs only whether
 the `Authorization` header is present, never its value.
 
 ### Multiple targets

--- a/examples/webhooks/README.zh-CN.md
+++ b/examples/webhooks/README.zh-CN.md
@@ -80,7 +80,8 @@ export OWLMAIL_WEBHOOK_SECRET='replace-this-development-secret'
 ./owlmail -webhook-config ./examples/webhooks/custom-json.json
 ```
 
-接收器会校验 `X-OwlMail-Signature`。对于 `Authorization`，它只记录请求头
+接收器会校验 `X-OwlMail-Signature-V2`、限制签名时间为五分钟，并拒绝重复 nonce。
+对于 `Authorization`，它只记录请求头
 是否存在，不会输出 Token 内容。
 
 ### 多目标分发

--- a/examples/webhooks/receiver/main.go
+++ b/examples/webhooks/receiver/main.go
@@ -11,13 +11,22 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 )
 
 const (
-	listenAddress  = "127.0.0.1:18080"
-	maxRequestBody = 2 << 20
+	listenAddress   = "127.0.0.1:18080"
+	maxRequestBody  = 2 << 20
+	maxSignatureAge = 5 * time.Minute
 )
+
+var replayNonces = &nonceCache{seen: make(map[string]time.Time)}
+
+type nonceCache struct {
+	mu   sync.Mutex
+	seen map[string]time.Time
+}
 
 func main() {
 	server := &http.Server{
@@ -43,7 +52,12 @@ func receive(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	verified, err := verifySignature(request.Header.Get("X-OwlMail-Signature"), body, os.Getenv("OWLMAIL_WEBHOOK_SECRET"))
+	verified, err := verifySignature(
+		request.Header.Get("X-OwlMail-Signature-V2"),
+		request.Header.Get("X-OwlMail-Timestamp"),
+		request.Header.Get("X-OwlMail-Nonce"),
+		body, os.Getenv("OWLMAIL_WEBHOOK_SECRET"), time.Now().UTC(), replayNonces,
+	)
 	if err != nil {
 		http.Error(writer, err.Error(), http.StatusUnauthorized)
 		return
@@ -62,10 +76,10 @@ func receive(writer http.ResponseWriter, request *http.Request) {
 	writer.WriteHeader(http.StatusNoContent)
 }
 
-func verifySignature(signature string, body []byte, secret string) (bool, error) {
+func verifySignature(signature, timestamp, nonce string, body []byte, secret string, now time.Time, nonces *nonceCache) (bool, error) {
 	if signature == "" {
 		if secret != "" {
-			return false, fmt.Errorf("X-OwlMail-Signature is required when OWLMAIL_WEBHOOK_SECRET is set")
+			return false, fmt.Errorf("X-OwlMail-Signature-V2 is required when OWLMAIL_WEBHOOK_SECRET is set")
 		}
 		return false, nil
 	}
@@ -73,18 +87,44 @@ func verifySignature(signature string, body []byte, secret string) (bool, error)
 		return false, nil
 	}
 
-	const prefix = "sha256="
+	if timestamp == "" || nonce == "" {
+		return false, fmt.Errorf("timestamp and nonce are required")
+	}
+	signedAt, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil || signedAt.After(now.Add(time.Minute)) || now.Sub(signedAt) > maxSignatureAge {
+		return false, fmt.Errorf("webhook signature timestamp is outside the accepted window")
+	}
+	const prefix = "v2="
 	if len(signature) <= len(prefix) || signature[:len(prefix)] != prefix {
-		return false, fmt.Errorf("invalid X-OwlMail-Signature format")
+		return false, fmt.Errorf("invalid X-OwlMail-Signature-V2 format")
 	}
 	provided, err := hex.DecodeString(signature[len(prefix):])
 	if err != nil {
-		return false, fmt.Errorf("invalid X-OwlMail-Signature encoding")
+		return false, fmt.Errorf("invalid X-OwlMail-Signature-V2 encoding")
 	}
 	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(timestamp + "." + nonce + "."))
 	_, _ = mac.Write(body)
 	if !hmac.Equal(provided, mac.Sum(nil)) {
-		return false, fmt.Errorf("X-OwlMail-Signature verification failed")
+		return false, fmt.Errorf("X-OwlMail-Signature-V2 verification failed")
+	}
+	if nonces != nil && !nonces.use(nonce, now.Add(maxSignatureAge), now) {
+		return false, fmt.Errorf("webhook nonce was already used")
 	}
 	return true, nil
+}
+
+func (cache *nonceCache) use(nonce string, expiresAt, now time.Time) bool {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	for value, expiry := range cache.seen {
+		if !expiry.After(now) {
+			delete(cache.seen, value)
+		}
+	}
+	if _, exists := cache.seen[nonce]; exists {
+		return false
+	}
+	cache.seen[nonce] = expiresAt
+	return true
 }

--- a/examples/webhooks/receiver/main_test.go
+++ b/examples/webhooks/receiver/main_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestReceiveUnsignedRequest(t *testing.T) {
@@ -27,17 +28,49 @@ func TestReceiveVerifiesSignature(t *testing.T) {
 	body := []byte(`{"event":"email.received"}`)
 	t.Setenv("OWLMAIL_WEBHOOK_SECRET", secret)
 
+	timestamp := time.Now().UTC().Format(time.RFC3339)
+	nonce := "test-nonce"
 	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(timestamp + "." + nonce + "."))
 	_, _ = mac.Write(body)
-	signature := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	signature := "v2=" + hex.EncodeToString(mac.Sum(nil))
 
 	recorder := httptest.NewRecorder()
 	request := httptest.NewRequest(http.MethodPost, "/owlmail", bytes.NewReader(body))
-	request.Header.Set("X-OwlMail-Signature", signature)
+	request.Header.Set("X-OwlMail-Signature-V2", signature)
+	request.Header.Set("X-OwlMail-Timestamp", timestamp)
+	request.Header.Set("X-OwlMail-Nonce", nonce)
 	receive(recorder, request)
 
 	if recorder.Code != http.StatusNoContent {
 		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNoContent)
+	}
+}
+
+func TestReceiveRejectsReplayedSignature(t *testing.T) {
+	const secret = "example-secret"
+	body := []byte(`{"event":"email.received"}`)
+	t.Setenv("OWLMAIL_WEBHOOK_SECRET", secret)
+	timestamp := time.Now().UTC().Format(time.RFC3339)
+	nonce := "replayed-nonce"
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(timestamp + "." + nonce + "."))
+	_, _ = mac.Write(body)
+	signature := "v2=" + hex.EncodeToString(mac.Sum(nil))
+	for attempt := 0; attempt < 2; attempt++ {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodPost, "/owlmail", bytes.NewReader(body))
+		request.Header.Set("X-OwlMail-Signature-V2", signature)
+		request.Header.Set("X-OwlMail-Timestamp", timestamp)
+		request.Header.Set("X-OwlMail-Nonce", nonce)
+		receive(recorder, request)
+		want := http.StatusNoContent
+		if attempt == 1 {
+			want = http.StatusUnauthorized
+		}
+		if recorder.Code != want {
+			t.Fatalf("attempt %d status = %d, want %d", attempt+1, recorder.Code, want)
+		}
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/microcosm-cc/bluemonday v1.0.27
+	github.com/redis/go-redis/v9 v9.22.0
 	github.com/soulteary/cli-kit v1.8.0
 	github.com/soulteary/health-kit/v2 v2.1.0
 	github.com/soulteary/logger-kit/v2 v2.1.0
@@ -27,7 +28,6 @@ require (
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
-	github.com/redis/go-redis/v9 v9.22.0 // indirect
 	github.com/rs/zerolog v1.35.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/tinylib/msgp v1.6.4 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,8 @@ import (
 // DefaultWebhookMaxConcurrency is the recommended concurrent email delivery
 // limit. Zero remains available as an explicit unlimited mode.
 const DefaultWebhookMaxConcurrency = 8
+const DefaultWebhookRedisPrefix = "owlmail:webhooks"
+const DefaultWebhookShutdownTimeout = "15s"
 
 // EnvMapping defines the mapping from MailDev environment variables to OwlMail environment variables.
 // This maintains backward compatibility with MailDev deployments.
@@ -230,72 +232,81 @@ type Config struct {
 	UseUUIDForEmailID bool
 
 	// Webhook forwarding configuration
-	WebhookConfig         string
-	WebhookMaxConcurrency int
+	WebhookConfig          string
+	WebhookMaxConcurrency  int
+	WebhookRedisURL        string
+	WebhookRedisPrefix     string
+	WebhookShutdownTimeout string
 }
 
 // DefaultConfig returns a Config with default values
 func DefaultConfig() *Config {
 	return &Config{
-		SMTPPort:              1025,
-		SMTPHost:              "localhost",
-		MailDir:               "",
-		WebPort:               1080,
-		WebHost:               "localhost",
-		WebUser:               "",
-		WebPassword:           "",
-		HTTPSEnabled:          false,
-		HTTPSCertFile:         "",
-		HTTPSKeyFile:          "",
-		OutgoingHost:          "",
-		OutgoingPort:          587,
-		OutgoingUser:          "",
-		OutgoingPass:          "",
-		OutgoingSecure:        false,
-		AutoRelay:             false,
-		AutoRelayAddr:         "",
-		AutoRelayRules:        "",
-		SMTPUser:              "",
-		SMTPPassword:          "",
-		TLSEnabled:            false,
-		TLSCertFile:           "",
-		TLSKeyFile:            "",
-		LogLevel:              "normal",
-		UseUUIDForEmailID:     false,
-		WebhookConfig:         "",
-		WebhookMaxConcurrency: DefaultWebhookMaxConcurrency,
+		SMTPPort:               1025,
+		SMTPHost:               "localhost",
+		MailDir:                "",
+		WebPort:                1080,
+		WebHost:                "localhost",
+		WebUser:                "",
+		WebPassword:            "",
+		HTTPSEnabled:           false,
+		HTTPSCertFile:          "",
+		HTTPSKeyFile:           "",
+		OutgoingHost:           "",
+		OutgoingPort:           587,
+		OutgoingUser:           "",
+		OutgoingPass:           "",
+		OutgoingSecure:         false,
+		AutoRelay:              false,
+		AutoRelayAddr:          "",
+		AutoRelayRules:         "",
+		SMTPUser:               "",
+		SMTPPassword:           "",
+		TLSEnabled:             false,
+		TLSCertFile:            "",
+		TLSKeyFile:             "",
+		LogLevel:               "normal",
+		UseUUIDForEmailID:      false,
+		WebhookConfig:          "",
+		WebhookMaxConcurrency:  DefaultWebhookMaxConcurrency,
+		WebhookRedisURL:        "",
+		WebhookRedisPrefix:     DefaultWebhookRedisPrefix,
+		WebhookShutdownTimeout: DefaultWebhookShutdownTimeout,
 	}
 }
 
 // FlagRefs holds references to all flag values for resolution after parsing.
 type FlagRefs struct {
-	SMTPPort              *int
-	SMTPHost              *string
-	MailDir               *string
-	WebPort               *int
-	WebHost               *string
-	WebUser               *string
-	WebPassword           *string
-	HTTPSEnabled          *bool
-	HTTPSCertFile         *string
-	HTTPSKeyFile          *string
-	OutgoingHost          *string
-	OutgoingPort          *int
-	OutgoingUser          *string
-	OutgoingPass          *string
-	OutgoingSecure        *bool
-	AutoRelay             *bool
-	AutoRelayAddr         *string
-	AutoRelayRules        *string
-	SMTPUser              *string
-	SMTPPassword          *string
-	TLSEnabled            *bool
-	TLSCertFile           *string
-	TLSKeyFile            *string
-	LogLevel              *string
-	UseUUIDForEmailID     *bool
-	WebhookConfig         *string
-	WebhookMaxConcurrency *int
+	SMTPPort               *int
+	SMTPHost               *string
+	MailDir                *string
+	WebPort                *int
+	WebHost                *string
+	WebUser                *string
+	WebPassword            *string
+	HTTPSEnabled           *bool
+	HTTPSCertFile          *string
+	HTTPSKeyFile           *string
+	OutgoingHost           *string
+	OutgoingPort           *int
+	OutgoingUser           *string
+	OutgoingPass           *string
+	OutgoingSecure         *bool
+	AutoRelay              *bool
+	AutoRelayAddr          *string
+	AutoRelayRules         *string
+	SMTPUser               *string
+	SMTPPassword           *string
+	TLSEnabled             *bool
+	TLSCertFile            *string
+	TLSKeyFile             *string
+	LogLevel               *string
+	UseUUIDForEmailID      *bool
+	WebhookConfig          *string
+	WebhookMaxConcurrency  *int
+	WebhookRedisURL        *string
+	WebhookRedisPrefix     *string
+	WebhookShutdownTimeout *string
 }
 
 // DefineFlags defines all configuration flags on the given FlagSet.
@@ -303,33 +314,36 @@ type FlagRefs struct {
 func DefineFlags(fs *flag.FlagSet) *FlagRefs {
 	cfg := DefaultConfig()
 	return &FlagRefs{
-		SMTPPort:              fs.Int("smtp", cfg.SMTPPort, "SMTP port to catch emails"),
-		SMTPHost:              fs.String("ip", cfg.SMTPHost, "IP address to bind SMTP service to"),
-		MailDir:               fs.String("mail-directory", cfg.MailDir, "Directory for persisting mails"),
-		WebPort:               fs.Int("web", cfg.WebPort, "Web API port"),
-		WebHost:               fs.String("web-ip", cfg.WebHost, "IP address to bind Web API to"),
-		WebUser:               fs.String("web-user", cfg.WebUser, "HTTP Basic Auth username"),
-		WebPassword:           fs.String("web-password", cfg.WebPassword, "HTTP Basic Auth password"),
-		HTTPSEnabled:          fs.Bool("https", cfg.HTTPSEnabled, "Enable HTTPS for Web API"),
-		HTTPSCertFile:         fs.String("https-cert", cfg.HTTPSCertFile, "HTTPS certificate file path"),
-		HTTPSKeyFile:          fs.String("https-key", cfg.HTTPSKeyFile, "HTTPS private key file path"),
-		OutgoingHost:          fs.String("outgoing-host", cfg.OutgoingHost, "Outgoing SMTP server host"),
-		OutgoingPort:          fs.Int("outgoing-port", cfg.OutgoingPort, "Outgoing SMTP server port"),
-		OutgoingUser:          fs.String("outgoing-user", cfg.OutgoingUser, "Outgoing SMTP server username"),
-		OutgoingPass:          fs.String("outgoing-pass", cfg.OutgoingPass, "Outgoing SMTP server password"),
-		OutgoingSecure:        fs.Bool("outgoing-secure", cfg.OutgoingSecure, "Use TLS for outgoing SMTP"),
-		AutoRelay:             fs.Bool("auto-relay", cfg.AutoRelay, "Automatically relay all emails"),
-		AutoRelayAddr:         fs.String("auto-relay-addr", cfg.AutoRelayAddr, "Auto relay to specific address"),
-		AutoRelayRules:        fs.String("auto-relay-rules", cfg.AutoRelayRules, "JSON file path for auto relay rules"),
-		SMTPUser:              fs.String("smtp-user", cfg.SMTPUser, "SMTP server username for authentication"),
-		SMTPPassword:          fs.String("smtp-password", cfg.SMTPPassword, "SMTP server password for authentication"),
-		TLSEnabled:            fs.Bool("tls", cfg.TLSEnabled, "Enable TLS/STARTTLS for SMTP server"),
-		TLSCertFile:           fs.String("tls-cert", cfg.TLSCertFile, "TLS certificate file path"),
-		TLSKeyFile:            fs.String("tls-key", cfg.TLSKeyFile, "TLS private key file path"),
-		LogLevel:              fs.String("log-level", cfg.LogLevel, "Log level: silent, normal, or verbose"),
-		UseUUIDForEmailID:     fs.Bool("use-uuid-for-email-id", cfg.UseUUIDForEmailID, "Use UUID instead of random string for email IDs"),
-		WebhookConfig:         fs.String("webhook-config", cfg.WebhookConfig, "JSON file path for webhook forwarding targets"),
-		WebhookMaxConcurrency: fs.Int("webhook-max-concurrency", cfg.WebhookMaxConcurrency, "Maximum concurrent webhook deliveries (0 = unlimited)"),
+		SMTPPort:               fs.Int("smtp", cfg.SMTPPort, "SMTP port to catch emails"),
+		SMTPHost:               fs.String("ip", cfg.SMTPHost, "IP address to bind SMTP service to"),
+		MailDir:                fs.String("mail-directory", cfg.MailDir, "Directory for persisting mails"),
+		WebPort:                fs.Int("web", cfg.WebPort, "Web API port"),
+		WebHost:                fs.String("web-ip", cfg.WebHost, "IP address to bind Web API to"),
+		WebUser:                fs.String("web-user", cfg.WebUser, "HTTP Basic Auth username"),
+		WebPassword:            fs.String("web-password", cfg.WebPassword, "HTTP Basic Auth password"),
+		HTTPSEnabled:           fs.Bool("https", cfg.HTTPSEnabled, "Enable HTTPS for Web API"),
+		HTTPSCertFile:          fs.String("https-cert", cfg.HTTPSCertFile, "HTTPS certificate file path"),
+		HTTPSKeyFile:           fs.String("https-key", cfg.HTTPSKeyFile, "HTTPS private key file path"),
+		OutgoingHost:           fs.String("outgoing-host", cfg.OutgoingHost, "Outgoing SMTP server host"),
+		OutgoingPort:           fs.Int("outgoing-port", cfg.OutgoingPort, "Outgoing SMTP server port"),
+		OutgoingUser:           fs.String("outgoing-user", cfg.OutgoingUser, "Outgoing SMTP server username"),
+		OutgoingPass:           fs.String("outgoing-pass", cfg.OutgoingPass, "Outgoing SMTP server password"),
+		OutgoingSecure:         fs.Bool("outgoing-secure", cfg.OutgoingSecure, "Use TLS for outgoing SMTP"),
+		AutoRelay:              fs.Bool("auto-relay", cfg.AutoRelay, "Automatically relay all emails"),
+		AutoRelayAddr:          fs.String("auto-relay-addr", cfg.AutoRelayAddr, "Auto relay to specific address"),
+		AutoRelayRules:         fs.String("auto-relay-rules", cfg.AutoRelayRules, "JSON file path for auto relay rules"),
+		SMTPUser:               fs.String("smtp-user", cfg.SMTPUser, "SMTP server username for authentication"),
+		SMTPPassword:           fs.String("smtp-password", cfg.SMTPPassword, "SMTP server password for authentication"),
+		TLSEnabled:             fs.Bool("tls", cfg.TLSEnabled, "Enable TLS/STARTTLS for SMTP server"),
+		TLSCertFile:            fs.String("tls-cert", cfg.TLSCertFile, "TLS certificate file path"),
+		TLSKeyFile:             fs.String("tls-key", cfg.TLSKeyFile, "TLS private key file path"),
+		LogLevel:               fs.String("log-level", cfg.LogLevel, "Log level: silent, normal, or verbose"),
+		UseUUIDForEmailID:      fs.Bool("use-uuid-for-email-id", cfg.UseUUIDForEmailID, "Use UUID instead of random string for email IDs"),
+		WebhookConfig:          fs.String("webhook-config", cfg.WebhookConfig, "JSON file path for webhook forwarding targets"),
+		WebhookMaxConcurrency:  fs.Int("webhook-max-concurrency", cfg.WebhookMaxConcurrency, "Maximum concurrent webhook deliveries (0 = unlimited)"),
+		WebhookRedisURL:        fs.String("webhook-redis-url", cfg.WebhookRedisURL, "Redis URL for durable webhook delivery"),
+		WebhookRedisPrefix:     fs.String("webhook-redis-prefix", cfg.WebhookRedisPrefix, "Redis key prefix for webhook delivery"),
+		WebhookShutdownTimeout: fs.String("webhook-shutdown-timeout", cfg.WebhookShutdownTimeout, "Maximum time to drain webhook delivery during shutdown"),
 	}
 }
 
@@ -369,9 +383,12 @@ func ResolveConfig(fs *flag.FlagSet, refs *FlagRefs) *Config {
 
 		LogLevel: resolveLogLevelWithFlag(fs, "log-level", *refs.LogLevel),
 
-		UseUUIDForEmailID:     resolveBoolWithFlag(fs, "use-uuid-for-email-id", "OWLMAIL_USE_UUID_FOR_EMAIL_ID", *refs.UseUUIDForEmailID),
-		WebhookConfig:         resolveStringWithFlag(fs, "webhook-config", "OWLMAIL_WEBHOOK_CONFIG", *refs.WebhookConfig),
-		WebhookMaxConcurrency: resolveIntWithFlag(fs, "webhook-max-concurrency", "OWLMAIL_WEBHOOK_MAX_CONCURRENCY", *refs.WebhookMaxConcurrency),
+		UseUUIDForEmailID:      resolveBoolWithFlag(fs, "use-uuid-for-email-id", "OWLMAIL_USE_UUID_FOR_EMAIL_ID", *refs.UseUUIDForEmailID),
+		WebhookConfig:          resolveStringWithFlag(fs, "webhook-config", "OWLMAIL_WEBHOOK_CONFIG", *refs.WebhookConfig),
+		WebhookMaxConcurrency:  resolveIntWithFlag(fs, "webhook-max-concurrency", "OWLMAIL_WEBHOOK_MAX_CONCURRENCY", *refs.WebhookMaxConcurrency),
+		WebhookRedisURL:        resolveStringWithFlag(fs, "webhook-redis-url", "OWLMAIL_WEBHOOK_REDIS_URL", *refs.WebhookRedisURL),
+		WebhookRedisPrefix:     resolveStringWithFlag(fs, "webhook-redis-prefix", "OWLMAIL_WEBHOOK_REDIS_PREFIX", *refs.WebhookRedisPrefix),
+		WebhookShutdownTimeout: resolveStringWithFlag(fs, "webhook-shutdown-timeout", "OWLMAIL_WEBHOOK_SHUTDOWN_TIMEOUT", *refs.WebhookShutdownTimeout),
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -280,6 +280,9 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.WebhookMaxConcurrency != 8 {
 		t.Errorf("DefaultConfig().WebhookMaxConcurrency = %d, want 8", cfg.WebhookMaxConcurrency)
 	}
+	if cfg.WebhookRedisURL != "" || cfg.WebhookRedisPrefix != "owlmail:webhooks" || cfg.WebhookShutdownTimeout != "15s" {
+		t.Errorf("unexpected default webhook queue config: %#v", cfg)
+	}
 }
 
 func TestDefineAndResolveConfig(t *testing.T) {
@@ -310,7 +313,7 @@ func TestDefineAndResolveConfig(t *testing.T) {
 	t.Run("CLI flags override defaults", func(t *testing.T) {
 		fs := flag.NewFlagSet("test-cli", flag.ContinueOnError)
 		refs := DefineFlags(fs)
-		_ = fs.Parse([]string{"-smtp", "2025", "-ip", "0.0.0.0", "-web", "8080", "-webhook-config", "cli-webhooks.json", "-webhook-max-concurrency", "0"})
+		_ = fs.Parse([]string{"-smtp", "2025", "-ip", "0.0.0.0", "-web", "8080", "-webhook-config", "cli-webhooks.json", "-webhook-max-concurrency", "0", "-webhook-redis-url", "redis://localhost:6379/2", "-webhook-redis-prefix", "test:hooks", "-webhook-shutdown-timeout", "30s"})
 		cfg := ResolveConfig(fs, refs)
 
 		if cfg.SMTPPort != 2025 {
@@ -328,6 +331,9 @@ func TestDefineAndResolveConfig(t *testing.T) {
 		if cfg.WebhookMaxConcurrency != 0 {
 			t.Errorf("ResolveConfig().WebhookMaxConcurrency = %d, want 0", cfg.WebhookMaxConcurrency)
 		}
+		if cfg.WebhookRedisURL != "redis://localhost:6379/2" || cfg.WebhookRedisPrefix != "test:hooks" || cfg.WebhookShutdownTimeout != "30s" {
+			t.Errorf("unexpected CLI webhook queue config: %#v", cfg)
+		}
 	})
 
 	t.Run("environment variables work", func(t *testing.T) {
@@ -335,6 +341,9 @@ func TestDefineAndResolveConfig(t *testing.T) {
 		_ = envMgr.Set("OWLMAIL_SMTP_HOST", "192.168.1.1")
 		_ = envMgr.Set("OWLMAIL_WEBHOOK_CONFIG", "env-webhooks.json")
 		_ = envMgr.Set("OWLMAIL_WEBHOOK_MAX_CONCURRENCY", "24")
+		_ = envMgr.Set("OWLMAIL_WEBHOOK_REDIS_URL", "rediss://redis.example.test:6380/0")
+		_ = envMgr.Set("OWLMAIL_WEBHOOK_REDIS_PREFIX", "env:hooks")
+		_ = envMgr.Set("OWLMAIL_WEBHOOK_SHUTDOWN_TIMEOUT", "45s")
 		defer envMgr.Cleanup()
 
 		fs := flag.NewFlagSet("test-env", flag.ContinueOnError)
@@ -353,6 +362,9 @@ func TestDefineAndResolveConfig(t *testing.T) {
 		}
 		if cfg.WebhookMaxConcurrency != 24 {
 			t.Errorf("ResolveConfig().WebhookMaxConcurrency = %d, want 24", cfg.WebhookMaxConcurrency)
+		}
+		if cfg.WebhookRedisURL != "rediss://redis.example.test:6380/0" || cfg.WebhookRedisPrefix != "env:hooks" || cfg.WebhookShutdownTimeout != "45s" {
+			t.Errorf("unexpected environment webhook queue config: %#v", cfg)
 		}
 	})
 

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/soulteary/cli-kit/validator"
 )
@@ -66,6 +68,13 @@ func ValidateConfig(cfg *Config) error {
 	}
 	if cfg.WebhookMaxConcurrency < 0 {
 		return fmt.Errorf("webhook max concurrency must be zero or greater")
+	}
+	if strings.TrimSpace(cfg.WebhookRedisPrefix) == "" {
+		return fmt.Errorf("webhook Redis prefix cannot be empty")
+	}
+	shutdownTimeout, err := time.ParseDuration(cfg.WebhookShutdownTimeout)
+	if err != nil || shutdownTimeout <= 0 {
+		return fmt.Errorf("webhook shutdown timeout must be a positive duration")
 	}
 
 	return nil

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -226,6 +226,19 @@ func TestValidateConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("invalid webhook drain settings", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.WebhookShutdownTimeout = "never"
+		if err := ValidateConfig(cfg); err == nil {
+			t.Error("invalid webhook shutdown timeout should fail")
+		}
+		cfg = DefaultConfig()
+		cfg.WebhookRedisPrefix = " "
+		if err := ValidateConfig(cfg); err == nil {
+			t.Error("empty webhook Redis prefix should fail")
+		}
+	})
+
 	t.Run("valid full config", func(t *testing.T) {
 		cfg := DefaultConfig()
 		cfg.SMTPPort = 2525

--- a/internal/mailserver/events.go
+++ b/internal/mailserver/events.go
@@ -11,6 +11,19 @@ func (ms *MailServer) On(event string, handler func(*types.Email)) {
 	_ = ms.OnWithConcurrency(event, 0, handler)
 }
 
+// OnSynchronous registers a lightweight handoff listener that completes
+// before emit returns. It is intended for durable queue writes, not network
+// delivery or other long-running work.
+func (ms *MailServer) OnSynchronous(event string, handler func(*types.Email)) error {
+	if handler == nil {
+		return fmt.Errorf("event handler cannot be nil")
+	}
+	ms.listenersMutex.Lock()
+	defer ms.listenersMutex.Unlock()
+	ms.listeners[event] = append(ms.listeners[event], eventListener{handler: handler, synchronous: true})
+	return nil
+}
+
 // OnWithConcurrency registers an event listener with an optional concurrency
 // limit. A limit of zero preserves the original unlimited behavior. Limited
 // listeners acquire a slot before their goroutine is created, providing real
@@ -38,17 +51,22 @@ func (ms *MailServer) emit(event string, email *types.Email) {
 	ms.listenersMutex.RLock()
 	listeners := append([]eventListener(nil), ms.listeners[event]...)
 	ms.listenersMutex.RUnlock()
+	for _, listener := range listeners {
+		if listener.synchronous {
+			listener.handler(cloneEmail(email))
+		}
+	}
 
 	// Start unlimited listeners first so a saturated bounded listener cannot
 	// delay UI broadcasts or lightweight logging handlers registered after it.
 	for _, listener := range listeners {
-		if listener.slots == nil {
+		if !listener.synchronous && listener.slots == nil {
 			emailSnapshot := cloneEmail(email)
 			go listener.handler(emailSnapshot)
 		}
 	}
 	for _, listener := range listeners {
-		if listener.slots == nil {
+		if listener.synchronous || listener.slots == nil {
 			continue
 		}
 		listener.slots <- struct{}{}

--- a/internal/mailserver/lifecycle.go
+++ b/internal/mailserver/lifecycle.go
@@ -2,10 +2,24 @@ package mailserver
 
 import (
 	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
 	"net"
 
 	"github.com/soulteary/owlmail/internal/common"
 )
+
+// AddCloser registers a component whose lifecycle is owned by the mail server.
+func (ms *MailServer) AddCloser(closer io.Closer) error {
+	if closer == nil {
+		return fmt.Errorf("closer cannot be nil")
+	}
+	ms.closersMutex.Lock()
+	defer ms.closersMutex.Unlock()
+	ms.closers = append(ms.closers, closer)
+	return nil
+}
 
 // Listen starts the SMTP server
 func (ms *MailServer) Listen() error {
@@ -37,6 +51,25 @@ func (ms *MailServer) Listen() error {
 
 // Close stops the SMTP server
 func (ms *MailServer) Close() error {
+	var closeErrors []error
+	// Stop accepting SMTP data before draining dependent delivery services.
+	if ms.smtpsServer != nil {
+		if err := ms.smtpsServer.Close(); err != nil {
+			closeErrors = append(closeErrors, err)
+		}
+	}
+	if err := ms.smtpServer.Close(); err != nil {
+		closeErrors = append(closeErrors, err)
+	}
+
+	ms.closersMutex.Lock()
+	closers := append([]io.Closer(nil), ms.closers...)
+	ms.closersMutex.Unlock()
+	for _, closer := range closers {
+		if err := closer.Close(); err != nil {
+			closeErrors = append(closeErrors, err)
+		}
+	}
 	if ms.outgoing != nil {
 		ms.outgoing.Close()
 	}
@@ -52,14 +85,5 @@ func (ms *MailServer) Close() error {
 		close(ms.eventChan)
 	}()
 
-	var err error
-	if ms.smtpsServer != nil {
-		if closeErr := ms.smtpsServer.Close(); closeErr != nil {
-			err = closeErr
-		}
-	}
-	if closeErr := ms.smtpServer.Close(); closeErr != nil {
-		err = closeErr
-	}
-	return err
+	return errors.Join(closeErrors...)
 }

--- a/internal/mailserver/types.go
+++ b/internal/mailserver/types.go
@@ -1,6 +1,7 @@
 package mailserver
 
 import (
+	"io"
 	"sync"
 
 	"github.com/emersion/go-smtp"
@@ -37,8 +38,9 @@ type TLSConfig struct {
 }
 
 type eventListener struct {
-	handler func(*types.Email)
-	slots   chan struct{}
+	handler     func(*types.Email)
+	slots       chan struct{}
+	synchronous bool
 }
 
 // MailServer represents the SMTP mail server
@@ -54,6 +56,8 @@ type MailServer struct {
 	eventChan      chan Event
 	listeners      map[string][]eventListener
 	listenersMutex sync.RWMutex
+	closers        []io.Closer
+	closersMutex   sync.Mutex
 	outgoing       interface {
 		RelayMail(email *types.Email, emlPath, relayTo string, isAutoRelay bool, callback func(error))
 		UpdateConfig(config interface{})

--- a/internal/webhook/dispatcher.go
+++ b/internal/webhook/dispatcher.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -83,6 +85,12 @@ func (dispatcher *Dispatcher) TargetCount() int {
 // Dispatch synchronously sends an email to every matching target. MailServer
 // invokes event listeners asynchronously, so this never blocks SMTP storage.
 func (dispatcher *Dispatcher) Dispatch(ctx context.Context, email *types.Email) []Result {
+	return dispatcher.DispatchDelivery(ctx, email, "")
+}
+
+// DispatchDelivery sends an email using a stable delivery ID. Durable queue
+// consumers use this ID as the receiver's idempotency key.
+func (dispatcher *Dispatcher) DispatchDelivery(ctx context.Context, email *types.Email, deliveryID string) []Result {
 	if dispatcher == nil {
 		return nil
 	}
@@ -99,12 +107,12 @@ func (dispatcher *Dispatcher) Dispatch(ctx context.Context, email *types.Email) 
 		if !target.matches(payload) {
 			continue
 		}
-		results = append(results, dispatcher.deliver(ctx, target, payload))
+		results = append(results, dispatcher.deliver(ctx, target, payload, deliveryID))
 	}
 	return results
 }
 
-func (dispatcher *Dispatcher) deliver(ctx context.Context, target compiledTarget, payload EmailPayload) Result {
+func (dispatcher *Dispatcher) deliver(ctx context.Context, target compiledTarget, payload EmailPayload, deliveryID string) Result {
 	result := Result{Target: target.name}
 	body, err := renderBody(target, payload)
 	if err != nil {
@@ -118,7 +126,7 @@ func (dispatcher *Dispatcher) deliver(ctx context.Context, target compiledTarget
 
 	for attempt := 0; attempt <= target.retries; attempt++ {
 		result.Attempts = attempt + 1
-		statusCode, retry, requestErr := dispatcher.sendAttempt(ctx, target, payload.ID, body)
+		statusCode, retry, requestErr := dispatcher.sendAttempt(ctx, target, payload.ID, deliveryID, body)
 		result.StatusCode = statusCode
 		if requestErr == nil {
 			result.Err = nil
@@ -156,7 +164,7 @@ func renderBody(target compiledTarget, payload EmailPayload) ([]byte, error) {
 	return body.Bytes(), nil
 }
 
-func (dispatcher *Dispatcher) sendAttempt(ctx context.Context, target compiledTarget, emailID string, body []byte) (int, bool, error) {
+func (dispatcher *Dispatcher) sendAttempt(ctx context.Context, target compiledTarget, emailID, deliveryID string, body []byte) (int, bool, error) {
 	attemptContext, cancel := context.WithTimeout(ctx, target.timeout)
 	defer cancel()
 
@@ -173,7 +181,21 @@ func (dispatcher *Dispatcher) sendAttempt(ctx context.Context, target compiledTa
 	}
 	request.Header.Set("X-OwlMail-Event", "email.received")
 	request.Header.Set("X-OwlMail-Email-ID", emailID)
+	if deliveryID == "" {
+		deliveryID = emailID
+	}
+	request.Header.Set("X-OwlMail-Delivery-ID", deliveryID)
 	if target.secret != "" {
+		timestamp := time.Now().UTC().Format(time.RFC3339)
+		nonce, nonceErr := newSignatureNonce()
+		if nonceErr != nil {
+			return 0, false, nonceErr
+		}
+		request.Header.Set("X-OwlMail-Timestamp", timestamp)
+		request.Header.Set("X-OwlMail-Nonce", nonce)
+		request.Header.Set("X-OwlMail-Signature-V2", signPayloadV2(target.secret, timestamp, nonce, body))
+		// Retain the body-only signature for existing receivers. New receivers
+		// should require Signature-V2 and reject stale or repeated nonces.
 		request.Header.Set("X-OwlMail-Signature", signPayload(target.secret, body))
 	}
 
@@ -209,6 +231,24 @@ func signPayload(secret string, payload []byte) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	_, _ = mac.Write(payload)
 	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func signPayloadV2(secret, timestamp, nonce string, payload []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(timestamp))
+	_, _ = mac.Write([]byte("."))
+	_, _ = mac.Write([]byte(nonce))
+	_, _ = mac.Write([]byte("."))
+	_, _ = mac.Write(payload)
+	return "v2=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func newSignatureNonce() (string, error) {
+	buffer := make([]byte, 18)
+	if _, err := io.ReadFull(rand.Reader, buffer); err != nil {
+		return "", fmt.Errorf("generate signature nonce: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buffer), nil
 }
 
 func waitForRetry(ctx context.Context, attempt int) bool {

--- a/internal/webhook/dispatcher_test.go
+++ b/internal/webhook/dispatcher_test.go
@@ -98,6 +98,21 @@ func TestDispatchCustomTemplateHeadersAndSignature(t *testing.T) {
 		if request.Header.Get("X-OwlMail-Signature") != wantSignature {
 			t.Errorf("signature = %q, want %q", request.Header.Get("X-OwlMail-Signature"), wantSignature)
 		}
+		timestamp := request.Header.Get("X-OwlMail-Timestamp")
+		nonce := request.Header.Get("X-OwlMail-Nonce")
+		if timestamp == "" || nonce == "" {
+			t.Fatal("timestamp and nonce headers are required")
+		}
+		mac = hmac.New(sha256.New, []byte(secret))
+		_, _ = mac.Write([]byte(timestamp + "." + nonce + "."))
+		_, _ = mac.Write(receivedBody)
+		wantV2 := "v2=" + hex.EncodeToString(mac.Sum(nil))
+		if request.Header.Get("X-OwlMail-Signature-V2") != wantV2 {
+			t.Errorf("v2 signature = %q, want %q", request.Header.Get("X-OwlMail-Signature-V2"), wantV2)
+		}
+		if request.Header.Get("X-OwlMail-Delivery-ID") != "email-123" {
+			t.Errorf("delivery id = %q", request.Header.Get("X-OwlMail-Delivery-ID"))
+		}
 		writer.WriteHeader(http.StatusAccepted)
 	}))
 	defer server.Close()
@@ -120,6 +135,37 @@ func TestDispatchCustomTemplateHeadersAndSignature(t *testing.T) {
 	}
 	if string(receivedBody) != `{"title":"System Alert","message":"Verification code","to":["ops@example.net"]}` {
 		t.Errorf("body = %s", receivedBody)
+	}
+}
+
+func TestDispatchRetriesUseFreshReplayProtection(t *testing.T) {
+	var headers []http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		headers = append(headers, request.Header.Clone())
+		if len(headers) == 1 {
+			writer.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	dispatcher, err := NewDispatcher(Config{Targets: []Target{{
+		Name: "retry", URL: server.URL, Secret: "secret", Retries: 1,
+	}}}, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := dispatcher.DispatchDelivery(context.Background(), testEmail(), "delivery-123")
+	if len(results) != 1 || results[0].Err != nil {
+		t.Fatalf("results = %#v", results)
+	}
+	if len(headers) != 2 || headers[0].Get("X-OwlMail-Nonce") == headers[1].Get("X-OwlMail-Nonce") {
+		t.Fatalf("retry nonces were not unique: %#v", headers)
+	}
+	for _, header := range headers {
+		if header.Get("X-OwlMail-Delivery-ID") != "delivery-123" {
+			t.Fatalf("delivery ID changed across retries: %q", header.Get("X-OwlMail-Delivery-ID"))
+		}
 	}
 }
 

--- a/internal/webhook/queue.go
+++ b/internal/webhook/queue.go
@@ -1,0 +1,207 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	defaultRedisPrefix = "owlmail:webhooks"
+	redisConsumerGroup = "owlmail"
+	redisClaimIdle     = 30 * time.Second
+	redisReadBlock     = time.Second
+)
+
+type queueReceipt struct {
+	id  string
+	job deliveryJob
+}
+
+type deliveryQueue interface {
+	Enqueue(context.Context, deliveryJob) error
+	Claim(context.Context) (*queueReceipt, error)
+	Ack(context.Context, *queueReceipt) error
+	DeadLetter(context.Context, *queueReceipt, []Result) error
+	Pending(context.Context) (int64, error)
+	Close() error
+}
+
+type redisDeliveryQueue struct {
+	client     *redis.Client
+	stream     string
+	deadLetter string
+	consumer   string
+}
+
+type deadLetterRecord struct {
+	Job      deliveryJob `json:"job"`
+	FailedAt time.Time   `json:"failedAt"`
+	Failures []failure   `json:"failures"`
+}
+
+type failure struct {
+	Target     string `json:"target"`
+	StatusCode int    `json:"statusCode,omitempty"`
+	Attempts   int    `json:"attempts"`
+	Error      string `json:"error"`
+}
+
+func newRedisDeliveryQueue(ctx context.Context, rawURL, prefix, consumer string) (*redisDeliveryQueue, error) {
+	options, err := redis.ParseURL(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse webhook Redis URL: %w", err)
+	}
+	client := redis.NewClient(options)
+	if err := client.Ping(ctx).Err(); err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("connect to webhook Redis: %w", err)
+	}
+	prefix = strings.TrimSpace(prefix)
+	if prefix == "" {
+		prefix = defaultRedisPrefix
+	}
+	queue := &redisDeliveryQueue{
+		client:     client,
+		stream:     prefix + ":events",
+		deadLetter: prefix + ":dead-letter",
+		consumer:   consumer,
+	}
+	if err := client.XGroupCreateMkStream(ctx, queue.stream, redisConsumerGroup, "0").Err(); err != nil && !strings.Contains(err.Error(), "BUSYGROUP") {
+		_ = client.Close()
+		return nil, fmt.Errorf("create webhook Redis consumer group: %w", err)
+	}
+	return queue, nil
+}
+
+func (queue *redisDeliveryQueue) Enqueue(ctx context.Context, job deliveryJob) error {
+	encoded, err := json.Marshal(job)
+	if err != nil {
+		return fmt.Errorf("encode webhook job: %w", err)
+	}
+	if err := queue.client.XAdd(ctx, &redis.XAddArgs{
+		Stream: queue.stream,
+		Values: map[string]interface{}{"job": encoded},
+	}).Err(); err != nil {
+		return fmt.Errorf("enqueue webhook job: %w", err)
+	}
+	return nil
+}
+
+func (queue *redisDeliveryQueue) Claim(ctx context.Context) (*queueReceipt, error) {
+	claimed, _, err := queue.client.XAutoClaim(ctx, &redis.XAutoClaimArgs{
+		Stream:   queue.stream,
+		Group:    redisConsumerGroup,
+		Consumer: queue.consumer,
+		MinIdle:  redisClaimIdle,
+		Start:    "0-0",
+		Count:    1,
+	}).Result()
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return nil, fmt.Errorf("reclaim webhook job: %w", err)
+	}
+	if len(claimed) > 0 {
+		return decodeRedisMessage(claimed[0])
+	}
+
+	streams, err := queue.client.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    redisConsumerGroup,
+		Consumer: queue.consumer,
+		Streams:  []string{queue.stream, ">"},
+		Count:    1,
+		Block:    redisReadBlock,
+	}).Result()
+	if errors.Is(err, redis.Nil) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("claim webhook job: %w", err)
+	}
+	if len(streams) == 0 || len(streams[0].Messages) == 0 {
+		return nil, nil
+	}
+	return decodeRedisMessage(streams[0].Messages[0])
+}
+
+func decodeRedisMessage(message redis.XMessage) (*queueReceipt, error) {
+	raw, exists := message.Values["job"]
+	if !exists {
+		return nil, fmt.Errorf("webhook Redis entry %s has no job field", message.ID)
+	}
+	var encoded []byte
+	switch value := raw.(type) {
+	case string:
+		encoded = []byte(value)
+	case []byte:
+		encoded = value
+	default:
+		return nil, fmt.Errorf("webhook Redis entry %s has invalid job field", message.ID)
+	}
+	var job deliveryJob
+	if err := json.Unmarshal(encoded, &job); err != nil {
+		return nil, fmt.Errorf("decode webhook Redis entry %s: %w", message.ID, err)
+	}
+	return &queueReceipt{id: message.ID, job: job}, nil
+}
+
+func (queue *redisDeliveryQueue) Ack(ctx context.Context, receipt *queueReceipt) error {
+	if receipt == nil {
+		return nil
+	}
+	_, err := queue.client.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+		pipe.XAck(ctx, queue.stream, redisConsumerGroup, receipt.id)
+		pipe.XDel(ctx, queue.stream, receipt.id)
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("acknowledge webhook job: %w", err)
+	}
+	return nil
+}
+
+func (queue *redisDeliveryQueue) DeadLetter(ctx context.Context, receipt *queueReceipt, results []Result) error {
+	if receipt == nil {
+		return nil
+	}
+	record := deadLetterRecord{Job: receipt.job, FailedAt: time.Now().UTC()}
+	for _, result := range results {
+		if result.Err == nil {
+			continue
+		}
+		record.Failures = append(record.Failures, failure{
+			Target: result.Target, StatusCode: result.StatusCode,
+			Attempts: result.Attempts, Error: result.Err.Error(),
+		})
+	}
+	encoded, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("encode webhook dead letter: %w", err)
+	}
+	_, err = queue.client.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+		pipe.XAdd(ctx, &redis.XAddArgs{Stream: queue.deadLetter, Values: map[string]interface{}{"record": encoded}})
+		pipe.XAck(ctx, queue.stream, redisConsumerGroup, receipt.id)
+		pipe.XDel(ctx, queue.stream, receipt.id)
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("store webhook dead letter: %w", err)
+	}
+	return nil
+}
+
+func (queue *redisDeliveryQueue) Pending(ctx context.Context) (int64, error) {
+	count, err := queue.client.XLen(ctx, queue.stream).Result()
+	if err != nil {
+		return 0, fmt.Errorf("count webhook jobs: %w", err)
+	}
+	return count, nil
+}
+
+func (queue *redisDeliveryQueue) Close() error {
+	return queue.client.Close()
+}

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -1,0 +1,276 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/soulteary/owlmail/internal/types"
+)
+
+const (
+	defaultMemoryQueueSize = 1024
+	defaultShutdownTimeout = 15 * time.Second
+)
+
+// ServiceOptions configures queued webhook delivery.
+type ServiceOptions struct {
+	RedisURL        string
+	RedisPrefix     string
+	MaxConcurrency  int
+	ShutdownTimeout time.Duration
+	OnResults       func(string, []Result)
+}
+
+type deliveryJob struct {
+	ID         string       `json:"id"`
+	EnqueuedAt time.Time    `json:"enqueuedAt"`
+	Email      *types.Email `json:"email"`
+}
+
+// Service owns webhook queue workers and their cancellation/drain lifecycle.
+type Service struct {
+	dispatcher      *Dispatcher
+	queue           deliveryQueue
+	memoryQueue     chan deliveryJob
+	ctx             context.Context
+	cancel          context.CancelFunc
+	shutdownTimeout time.Duration
+	onResults       func(string, []Result)
+	workerCount     int
+	unlimited       bool
+	accepting       bool
+	handoffMutex    sync.RWMutex
+	closeOnce       sync.Once
+	handoffs        sync.WaitGroup
+	workers         sync.WaitGroup
+	deliveries      sync.WaitGroup
+	closeErr        error
+}
+
+// NewService creates and starts a queued delivery service. Redis-backed mode
+// uses a consumer-group stream and dead-letter stream; an empty Redis URL keeps
+// a process-local queue while retaining cancellation and graceful drain.
+func NewService(dispatcher *Dispatcher, options ServiceOptions) (*Service, error) {
+	if dispatcher == nil {
+		return nil, fmt.Errorf("webhook dispatcher is nil")
+	}
+	if options.MaxConcurrency < 0 {
+		return nil, fmt.Errorf("webhook max concurrency must be zero or greater")
+	}
+	if options.ShutdownTimeout <= 0 {
+		options.ShutdownTimeout = defaultShutdownTimeout
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	service := &Service{
+		dispatcher: dispatcher, ctx: ctx, cancel: cancel,
+		shutdownTimeout: options.ShutdownTimeout, onResults: options.OnResults,
+		workerCount: options.MaxConcurrency, unlimited: options.MaxConcurrency == 0,
+	}
+	if options.RedisURL != "" {
+		consumer := fmt.Sprintf("%s-%s", runtime.GOOS, uuid.NewString())
+		queue, err := newRedisDeliveryQueue(ctx, options.RedisURL, options.RedisPrefix, consumer)
+		if err != nil {
+			cancel()
+			return nil, err
+		}
+		service.queue = queue
+	} else {
+		service.memoryQueue = make(chan deliveryJob, defaultMemoryQueueSize)
+	}
+	service.accepting = true
+	service.start()
+	return service, nil
+}
+
+func (service *Service) start() {
+	if service.unlimited {
+		service.workers.Add(1)
+		go service.runPump()
+		return
+	}
+	for i := 0; i < service.workerCount; i++ {
+		service.workers.Add(1)
+		go service.runWorker()
+	}
+}
+
+// Enqueue durably hands an email to Redis when configured. Delivery remains
+// at-least-once: receivers should deduplicate X-OwlMail-Delivery-ID.
+func (service *Service) Enqueue(email *types.Email) error {
+	if service == nil || email == nil {
+		return fmt.Errorf("webhook email is nil")
+	}
+	service.handoffMutex.Lock()
+	if !service.accepting {
+		service.handoffMutex.Unlock()
+		return fmt.Errorf("webhook service is shutting down")
+	}
+	service.handoffs.Add(1)
+	service.handoffMutex.Unlock()
+	defer service.handoffs.Done()
+	emailSnapshot, err := cloneDeliveryEmail(email)
+	if err != nil {
+		return err
+	}
+	job := deliveryJob{ID: uuid.NewString(), EnqueuedAt: time.Now().UTC(), Email: emailSnapshot}
+	if service.queue != nil {
+		if err := service.queue.Enqueue(service.ctx, job); err != nil {
+			return err
+		}
+		return nil
+	}
+	select {
+	case service.memoryQueue <- job:
+		return nil
+	case <-service.ctx.Done():
+		return service.ctx.Err()
+	}
+}
+
+func cloneDeliveryEmail(email *types.Email) (*types.Email, error) {
+	encoded, err := json.Marshal(email)
+	if err != nil {
+		return nil, fmt.Errorf("encode webhook email snapshot: %w", err)
+	}
+	var snapshot types.Email
+	if err := json.Unmarshal(encoded, &snapshot); err != nil {
+		return nil, fmt.Errorf("decode webhook email snapshot: %w", err)
+	}
+	return &snapshot, nil
+}
+
+func (service *Service) runWorker() {
+	defer service.workers.Done()
+	for {
+		job, receipt, ok := service.nextJob()
+		if !ok {
+			return
+		}
+		service.deliver(job, receipt)
+	}
+}
+
+func (service *Service) runPump() {
+	defer service.workers.Done()
+	for {
+		job, receipt, ok := service.nextJob()
+		if !ok {
+			return
+		}
+		service.deliveries.Add(1)
+		go func() {
+			defer service.deliveries.Done()
+			service.deliver(job, receipt)
+		}()
+	}
+}
+
+func (service *Service) nextJob() (deliveryJob, *queueReceipt, bool) {
+	if service.queue == nil {
+		select {
+		case job, open := <-service.memoryQueue:
+			return job, nil, open
+		case <-service.ctx.Done():
+			return deliveryJob{}, nil, false
+		}
+	}
+	for {
+		if !service.isAccepting() {
+			pending, err := service.queue.Pending(service.ctx)
+			if err == nil && pending == 0 {
+				return deliveryJob{}, nil, false
+			}
+		}
+		receipt, err := service.queue.Claim(service.ctx)
+		if err != nil {
+			if service.ctx.Err() != nil {
+				return deliveryJob{}, nil, false
+			}
+			service.report("", []Result{{Err: err}})
+			continue
+		}
+		if receipt != nil {
+			return receipt.job, receipt, true
+		}
+	}
+}
+
+func (service *Service) isAccepting() bool {
+	service.handoffMutex.RLock()
+	defer service.handoffMutex.RUnlock()
+	return service.accepting
+}
+
+func (service *Service) deliver(job deliveryJob, receipt *queueReceipt) {
+	results := service.dispatcher.DispatchDelivery(service.ctx, job.Email, job.ID)
+	failed := false
+	for _, result := range results {
+		if result.Err != nil {
+			failed = true
+			break
+		}
+	}
+	if service.queue != nil {
+		var err error
+		if failed {
+			err = service.queue.DeadLetter(service.ctx, receipt, results)
+		} else {
+			err = service.queue.Ack(service.ctx, receipt)
+		}
+		if err != nil {
+			results = append(results, Result{Err: err})
+		}
+	}
+	service.report(job.ID, results)
+}
+
+func (service *Service) report(jobID string, results []Result) {
+	if service.onResults != nil {
+		service.onResults(jobID, results)
+	}
+}
+
+// Close stops accepting jobs, drains queued and active delivery until the
+// configured deadline, then cancels remaining HTTP and Redis operations.
+func (service *Service) Close() error {
+	if service == nil {
+		return nil
+	}
+	service.closeOnce.Do(func() {
+		service.handoffMutex.Lock()
+		service.accepting = false
+		service.handoffMutex.Unlock()
+		drained := make(chan struct{})
+		go func() {
+			service.handoffs.Wait()
+			if service.memoryQueue != nil {
+				close(service.memoryQueue)
+			}
+			service.workers.Wait()
+			service.deliveries.Wait()
+			close(drained)
+		}()
+		timer := time.NewTimer(service.shutdownTimeout)
+		defer timer.Stop()
+		select {
+		case <-drained:
+		case <-timer.C:
+			service.closeErr = fmt.Errorf("webhook drain exceeded %s", service.shutdownTimeout)
+			service.cancel()
+			<-drained
+		}
+		service.cancel()
+		if service.queue != nil {
+			if err := service.queue.Close(); err != nil && !errors.Is(err, context.Canceled) && service.closeErr == nil {
+				service.closeErr = err
+			}
+		}
+	})
+	return service.closeErr
+}

--- a/internal/webhook/service_test.go
+++ b/internal/webhook/service_test.go
@@ -1,0 +1,168 @@
+package webhook
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestServiceCloseDrainsInFlightDelivery(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	receiver := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		close(started)
+		<-release
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer receiver.Close()
+	dispatcher, err := NewDispatcher(Config{Targets: []Target{{Name: "drain", URL: receiver.URL}}}, receiver.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service, err := NewService(dispatcher, ServiceOptions{MaxConcurrency: 1, ShutdownTimeout: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := service.Enqueue(testEmail()); err != nil {
+		t.Fatal(err)
+	}
+	<-started
+	closed := make(chan error, 1)
+	go func() { closed <- service.Close() }()
+	select {
+	case err := <-closed:
+		t.Fatalf("Close returned before delivery completed: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	close(release)
+	if err := <-closed; err != nil {
+		t.Fatal(err)
+	}
+	if err := service.Enqueue(testEmail()); err == nil {
+		t.Fatal("enqueue after close should fail")
+	}
+}
+
+type fakeDeliveryQueue struct {
+	claims chan *queueReceipt
+	mu     sync.Mutex
+	acked  []string
+	dead   []string
+	count  int64
+}
+
+func (queue *fakeDeliveryQueue) Enqueue(_ context.Context, job deliveryJob) error {
+	queue.mu.Lock()
+	queue.count++
+	queue.mu.Unlock()
+	queue.claims <- &queueReceipt{id: job.ID, job: job}
+	return nil
+}
+
+func (queue *fakeDeliveryQueue) Claim(ctx context.Context) (*queueReceipt, error) {
+	select {
+	case receipt := <-queue.claims:
+		return receipt, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(5 * time.Millisecond):
+		return nil, nil
+	}
+}
+
+func (queue *fakeDeliveryQueue) Ack(_ context.Context, receipt *queueReceipt) error {
+	queue.mu.Lock()
+	defer queue.mu.Unlock()
+	queue.acked = append(queue.acked, receipt.id)
+	queue.count--
+	return nil
+}
+
+func (queue *fakeDeliveryQueue) DeadLetter(_ context.Context, receipt *queueReceipt, _ []Result) error {
+	queue.mu.Lock()
+	defer queue.mu.Unlock()
+	queue.dead = append(queue.dead, receipt.id)
+	queue.count--
+	return nil
+}
+
+func (queue *fakeDeliveryQueue) Pending(_ context.Context) (int64, error) {
+	queue.mu.Lock()
+	defer queue.mu.Unlock()
+	return queue.count, nil
+}
+
+func (queue *fakeDeliveryQueue) Close() error { return nil }
+
+func TestDurableServiceDeadLettersExhaustedDelivery(t *testing.T) {
+	receiver := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Header.Get("X-OwlMail-Delivery-ID") != "replayed-job" {
+			t.Errorf("delivery ID = %q", request.Header.Get("X-OwlMail-Delivery-ID"))
+		}
+		writer.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer receiver.Close()
+	dispatcher, err := NewDispatcher(Config{Targets: []Target{{Name: "failing", URL: receiver.URL}}}, receiver.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	queue := &fakeDeliveryQueue{claims: make(chan *queueReceipt, 1), count: 1}
+	queue.claims <- &queueReceipt{id: "redis-entry", job: deliveryJob{ID: "replayed-job", Email: testEmail()}}
+	service := &Service{
+		dispatcher: dispatcher, queue: queue, ctx: ctx, cancel: cancel,
+		shutdownTimeout: time.Second, workerCount: 1, accepting: true,
+	}
+	service.start()
+	deadline := time.Now().Add(time.Second)
+	for {
+		queue.mu.Lock()
+		dead := append([]string(nil), queue.dead...)
+		queue.mu.Unlock()
+		if len(dead) == 1 {
+			if dead[0] != "redis-entry" {
+				t.Fatalf("dead letter IDs = %v", dead)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("failed job was not dead-lettered")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if err := service.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRedisQueueIntegration(t *testing.T) {
+	redisURL := testRedisURL()
+	if redisURL == "" {
+		t.Skip("set OWLMAIL_TEST_REDIS_URL to run Redis Streams integration coverage")
+	}
+	ctx := context.Background()
+	queue, err := newRedisDeliveryQueue(ctx, redisURL, "owlmail:test", "test-consumer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = queue.Close() }()
+	job := deliveryJob{ID: "integration-job", EnqueuedAt: time.Now().UTC(), Email: testEmail()}
+	if err := queue.Enqueue(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := queue.Claim(ctx)
+	if err != nil || receipt == nil || receipt.job.ID != job.ID {
+		t.Fatalf("Claim() = %#v, %v", receipt, err)
+	}
+	if err := queue.Ack(ctx, receipt); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testRedisURL() string {
+	return os.Getenv("OWLMAIL_TEST_REDIS_URL")
+}

--- a/tests/docs/markdown.test.js
+++ b/tests/docs/markdown.test.js
@@ -271,8 +271,8 @@ test("security-sensitive authentication limitations remain explicit", () => {
   }
 
   const capacityReferences = [
-    ["docs/en/Webhook-Forwarding.md", ["SMTP `DATA` completion", "does not drain", "100 UTF-8 bytes"]],
-    ["docs/zh-CN/Webhook-Forwarding.md", ["SMTP `DATA` 命令", "不会等待正在进行", "100 个 UTF-8 字节"]],
+    ["docs/en/Webhook-Forwarding.md", ["SMTP `DATA` completion", "drains queued", "100 UTF-8 bytes"]],
+    ["docs/zh-CN/Webhook-Forwarding.md", ["SMTP `DATA` 命令", "排空排队", "100 个 UTF-8 字节"]],
   ];
   for (const [reference, markers] of capacityReferences) {
     const markdown = fs.readFileSync(path.join(root, reference), "utf8");


### PR DESCRIPTION
## Summary

- add optional Redis Streams consumer-group delivery with stable delivery IDs, restart reclaim, ACK/delete, and a dead-letter stream
- replace detached background dispatch with an owned service context, bounded/unlimited queue consumers, and graceful shutdown drain
- synchronously hand stored-email events to the queue while keeping target HTTP delivery asynchronous
- add replay-aware HMAC v2 headers (timestamp + nonce + body), keep the legacy signature for compatibility, and update the example receiver to reject stale/replayed requests
- expose Redis URL/prefix and shutdown-timeout flags and environment variables, with operational documentation

## Delivery semantics

Redis mode is at least once. Receivers should deduplicate `X-OwlMail-Delivery-ID`. A process crash can duplicate a request that succeeded remotely but was not yet acknowledged in Redis.

This PR is stacked on #33 because durable handoff must serialize detached mail snapshots rather than the mutable in-memory store object.

## Tests

- `go test -race ./...`
- `bun test ./tests/web ./tests/docs`
- Redis Streams integration coverage is available with `OWLMAIL_TEST_REDIS_URL`