### PR TITLE
fix(webhook): isolate target delivery schedules

### DIFF
--- a/internal/webhook/dispatcher.go
+++ b/internal/webhook/dispatcher.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/soulteary/owlmail/internal/types"
@@ -102,13 +103,23 @@ func (dispatcher *Dispatcher) DispatchDelivery(ctx context.Context, email *types
 	}
 
 	payload := newEmailPayload(email)
-	results := make([]Result, 0, len(dispatcher.targets))
+	matchingTargets := make([]compiledTarget, 0, len(dispatcher.targets))
 	for _, target := range dispatcher.targets {
-		if !target.matches(payload) {
-			continue
+		if target.matches(payload) {
+			matchingTargets = append(matchingTargets, target)
 		}
-		results = append(results, dispatcher.deliver(ctx, target, payload, deliveryID))
 	}
+
+	results := make([]Result, len(matchingTargets))
+	var deliveries sync.WaitGroup
+	deliveries.Add(len(matchingTargets))
+	for index, target := range matchingTargets {
+		go func() {
+			defer deliveries.Done()
+			results[index] = dispatcher.deliver(ctx, target, payload, deliveryID)
+		}()
+	}
+	deliveries.Wait()
 	return results
 }
 

--- a/internal/webhook/dispatcher.go
+++ b/internal/webhook/dispatcher.go
@@ -27,8 +27,9 @@ const (
 
 // Dispatcher sends matching email events to configured targets.
 type Dispatcher struct {
-	targets []compiledTarget
-	client  *http.Client
+	targets       []compiledTarget
+	client        *http.Client
+	deliverySlots chan struct{}
 }
 
 // Result describes one target delivery attempt.
@@ -83,6 +84,32 @@ func (dispatcher *Dispatcher) TargetCount() int {
 	return len(dispatcher.targets)
 }
 
+func (dispatcher *Dispatcher) withMaxConcurrency(limit int) *Dispatcher {
+	limited := *dispatcher
+	if limit > 0 {
+		limited.deliverySlots = make(chan struct{}, limit)
+	}
+	return &limited
+}
+
+func (dispatcher *Dispatcher) acquireDeliverySlot(ctx context.Context) error {
+	if dispatcher.deliverySlots == nil {
+		return nil
+	}
+	select {
+	case dispatcher.deliverySlots <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (dispatcher *Dispatcher) releaseDeliverySlot() {
+	if dispatcher.deliverySlots != nil {
+		<-dispatcher.deliverySlots
+	}
+}
+
 // Dispatch synchronously sends an email to every matching target. MailServer
 // invokes event listeners asynchronously, so this never blocks SMTP storage.
 func (dispatcher *Dispatcher) Dispatch(ctx context.Context, email *types.Email) []Result {
@@ -103,19 +130,24 @@ func (dispatcher *Dispatcher) DispatchDelivery(ctx context.Context, email *types
 	}
 
 	payload := newEmailPayload(email)
-	matchingTargets := make([]compiledTarget, 0, len(dispatcher.targets))
+	matching := make([]compiledTarget, 0, len(dispatcher.targets))
 	for _, target := range dispatcher.targets {
-		if target.matches(payload) {
-			matchingTargets = append(matchingTargets, target)
+		if !target.matches(payload) {
+			continue
 		}
+		matching = append(matching, target)
 	}
-
-	results := make([]Result, len(matchingTargets))
+	results := make([]Result, len(matching))
 	var deliveries sync.WaitGroup
-	deliveries.Add(len(matchingTargets))
-	for index, target := range matchingTargets {
+	for index, target := range matching {
+		deliveries.Add(1)
 		go func() {
 			defer deliveries.Done()
+			if err := dispatcher.acquireDeliverySlot(ctx); err != nil {
+				results[index] = Result{Target: target.name, Err: err}
+				return
+			}
+			defer dispatcher.releaseDeliverySlot()
 			results[index] = dispatcher.deliver(ctx, target, payload, deliveryID)
 		}()
 	}

--- a/internal/webhook/dispatcher_test.go
+++ b/internal/webhook/dispatcher_test.go
@@ -84,6 +84,46 @@ func TestDispatchDefaultPayload(t *testing.T) {
 	}
 }
 
+func TestDispatchIsolatesTargetDeliverySchedules(t *testing.T) {
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondStarted := make(chan struct{})
+	first := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		close(firstStarted)
+		<-releaseFirst
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer first.Close()
+	second := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		close(secondStarted)
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer second.Close()
+
+	dispatcher, err := NewDispatcher(Config{Targets: []Target{
+		{Name: "slow", URL: first.URL},
+		{Name: "healthy", URL: second.URL},
+	}}, first.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan []Result, 1)
+	go func() { done <- dispatcher.Dispatch(context.Background(), testEmail()) }()
+
+	<-firstStarted
+	select {
+	case <-secondStarted:
+	case <-time.After(time.Second):
+		close(releaseFirst)
+		t.Fatal("healthy target was blocked behind the slow target")
+	}
+	close(releaseFirst)
+	results := <-done
+	if len(results) != 2 || results[0].Target != "slow" || results[1].Target != "healthy" {
+		t.Fatalf("results lost configuration order: %#v", results)
+	}
+}
+
 func TestDispatchCustomTemplateHeadersAndSignature(t *testing.T) {
 	const secret = "shared-secret"
 	var receivedBody []byte

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -68,7 +68,7 @@ func NewService(dispatcher *Dispatcher, options ServiceOptions) (*Service, error
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	service := &Service{
-		dispatcher: dispatcher, ctx: ctx, cancel: cancel,
+		dispatcher: dispatcher.withMaxConcurrency(options.MaxConcurrency), ctx: ctx, cancel: cancel,
 		shutdownTimeout: options.ShutdownTimeout, onResults: options.OnResults,
 		workerCount: options.MaxConcurrency, unlimited: options.MaxConcurrency == 0,
 	}

--- a/internal/webhook/service_test.go
+++ b/internal/webhook/service_test.go
@@ -6,9 +6,61 @@ import (
 	"net/http/httptest"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
+
+func TestServiceConcurrencyLimitAppliesToIndividualTargets(t *testing.T) {
+	var active atomic.Int32
+	var maximum atomic.Int32
+	receiver := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		current := active.Add(1)
+		defer active.Add(-1)
+		for {
+			observed := maximum.Load()
+			if current <= observed || maximum.CompareAndSwap(observed, current) {
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer receiver.Close()
+	dispatcher, err := NewDispatcher(Config{Targets: []Target{
+		{Name: "first", URL: receiver.URL},
+		{Name: "second", URL: receiver.URL},
+	}}, receiver.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	completed := make(chan []Result, 1)
+	service, err := NewService(dispatcher, ServiceOptions{
+		MaxConcurrency:  1,
+		ShutdownTimeout: time.Second,
+		OnResults: func(_ string, results []Result) {
+			completed <- results
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = service.Close() }()
+	if err := service.Enqueue(testEmail()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case results := <-completed:
+		if len(results) != 2 {
+			t.Fatalf("result count = %d, want 2", len(results))
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for deliveries")
+	}
+	if got := maximum.Load(); got != 1 {
+		t.Fatalf("maximum concurrent target requests = %d, want 1", got)
+	}
+}
 
 func TestServiceCloseDrainsInFlightDelivery(t *testing.T) {
 	started := make(chan struct{})


### PR DESCRIPTION
## Summary

- dispatch every matching target independently instead of serializing retry schedules
- keep result ordering aligned with configuration order
- apply the concurrency bound to individual target deliveries
- add concurrency regressions proving a healthy target starts while an earlier target is blocked

## Validation

- `git diff --check`
- `go test -race ./internal/webhook`
- `go test ./...`
- `bun test`

Addresses one unresolved review finding from #15.