### PR TITLE
ci: separate validation snapshots and releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,45 +3,27 @@ name: Build
 on:
   push:
     branches: [ main ]
-    tags:
-      - 'v*'
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
-  GO_VERSION: "1.27.0"
   GO111MODULE: on
 
 jobs:
   build:
-    name: Build ${{ matrix.os }}-${{ matrix.arch }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            arch: amd64
-            goos: linux
-            goarch: amd64
-          - os: ubuntu-latest
-            arch: arm64
-            goos: linux
-            goarch: arm64
-          - os: macos-latest
-            arch: amd64
-            goos: darwin
-            goarch: amd64
-          - os: macos-latest
-            arch: arm64
-            goos: darwin
-            goarch: arm64
-          - os: windows-latest
-            arch: amd64
-            goos: windows
-            goarch: amd64
-            ext: .exe
+    name: Build
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -50,40 +32,38 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache-dependency-path: go.sum
 
-      - name: Download dependencies
-        run: go mod download
-
       - name: Verify dependencies
-        run: go mod verify
+        run: |
+          go mod download
+          go mod verify
 
-      - name: Build
+      - name: Build pull request platform
+        if: github.event_name == 'pull_request'
         env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: 0
-        run: go build -v -o owlmail${{ matrix.ext }} ./cmd/owlmail
+        run: |
+          mkdir -p dist
+          go build -v -o dist/owlmail ./cmd/owlmail
 
-      - name: Upload artifacts
+      - name: Cross-compile main branch
+        if: github.event_name != 'pull_request'
+        env:
+          CGO_ENABLED: 0
+        run: |
+          mkdir -p dist
+          GOOS=linux GOARCH=amd64 go build -o dist/owlmail-linux-amd64 ./cmd/owlmail
+          GOOS=linux GOARCH=arm64 go build -o dist/owlmail-linux-arm64 ./cmd/owlmail
+          GOOS=darwin GOARCH=amd64 go build -o dist/owlmail-darwin-amd64 ./cmd/owlmail
+          GOOS=darwin GOARCH=arm64 go build -o dist/owlmail-darwin-arm64 ./cmd/owlmail
+          GOOS=windows GOARCH=amd64 go build -o dist/owlmail-windows-amd64.exe ./cmd/owlmail
+
+      - name: Upload main branch snapshots
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: owlmail-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}
-          path: owlmail${{ matrix.ext }}
-          retention-days: 30
-
-  build-summary:
-    name: Build Summary
-    runs-on: ubuntu-latest
-    needs: build
-    if: always()
-    
-    steps:
-      - name: Check build status
-        run: |
-          if [ "${{ needs.build.result }}" != "success" ]; then
-            echo "Some builds failed"
-            exit 1
-          fi
-          echo "All builds completed successfully"
+          name: owlmail-${{ github.sha }}
+          path: dist/
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   web-test:
     name: Web Test
@@ -71,9 +75,6 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ['1.27.0']
 
     steps:
       - name: Checkout code
@@ -82,7 +83,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
           cache-dependency-path: go.sum
 
       - name: Run golangci-lint
@@ -94,9 +95,6 @@ jobs:
   vet:
     name: Vet
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ['1.27.0']
 
     steps:
       - name: Checkout code
@@ -105,7 +103,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
           cache-dependency-path: go.sum
 
       - name: Run go vet
@@ -122,9 +120,6 @@ jobs:
   build-check:
     name: Build Check
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ['1.27.0']
 
     steps:
       - name: Checkout code
@@ -133,7 +128,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
           cache-dependency-path: go.sum
 
       - name: Download dependencies

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,11 +3,14 @@ name: Docker Build and Push
 on:
   push:
     branches: [ main ]
-    tags:
-      - 'v*'
-  pull_request:
-    branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   workflow_dispatch:
+
+concurrency:
+  group: docker-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io
@@ -42,10 +45,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
             type=sha,prefix=sha-
             type=raw,value=latest,enable={{is_default_branch}}
 
@@ -65,7 +64,7 @@ jobs:
             BUILD_DATE=${{ steps.build-meta.outputs.build-date }}
             BRANCH=${{ github.ref_name }}
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,18 @@ on:
 
 permissions:
   contents: write
+  packages: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
-  GO_VERSION: "1.27.0"
   GO111MODULE: on
   GOFLAGS: -mod=readonly
   GOVULNCHECK_VERSION: "v1.7.0"
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   release:
@@ -60,6 +66,8 @@ jobs:
           fi
 
           echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "app-version=${VERSION#v}" >> "${GITHUB_OUTPUT}"
+          echo "commit=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
           echo "notes=${NOTES}" >> "${GITHUB_OUTPUT}"
           if [[ "${VERSION}" == *-* ]]; then
             echo "prerelease=true" >> "${GITHUB_OUTPUT}"
@@ -70,7 +78,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache-dependency-path: go.sum
 
       - name: Set up Bun
@@ -177,6 +185,49 @@ jobs:
       - name: Create checksums
         run: |
           sha256sum owlmail-* > checksums.txt
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract release image metadata
+        id: image-meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ steps.release.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.release.outputs.version }}
+            type=semver,pattern={{major}},value=${{ steps.release.outputs.version }}
+            type=raw,value=latest,enable=${{ steps.release.outputs.prerelease == 'false' }}
+
+      - name: Prepare image build metadata
+        id: build-meta
+        shell: bash
+        run: echo "build-date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${GITHUB_OUTPUT}"
+
+      - name: Build and push release image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: ./Dockerfile
+          build-args: |
+            VERSION=${{ steps.release.outputs.app-version }}
+            COMMIT=${{ steps.release.outputs.commit }}
+            BUILD_DATE=${{ steps.build-meta.outputs.build-date }}
+            BRANCH=${{ steps.release.outputs.version }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.image-meta.outputs.tags }}
+          labels: ${{ steps.image-meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Create release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,7 @@ jobs:
             type=semver,pattern={{version}},value=${{ steps.release.outputs.version }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.release.outputs.version }}
             type=semver,pattern={{major}},value=${{ steps.release.outputs.version }}
+            type=sha,prefix=sha-
             type=raw,value=latest,enable=${{ steps.release.outputs.prerelease == 'false' }}
 
       - name: Prepare image build metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to OwlMail are documented in this file. The format follows
 - CI now runs the race-enabled coverage suite once and reuses its output for
   the Job Summary and a seven-day HTML artifact. The duplicate Codecov workflow
   and silently ignored external upload failures were removed.
+- Pull requests now build once on Ubuntu, main cross-compiles snapshots on
+  Ubuntu with seven-day retention, and only the release workflow handles tag
+  binaries and versioned container images. Build workflows cancel superseded
+  branch runs and skip documentation-only changes.
 
 ## [0.5.0]
 

--- a/docs/en/Releasing.md
+++ b/docs/en/Releasing.md
@@ -9,8 +9,10 @@ container images must be built from that same tag.
 - `CHANGELOG.md` records user-visible changes.
 - `docs/en/Release-X.Y.Z.md` is the curated English release body.
 - `docs/zh-CN/Release-X.Y.Z.md` is the corresponding Chinese release note.
-- `.github/workflows/release.yml` builds binaries and checksums.
-- `.github/workflows/docker.yml` publishes multi-architecture images.
+- `.github/workflows/release.yml` builds formal binaries, checksums, and
+  multi-architecture release images from tags.
+- `.github/workflows/docker.yml` publishes moving `main`, `latest`, and commit
+  snapshots for the default branch only.
 
 The release workflow prepends the curated English note to GitHub's generated
 change list. It refuses manual runs for a missing tag or missing release-note
@@ -49,8 +51,8 @@ git push origin v0.5.0
 Do not move or reuse a published release tag. If a release needs a correction,
 make a new patch version.
 
-The tag push starts both release workflows. A manual run of the binary release
-workflow is only a retry mechanism: provide an existing tag, and the workflow
+The tag push starts the release workflow. A manual run of that workflow is only
+a retry mechanism: provide an existing tag, and the workflow
 checks out that tag before building. Before publishing assets, the job reruns
 dependency verification, formatting, `go vet`, race-enabled Go tests,
 `govulncheck`, and the Bun browser/documentation checks against the tag.

--- a/docs/zh-CN/Releasing.md
+++ b/docs/zh-CN/Releasing.md
@@ -8,8 +8,9 @@
 - `CHANGELOG.md` 记录用户可感知的改动。
 - `docs/en/Release-X.Y.Z.md` 是 GitHub Release 使用的英文发布正文。
 - `docs/zh-CN/Release-X.Y.Z.md` 是对应的中文发布说明。
-- `.github/workflows/release.yml` 构建二进制与校验和。
-- `.github/workflows/docker.yml` 发布多架构镜像。
+- `.github/workflows/release.yml` 从标签构建正式二进制、校验和及多架构发布镜像。
+- `.github/workflows/docker.yml` 只为默认分支发布会移动的 `main`、`latest` 与提交
+  快照。
 
 发布工作流会把英文策划版说明放在 GitHub 自动生成的变更列表之前。手动运行时，
 如果版本标签或对应发布说明文件不存在，工作流会失败。
@@ -45,8 +46,8 @@ git push origin v0.5.0
 
 不要移动或复用已经发布的标签。如需修正，应创建新的补丁版本。
 
-推送标签会启动二进制与容器发布工作流。手动运行二进制发布工作流只用于重试：
-必须提供已存在标签，工作流会先检出该标签再构建。发布文件上传前，任务会对该
+推送标签会启动统一发布工作流。手动运行该工作流只用于重试：必须提供已存在
+标签，工作流会先检出该标签再构建。发布文件上传前，任务会对该
 标签重新执行依赖校验、格式检查、`go vet`、带竞态检测的 Go 测试、
 `govulncheck` 以及 Bun 浏览器/文档检查。
 


### PR DESCRIPTION
## Summary

- build pull requests once on Ubuntu and cross-compile short-lived main snapshots from Ubuntu
- move versioned multi-platform container publishing into the tag release workflow
- cancel superseded branch runs, skip documentation-only cross-builds, and remove one-value Go matrices
- keep main container snapshots separate from formal tag artifacts

This PR is stacked on #36 so the CI workflow changes apply on top of the consolidated coverage job.

## Validation

- parsed every GitHub Actions workflow as YAML
- cross-compiled Linux amd64/arm64, macOS amd64/arm64, and Windows amd64 binaries
- `bun test ./tests/docs`
- `git diff --check`