### PR TITLE
docs: document the pinned Bun prerequisite

### DIFF
--- a/.github/CONTRIBUTING.de.md
+++ b/.github/CONTRIBUTING.de.md
@@ -107,7 +107,10 @@ If you find a bug or have a feature suggestion, please:
 ### Prerequisites
 
 - Go 1.27.0 or higher
+- Bun version pinned in `.bun-version`
 - Git
+
+Install Bun using the [official instructions](https://bun.sh/docs/installation), then run `bun --version` and confirm it matches `.bun-version` before executing the browser and documentation checks.
 
 ### Setup Steps
 

--- a/.github/CONTRIBUTING.fr.md
+++ b/.github/CONTRIBUTING.fr.md
@@ -107,7 +107,10 @@ If you find a bug or have a feature suggestion, please:
 ### Prerequisites
 
 - Go 1.27.0 or higher
+- Bun version pinned in `.bun-version`
 - Git
+
+Install Bun using the [official instructions](https://bun.sh/docs/installation), then run `bun --version` and confirm it matches `.bun-version` before executing the browser and documentation checks.
 
 ### Setup Steps
 

--- a/.github/CONTRIBUTING.it.md
+++ b/.github/CONTRIBUTING.it.md
@@ -107,7 +107,10 @@ If you find a bug or have a feature suggestion, please:
 ### Prerequisites
 
 - Go 1.27.0 or higher
+- Bun version pinned in `.bun-version`
 - Git
+
+Install Bun using the [official instructions](https://bun.sh/docs/installation), then run `bun --version` and confirm it matches `.bun-version` before executing the browser and documentation checks.
 
 ### Setup Steps
 

--- a/.github/CONTRIBUTING.ja.md
+++ b/.github/CONTRIBUTING.ja.md
@@ -107,7 +107,10 @@ If you find a bug or have a feature suggestion, please:
 ### Prerequisites
 
 - Go 1.27.0 or higher
+- Bun version pinned in `.bun-version`
 - Git
+
+Install Bun using the [official instructions](https://bun.sh/docs/installation), then run `bun --version` and confirm it matches `.bun-version` before executing the browser and documentation checks.
 
 ### Setup Steps
 

--- a/.github/CONTRIBUTING.ko.md
+++ b/.github/CONTRIBUTING.ko.md
@@ -107,7 +107,10 @@ If you find a bug or have a feature suggestion, please:
 ### Prerequisites
 
 - Go 1.27.0 or higher
+- Bun version pinned in `.bun-version`
 - Git
+
+Install Bun using the [official instructions](https://bun.sh/docs/installation), then run `bun --version` and confirm it matches `.bun-version` before executing the browser and documentation checks.
 
 ### Setup Steps
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -107,7 +107,10 @@ If you find a bug or have a feature suggestion, please:
 ### Prerequisites
 
 - Go 1.27.0 or higher
+- Bun version pinned in `.bun-version`
 - Git
+
+Install Bun using the [official instructions](https://bun.sh/docs/installation), then run `bun --version` and confirm it matches `.bun-version` before executing the browser and documentation checks.
 
 ### Setup Steps
 

--- a/.github/CONTRIBUTING.zh-CN.md
+++ b/.github/CONTRIBUTING.zh-CN.md
@@ -107,7 +107,10 @@
 ### 前置要求
 
 - Go 1.27.0 或更高版本
+- `.bun-version` 中固定的 Bun 版本
 - Git
+
+请按照 [Bun 官方安装说明](https://bun.sh/docs/installation)安装，然后运行 `bun --version`，确认版本与 `.bun-version` 一致，再执行浏览器和文档检查。
 
 ### 设置步骤
 


### PR DESCRIPTION
## Summary

- list the Bun version pinned by `.bun-version` as a development prerequisite
- link the official installation instructions and add a version-verification step
- update all seven localized contribution guides

## Validation

- `git diff --check`
- documentation contract tests are delegated to repository CI

Addresses the remaining review finding from #29.