### PR TITLE
fix(web): preserve inbox language on help fallback

### DIFF
--- a/tests/web/help.test.js
+++ b/tests/web/help.test.js
@@ -1,0 +1,57 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { test } = require('bun:test');
+const vm = require('node:vm');
+
+const source = fs.readFileSync(path.join(__dirname, '../../web/help.js'), 'utf8');
+
+function createHarness(savedLanguage) {
+    const storage = new Map([['language', savedLanguage], ['theme', 'light']]);
+    const listeners = new Map();
+    const languageSelect = {
+        value: '',
+        addEventListener(name, handler) { listeners.set(name, handler); }
+    };
+    const themeButton = {
+        textContent: '',
+        addEventListener() {},
+        setAttribute() {}
+    };
+    const panels = [
+        { dataset: { language: 'en' }, hidden: false },
+        { dataset: { language: 'zh-CN' }, hidden: false }
+    ];
+    const sandbox = {
+        document: {
+            title: '',
+            documentElement: { lang: '', dataset: {} },
+            body: { classList: { contains: () => false, toggle() {} } },
+            getElementById(id) { return id === 'helpLanguage' ? languageSelect : themeButton; },
+            querySelectorAll() { return panels; }
+        },
+        navigator: { language: 'en-US' },
+        localStorage: {
+            getItem(key) { return storage.get(key) || null; },
+            setItem(key, value) { storage.set(key, value); }
+        }
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(source, sandbox, { filename: 'web/help.js' });
+    return { languageSelect, listeners, storage };
+}
+
+test('help fallback does not overwrite the inbox language preference', () => {
+    const harness = createHarness('de');
+
+    assert.equal(harness.languageSelect.value, 'en');
+    assert.equal(harness.storage.get('language'), 'de');
+});
+
+test('an explicit help language change updates the shared preference', () => {
+    const harness = createHarness('de');
+
+    harness.listeners.get('change')({ target: { value: 'zh-CN' } });
+
+    assert.equal(harness.storage.get('language'), 'zh-CN');
+});

--- a/web/help.js
+++ b/web/help.js
@@ -25,7 +25,7 @@
         return (navigator.language || '').toLowerCase().startsWith('zh') ? 'zh-CN' : 'en';
     }
 
-    function applyLanguage(language) {
+    function applyLanguage(language, persist = false) {
         const selected = supportedLanguages.has(language) ? language : 'en';
         document.documentElement.lang = selected;
         document.documentElement.dataset.language = selected;
@@ -34,7 +34,7 @@
         document.querySelectorAll('.language-panel').forEach((panel) => {
             panel.hidden = panel.dataset.language !== selected;
         });
-        savePreference('language', selected);
+        if (persist) savePreference('language', selected);
     }
 
     function applyTheme(theme) {
@@ -46,7 +46,7 @@
         savePreference('theme', dark ? 'dark' : 'light');
     }
 
-    languageSelect.addEventListener('change', (event) => applyLanguage(event.target.value));
+    languageSelect.addEventListener('change', (event) => applyLanguage(event.target.value, true));
     themeButton.addEventListener('click', () => {
         applyTheme(document.body.classList.contains('dark-theme') ? 'light' : 'dark');
     });


### PR DESCRIPTION
## Summary

- stop the two-language help page from overwriting a supported inbox language during initialization
- persist the shared preference only after an explicit help-page selection
- add browser tests for fallback and user-driven changes

## Validation

- `node --check web/help.js`
- `node --check tests/web/help.test.js`
- `git diff --check`
- Bun execution is delegated to repository CI

Addresses the unresolved review finding from #16.