### PR TITLE
docs(demo): keep OwlMail integration on loopback

### DIFF
--- a/examples/webhooks/soulteary-webhook/README.md
+++ b/examples/webhooks/soulteary-webhook/README.md
@@ -32,6 +32,10 @@ The Compose file has a development-only fallback secret so the demo can start,
 but set your own random value whenever the ports are reachable by another
 machine. The same secret is passed to both containers.
 
+All published ports are bound to `127.0.0.1` so the unauthenticated local demo
+is not exposed to the LAN. Change those bindings only after adding an
+authenticated reverse proxy or enabling OwlMail Web and SMTP authentication.
+
 OwlMail explicitly uses `OWLMAIL_WEBHOOK_MAX_CONCURRENCY=8`, its safe default.
 Keep the limit sized to downstream capacity. Set it to `0` only when unlimited
 webhook delivery is intentional and the receiving system can absorb it.
@@ -92,8 +96,9 @@ export OWLMAIL_WEBHOOK_MAX_CONCURRENCY=8
 owlmail -webhook-config owlmail.json
 ```
 
-For production, keep WebHook private or behind an authenticated reverse proxy,
-retain HMAC verification, restrict allowed command paths, bound execution and
+For production, keep both OwlMail and WebHook private or behind authenticated
+reverse proxies, enable OwlMail Web Basic Auth and SMTP authentication, retain
+HMAC verification, restrict allowed command paths, bound execution and
 concurrency, and avoid logging full email bodies.
 
 [中文说明](./README.zh-CN.md) ·

--- a/examples/webhooks/soulteary-webhook/README.zh-CN.md
+++ b/examples/webhooks/soulteary-webhook/README.zh-CN.md
@@ -29,6 +29,9 @@ docker compose up
 Compose 文件保留了仅用于本地演示的默认密钥，因此不设置变量也能启动；只要端口
 可能被其他机器访问，就应该使用自己的随机密钥。同一个密钥会传给两个容器。
 
+所有宿主机端口都绑定到 `127.0.0.1`，避免未鉴权的本地 Demo 暴露到局域网。只有在
+增加带鉴权的反向代理，或同时启用 OwlMail Web 与 SMTP 鉴权后，才应修改这些绑定。
+
 OwlMail 显式设置 `OWLMAIL_WEBHOOK_MAX_CONCURRENCY=8`，与安全默认值一致。生产
 环境应根据下游处理能力设置上限；只有明确希望不限制并发，并确认接收端能够承受时，
 才应设置为 `0`。
@@ -85,8 +88,9 @@ export OWLMAIL_WEBHOOK_MAX_CONCURRENCY=8
 owlmail -webhook-config owlmail.json
 ```
 
-生产环境建议保持 WebHook 仅内网可访问或放在带鉴权的反向代理之后，继续启用 HMAC
-验证，限制允许执行的命令路径，设置执行时间和并发上限，并避免记录完整邮件正文。
+生产环境建议保持 OwlMail 和 WebHook 都仅内网可访问或放在带鉴权的反向代理之后，
+启用 OwlMail Web Basic Auth 与 SMTP 鉴权，继续启用 HMAC 验证，限制允许执行的命令
+路径，设置执行时间和并发上限，并避免记录完整邮件正文。
 
 [English](./README.md) ·
 [Webhook 消息转发参考](../../../docs/zh-CN/Webhook-Forwarding.md) ·

--- a/examples/webhooks/soulteary-webhook/compose.yaml
+++ b/examples/webhooks/soulteary-webhook/compose.yaml
@@ -2,7 +2,7 @@ services:
   webhook:
     image: soulteary/webhook:7.0.0
     ports:
-      - "9000:9000"
+      - "127.0.0.1:9000:9000"
     environment:
       HOST: "0.0.0.0"
       PORT: "9000"
@@ -28,8 +28,8 @@ services:
       webhook:
         condition: service_healthy
     ports:
-      - "1025:1025"
-      - "1080:1080"
+      - "127.0.0.1:1025:1025"
+      - "127.0.0.1:1080:1080"
     environment:
       OWLMAIL_SMTP_HOST: "0.0.0.0"
       OWLMAIL_WEB_HOST: "0.0.0.0"


### PR DESCRIPTION
## Summary

- bind the OwlMail SMTP/UI and WebHook demo ports to `127.0.0.1`
- document that changing the bindings requires authentication or a protected reverse proxy
- extend English and Chinese production guidance to protect OwlMail as well as WebHook

## Validation

- `git diff --check`
- Compose and documentation checks are delegated to repository CI

Addresses the unresolved review finding from #31.

> Superseded by #55, which adds the same loopback bindings plus an executable documentation regression test.