### PR TITLE
ci: attest and sign release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
+  attestations: write
 
 concurrency:
   group: release-${{ github.ref }}
@@ -44,6 +46,10 @@ jobs:
         run: |
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
             VERSION="${REQUESTED_VERSION}"
+            if [ "${GITHUB_REF}" != "refs/tags/${VERSION}" ]; then
+              echo "::error::Manual releases must run at the requested tag ref; use --ref ${VERSION}"
+              exit 1
+            fi
           else
             VERSION="${GITHUB_REF_NAME}"
           fi
@@ -182,9 +188,65 @@ jobs:
             exit 1
           fi
 
+      - name: Generate Linux amd64 SBOM
+        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
+        with:
+          file: owlmail-linux-amd64
+          format: spdx-json
+          output-file: owlmail-linux-amd64.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Generate Linux arm64 SBOM
+        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
+        with:
+          file: owlmail-linux-arm64
+          format: spdx-json
+          output-file: owlmail-linux-arm64.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Generate macOS amd64 SBOM
+        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
+        with:
+          file: owlmail-darwin-amd64
+          format: spdx-json
+          output-file: owlmail-darwin-amd64.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Generate macOS arm64 SBOM
+        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
+        with:
+          file: owlmail-darwin-arm64
+          format: spdx-json
+          output-file: owlmail-darwin-arm64.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Generate Windows amd64 SBOM
+        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
+        with:
+          file: owlmail-windows-amd64.exe
+          format: spdx-json
+          output-file: owlmail-windows-amd64.exe.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
       - name: Create checksums
         run: |
           sha256sum owlmail-* > checksums.txt
+
+      - name: Attest release binaries
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-checksums: checksums.txt
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign checksum manifest with Sigstore
+        run: cosign sign-blob --yes --bundle checksums.txt.sigstore.json checksums.txt
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -207,6 +269,11 @@ jobs:
             type=semver,pattern={{major}},value=${{ steps.release.outputs.version }}
             type=sha,prefix=sha-
             type=raw,value=latest,enable=${{ steps.release.outputs.prerelease == 'false' }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ steps.release.outputs.commit }}
+            org.opencontainers.image.version=${{ steps.release.outputs.app-version }}
+            org.opencontainers.image.licenses=MIT
 
       - name: Prepare image build metadata
         id: build-meta
@@ -214,6 +281,7 @@ jobs:
         run: echo "build-date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${GITHUB_OUTPUT}"
 
       - name: Build and push release image
+        id: image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
@@ -225,10 +293,24 @@ jobs:
             BRANCH=${{ steps.release.outputs.version }}
           platforms: linux/amd64,linux/arm64
           push: true
+          sbom: true
+          provenance: mode=max
           tags: ${{ steps.image-meta.outputs.tags }}
           labels: ${{ steps.image-meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Attest release image
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.image.outputs.digest }}
+          push-to-registry: true
+
+      - name: Sign release image with Sigstore
+        env:
+          IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
+        run: cosign sign --yes "${REGISTRY}/${IMAGE_NAME}@${IMAGE_DIGEST}"
 
       - name: Create release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
@@ -239,6 +321,7 @@ jobs:
           files: |
             owlmail-*
             checksums.txt
+            checksums.txt.sigstore.json
           fail_on_unmatched_files: true
           generate_release_notes: true
           draft: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to OwlMail are documented in this file. The format follows
   Ubuntu with seven-day retention, and only the release workflow handles tag
   binaries and versioned container images. Build workflows cancel superseded
   branch runs and skip documentation-only changes.
+- Formal releases now publish per-binary SPDX SBOMs, GitHub provenance
+  attestations, a keyless Sigstore signature for the checksum manifest, signed
+  container manifests, BuildKit SBOM/provenance attestations, and explicit OCI
+  source, revision, version, and license labels.
 
 ## [0.5.0]
 

--- a/docs/en/Releasing.md
+++ b/docs/en/Releasing.md
@@ -9,8 +9,9 @@ container images must be built from that same tag.
 - `CHANGELOG.md` records user-visible changes.
 - `docs/en/Release-X.Y.Z.md` is the curated English release body.
 - `docs/zh-CN/Release-X.Y.Z.md` is the corresponding Chinese release note.
-- `.github/workflows/release.yml` builds formal binaries, checksums, and
-  multi-architecture release images from tags.
+- `.github/workflows/release.yml` builds formal binaries, checksums, per-binary
+  SBOMs, provenance, signatures, and multi-architecture release images from
+  tags.
 - `.github/workflows/docker.yml` publishes moving `main`, `latest`, and commit
   snapshots for the default branch only.
 
@@ -51,29 +52,52 @@ git push origin v0.5.0
 Do not move or reuse a published release tag. If a release needs a correction,
 make a new patch version.
 
-The tag push starts the release workflow. A manual run of that workflow is only
-a retry mechanism: provide an existing tag, and the workflow
+The tag push starts the release workflow. A manual run is only a retry mechanism
+and must execute at the same tag ref so its OIDC identity is tag-bound:
+
+```bash
+gh workflow run release.yml --ref v0.5.0 -f version=v0.5.0
+```
+
+The workflow rejects a manual run whose ref and requested version differ, then
 checks out that tag before building. Before publishing assets, the job reruns
 dependency verification, formatting, `go vet`, race-enabled Go tests,
-`govulncheck`, and the Bun browser/documentation checks against the tag.
+`govulncheck`, and the Bun browser/documentation checks against the tag. It then
+generates SPDX SBOMs, GitHub artifact attestations, and keyless Sigstore
+signatures before publishing the release.
 
 ## Verify published artifacts
 
-The GitHub release must contain these six uploaded assets for 0.5.0 (in addition
-to GitHub's automatic source archives):
+In addition to GitHub's automatic source archives, a release made with the
+current workflow contains:
 
 - `checksums.txt`
+- `checksums.txt.sigstore.json`
 - `owlmail-linux-amd64`
+- `owlmail-linux-amd64.spdx.json`
 - `owlmail-linux-arm64`
+- `owlmail-linux-arm64.spdx.json`
 - `owlmail-darwin-amd64`
+- `owlmail-darwin-amd64.spdx.json`
 - `owlmail-darwin-arm64`
+- `owlmail-darwin-arm64.spdx.json`
 - `owlmail-windows-amd64.exe`
+- `owlmail-windows-amd64.exe.spdx.json`
 
 Download all files into an empty directory and verify them:
 
 ```bash
 sha256sum -c checksums.txt
+gh attestation verify owlmail-linux-amd64 --repo soulteary/owlmail
+cosign verify-blob \
+  --bundle checksums.txt.sigstore.json \
+  --certificate-identity-regexp '^https://github.com/soulteary/owlmail/.github/workflows/release.yml@refs/tags/v' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  checksums.txt
 ```
+
+The checksum manifest and GitHub provenance attestations cover all five
+executables and all five adjacent `*.spdx.json` SBOMs.
 
 Smoke-test at least one binary:
 
@@ -94,6 +118,10 @@ used to prove release reproducibility.
 
 ```bash
 docker buildx imagetools inspect ghcr.io/soulteary/owlmail:0.5.0
+cosign verify \
+  --certificate-identity-regexp '^https://github.com/soulteary/owlmail/.github/workflows/release.yml@refs/tags/v' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/soulteary/owlmail:0.5.0
 docker run --rm \
   -p 127.0.0.1:11025:1025 \
   -p 127.0.0.1:11080:1080 \
@@ -101,14 +129,18 @@ docker run --rm \
 ```
 
 Confirm the manifest lists `linux/amd64` and `linux/arm64`, then repeat the
-health, version, and SMTP smoke tests against the container.
+health, version, and SMTP smoke tests against the container. The manifest also
+has BuildKit SBOM and maximum-mode provenance attestations, a GitHub provenance
+attestation, and explicit OCI source, revision, version, and MIT license labels.
 
 ## Post-release checklist
 
 - [ ] GitHub marks `v0.5.0` as the latest non-prerelease release.
 - [ ] The curated note appears before the generated pull-request list.
-- [ ] Every binary and `checksums.txt` is downloadable and verified.
+- [ ] Every binary, SBOM, checksum, signature bundle, and GitHub attestation is
+  downloadable or discoverable and verified.
 - [ ] Container version and commit tags resolve to the expected manifest.
+- [ ] The release image's Cosign signature and OCI attestations verify.
 - [ ] Go installation with `@v0.5.0` succeeds on the documented Go version.
 - [ ] README and release-note installation commands resolve.
 - [ ] Any release failure or known limitation is added to the release body and changelog.

--- a/docs/zh-CN/Releasing.md
+++ b/docs/zh-CN/Releasing.md
@@ -8,7 +8,8 @@
 - `CHANGELOG.md` 记录用户可感知的改动。
 - `docs/en/Release-X.Y.Z.md` 是 GitHub Release 使用的英文发布正文。
 - `docs/zh-CN/Release-X.Y.Z.md` 是对应的中文发布说明。
-- `.github/workflows/release.yml` 从标签构建正式二进制、校验和及多架构发布镜像。
+- `.github/workflows/release.yml` 从标签构建正式二进制、校验和、逐二进制 SBOM、
+  来源证明、签名及多架构发布镜像。
 - `.github/workflows/docker.yml` 只为默认分支发布会移动的 `main`、`latest` 与提交
   快照。
 
@@ -46,27 +47,50 @@ git push origin v0.5.0
 
 不要移动或复用已经发布的标签。如需修正，应创建新的补丁版本。
 
-推送标签会启动统一发布工作流。手动运行该工作流只用于重试：必须提供已存在
-标签，工作流会先检出该标签再构建。发布文件上传前，任务会对该
+推送标签会启动统一发布工作流。手动运行只用于重试，并且必须在同一个标签引用
+上执行，使 OIDC 身份与标签绑定：
+
+```bash
+gh workflow run release.yml --ref v0.5.0 -f version=v0.5.0
+```
+
+工作流会拒绝引用和请求版本不一致的手动运行，然后检出该标签再构建。发布文件
+上传前，任务会对该
 标签重新执行依赖校验、格式检查、`go vet`、带竞态检测的 Go 测试、
-`govulncheck` 以及 Bun 浏览器/文档检查。
+`govulncheck` 以及 Bun 浏览器/文档检查，随后生成 SPDX SBOM、GitHub Artifact
+Attestation 与 Sigstore 无密钥签名，再正式发布。
 
 ## 验证发布文件
 
-除 GitHub 自动生成的源码归档外，0.5.0 的 GitHub Release 应包含以下 6 个上传文件：
+除 GitHub 自动生成的源码归档外，使用当前工作流发布的版本应包含：
 
 - `checksums.txt`
+- `checksums.txt.sigstore.json`
 - `owlmail-linux-amd64`
+- `owlmail-linux-amd64.spdx.json`
 - `owlmail-linux-arm64`
+- `owlmail-linux-arm64.spdx.json`
 - `owlmail-darwin-amd64`
+- `owlmail-darwin-amd64.spdx.json`
 - `owlmail-darwin-arm64`
+- `owlmail-darwin-arm64.spdx.json`
 - `owlmail-windows-amd64.exe`
+- `owlmail-windows-amd64.exe.spdx.json`
 
 将全部文件下载到空目录并校验：
 
 ```bash
 sha256sum -c checksums.txt
+gh attestation verify owlmail-linux-amd64 --repo soulteary/owlmail
+cosign verify-blob \
+  --bundle checksums.txt.sigstore.json \
+  --certificate-identity-regexp '^https://github.com/soulteary/owlmail/.github/workflows/release.yml@refs/tags/v' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  checksums.txt
 ```
+
+校验和清单与 GitHub provenance 同时覆盖 5 个可执行文件及其 5 个
+`*.spdx.json` SBOM。
 
 至少冒烟测试一个二进制：
 
@@ -86,6 +110,10 @@ curl --fail http://localhost:11080/api/v1/version
 
 ```bash
 docker buildx imagetools inspect ghcr.io/soulteary/owlmail:0.5.0
+cosign verify \
+  --certificate-identity-regexp '^https://github.com/soulteary/owlmail/.github/workflows/release.yml@refs/tags/v' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/soulteary/owlmail:0.5.0
 docker run --rm \
   -p 127.0.0.1:11025:1025 \
   -p 127.0.0.1:11080:1080 \
@@ -93,14 +121,17 @@ docker run --rm \
 ```
 
 确认清单包含 `linux/amd64` 与 `linux/arm64`，再对容器重复健康、版本和 SMTP
-冒烟测试。
+冒烟测试。镜像清单还应包含 BuildKit SBOM、最高模式 provenance、GitHub
+provenance、Cosign 签名，以及明确的 OCI 来源、修订、版本和 MIT 许可证标签。
 
 ## 发布后检查
 
 - [ ] GitHub 将 `v0.5.0` 标记为最新非预发布版本。
 - [ ] 策划版说明显示在自动生成的 PR 列表之前。
-- [ ] 所有二进制与 `checksums.txt` 均可下载并通过校验。
+- [ ] 所有二进制、SBOM、校验和、签名包与 GitHub Attestation 均可下载或发现，
+  并通过校验。
 - [ ] 容器版本标签和提交标签指向预期清单。
+- [ ] 发布镜像的 Cosign 签名与 OCI Attestation 通过验证。
 - [ ] 使用文档要求的 Go 版本执行 `@v0.5.0` 安装成功。
 - [ ] README 与发布说明中的安装命令均可解析。
 - [ ] 所有发布失败或已知限制均已补充到发布正文与变更日志。

--- a/tests/docs/markdown.test.js
+++ b/tests/docs/markdown.test.js
@@ -385,6 +385,43 @@ test("0.5.0 release documentation and workflow stay connected", () => {
   }
 });
 
+test("release workflow preserves supply-chain evidence", () => {
+  const workflow = fs.readFileSync(path.join(root, ".github/workflows/release.yml"), "utf8");
+  for (const marker of [
+    "id-token: write",
+    "attestations: write",
+    "anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26",
+    "actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8",
+    "sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6",
+    "subject-checksums: checksums.txt",
+    "checksums.txt.sigstore.json",
+    "sbom: true",
+    "provenance: mode=max",
+    "push-to-registry: true",
+    "org.opencontainers.image.source",
+    "org.opencontainers.image.revision",
+    "org.opencontainers.image.version",
+    "org.opencontainers.image.licenses=MIT",
+    'cosign sign --yes "${REGISTRY}/${IMAGE_NAME}@${IMAGE_DIGEST}"',
+    '"${GITHUB_REF}" != "refs/tags/${VERSION}"',
+  ]) {
+    assert.ok(workflow.includes(marker), `.github/workflows/release.yml is missing ${marker}`);
+  }
+
+  for (const guide of ["docs/en/Releasing.md", "docs/zh-CN/Releasing.md"]) {
+    const markdown = fs.readFileSync(path.join(root, guide), "utf8");
+    for (const marker of [
+      "checksums.txt.sigstore.json",
+      "gh attestation verify",
+      "cosign verify-blob",
+      "cosign verify",
+      "--ref v0.5.0",
+    ]) {
+      assert.ok(markdown.includes(marker), `${guide} is missing supply-chain marker ${marker}`);
+    }
+  }
+});
+
 test("browser and documentation tests use the pinned Bun runner", () => {
   const legacyRunner = `node:${"test"}`;
   for (const testFile of [


### PR DESCRIPTION
## Summary

- publish an SPDX JSON SBOM for every release binary and cover binaries/SBOMs with the checksum manifest
- create GitHub provenance attestations for release files and the pushed OCI manifest
- keylessly sign the checksum manifest and multi-architecture image with Cosign
- attach BuildKit SBOM and maximum-mode provenance to images and set explicit OCI source, revision, version, and MIT license labels
- require manual retries to run at the requested tag ref so OIDC identity remains tag-bound
- document verification commands in English and Chinese and add a regression contract test

This PR is stacked on #37 because it extends the unified tag release workflow introduced there.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `bun test ./tests/web ./tests/docs`
- parsed and structurally checked `release.yml`
- verified action versions and immutable commit SHAs from their official GitHub repositories
- `git diff --check`