### PR TITLE
fix(web): tolerate missing email address values

### DIFF
--- a/tests/web/app.test.js
+++ b/tests/web/app.test.js
@@ -168,3 +168,11 @@ test('insecure contexts report notifications as unavailable', () => {
     assert.equal(harness.notificationToggle.attributes.get('aria-pressed'), 'false');
     assert.equal(harness.storage.get('owlmail.browserNotifications.enabled'), 'true');
 });
+
+test('address formatting tolerates null and undefined values', () => {
+    const harness = createHarness();
+
+    assert.equal(harness.run('formatAddress(null)'), 'Unknown');
+    assert.equal(harness.run('formatAddress(undefined)'), 'Unknown');
+    assert.equal(harness.run('formatAddress({ Name: "Sender", Address: "sender@example.test" })'), 'Sender <sender@example.test>');
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1412,6 +1412,7 @@ function formatTime(timeStr) {
 
 function formatAddress(addr) {
     if (typeof addr === 'string') return addr;
+    if (!addr || typeof addr !== 'object') return t('unknown');
     
     // 支持大小写两种字段名格式（Name/Address 或 name/address）
     const name = addr.Name || addr.name || '';


### PR DESCRIPTION
## Summary

- guard `formatAddress` against null, undefined, and non-object values
- return the localized unknown-address label instead of throwing
- add browser regression coverage for null, undefined, and normal address objects

## Validation

- `git diff --check`
- Bun tests are delegated to repository CI because Bun is unavailable locally

Addresses the unresolved review finding from #4.