### PR TITLE
fix(api): enforce scheme in authenticated origin checks

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -59,7 +59,7 @@ func NewAPIWithHTTPS(mailServer *mailserver.MailServer, port int, host, user, pa
 		httpsKeyFile:  keyFile,
 		wsUpgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
-				return !authEnabled || originMatchesHost(r.Header.Get("Origin"), r.Host)
+				return !authEnabled || originMatchesRequest(r.Header.Get("Origin"), requestScheme(r), r.Host)
 			},
 		},
 	}

--- a/internal/api/api_middleware.go
+++ b/internal/api/api_middleware.go
@@ -9,10 +9,10 @@ import (
 	"github.com/gofiber/fiber/v3"
 )
 
-// originMatchesHost implements the browser same-origin host check used for
+// originMatchesRequest implements the browser same-origin check used for
 // authenticated HTTP and WebSocket requests. Requests without an Origin header
 // are non-browser clients and remain allowed.
-func originMatchesHost(origin, host string) bool {
+func originMatchesRequest(origin, scheme, host string) bool {
 	if origin == "" {
 		return true
 	}
@@ -20,12 +20,27 @@ func originMatchesHost(origin, host string) bool {
 	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") {
 		return false
 	}
-	return parsed.User == nil && strings.EqualFold(parsed.Host, host)
+	return parsed.User == nil &&
+		strings.EqualFold(parsed.Scheme, scheme) &&
+		strings.EqualFold(parsed.Host, host)
+}
+
+func requestScheme(request *http.Request) string {
+	if request == nil {
+		return ""
+	}
+	if request.URL != nil && request.URL.Scheme != "" {
+		return strings.ToLower(request.URL.Scheme)
+	}
+	if request.TLS != nil {
+		return "https"
+	}
+	return "http"
 }
 
 func sameOriginMiddleware() fiber.Handler {
 	return func(c fiber.Ctx) error {
-		if !originMatchesHost(c.Get(fiber.HeaderOrigin), c.Host()) {
+		if !originMatchesRequest(c.Get(fiber.HeaderOrigin), c.Protocol(), c.Host()) {
 			return c.SendStatus(http.StatusForbidden)
 		}
 		return c.Next()

--- a/internal/api/api_middleware_test.go
+++ b/internal/api/api_middleware_test.go
@@ -62,6 +62,28 @@ func TestAuthenticatedAPIRejectsCrossOriginBrowserRequest(t *testing.T) {
 	}
 }
 
+func TestAuthenticatedAPIRejectsCrossSchemeBrowserRequest(t *testing.T) {
+	tmpDir := t.TempDir()
+	server, err := mailserver.NewMailServer(1025, "localhost", tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	api := NewAPIWithAuth(server, 1080, "localhost", "user", "pass")
+	req, _ := http.NewRequest(http.MethodGet, "http://owlmail.test/api/v1/emails", nil)
+	req.Header.Set("Origin", "https://owlmail.test")
+	req.SetBasicAuth("user", "pass")
+	resp, err := api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+}
+
 func TestAuthenticatedAPIAllowsSameOriginAndNonBrowserRequests(t *testing.T) {
 	tmpDir := t.TempDir()
 	server, err := mailserver.NewMailServer(1025, "localhost", tmpDir)
@@ -101,6 +123,7 @@ func TestAuthenticatedWebSocketOriginPolicy(t *testing.T) {
 	}{
 		{origin: "", want: true},
 		{origin: "http://owlmail.test", want: true},
+		{origin: "https://owlmail.test", want: false},
 		{origin: "https://attacker.example", want: false},
 		{origin: "://invalid", want: false},
 	}


### PR DESCRIPTION
## Summary

- compare the request scheme as well as host and port for authenticated browser requests
- apply the same full-origin policy to HTTP routes and WebSocket upgrades
- add regression coverage for HTTPS-origin requests against an HTTP OwlMail endpoint

## Why

A host-only comparison treats `http://example.test` and `https://example.test` as the same origin. Browsers can then reuse cached Basic Auth credentials across schemes, including for WebSocket connections.

## Validation

- `git diff --check`
- Go tests are delegated to repository CI because the local workspace does not include the Go toolchain

Addresses the unresolved review finding from #20.

> Superseded by #52, which carries the same fix with expanded scheme/host regression coverage and completed local Go/Bun validation.