### PR TITLE
fix(webhook): retain nonces for the full signature window

### DIFF
--- a/examples/webhooks/receiver/main.go
+++ b/examples/webhooks/receiver/main.go
@@ -91,7 +91,7 @@ func verifySignature(signature, timestamp, nonce string, body []byte, secret str
 		return false, fmt.Errorf("timestamp and nonce are required")
 	}
 	signedAt, err := time.Parse(time.RFC3339, timestamp)
-	if err != nil || signedAt.After(now.Add(time.Minute)) || now.Sub(signedAt) > maxSignatureAge {
+	if err != nil || signedAt.After(now.Add(time.Minute)) || !now.Before(signedAt.Add(maxSignatureAge)) {
 		return false, fmt.Errorf("webhook signature timestamp is outside the accepted window")
 	}
 	const prefix = "v2="

--- a/examples/webhooks/receiver/main.go
+++ b/examples/webhooks/receiver/main.go
@@ -108,7 +108,7 @@ func verifySignature(signature, timestamp, nonce string, body []byte, secret str
 	if !hmac.Equal(provided, mac.Sum(nil)) {
 		return false, fmt.Errorf("X-OwlMail-Signature-V2 verification failed")
 	}
-	if nonces != nil && !nonces.use(nonce, now.Add(maxSignatureAge), now) {
+	if nonces != nil && !nonces.use(nonce, signedAt.Add(maxSignatureAge), now) {
 		return false, fmt.Errorf("webhook nonce was already used")
 	}
 	return true, nil

--- a/examples/webhooks/receiver/main_test.go
+++ b/examples/webhooks/receiver/main_test.go
@@ -74,6 +74,28 @@ func TestReceiveRejectsReplayedSignature(t *testing.T) {
 	}
 }
 
+func TestFutureSkewNonceLivesThroughSignatureWindow(t *testing.T) {
+	const secret = "example-secret"
+	body := []byte(`{"event":"email.received"}`)
+	now := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
+	signedAt := now.Add(time.Minute)
+	timestamp := signedAt.Format(time.RFC3339)
+	nonce := "future-skew-nonce"
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(timestamp + "." + nonce + "."))
+	_, _ = mac.Write(body)
+	signature := "v2=" + hex.EncodeToString(mac.Sum(nil))
+	cache := &nonceCache{seen: make(map[string]time.Time)}
+
+	if verified, err := verifySignature(signature, timestamp, nonce, body, secret, now, cache); !verified || err != nil {
+		t.Fatalf("first verification failed: verified=%v err=%v", verified, err)
+	}
+	replayAt := now.Add(5*time.Minute + 30*time.Second)
+	if verified, err := verifySignature(signature, timestamp, nonce, body, secret, replayAt, cache); verified || err == nil {
+		t.Fatalf("replay inside signature window was accepted: verified=%v err=%v", verified, err)
+	}
+}
+
 func TestReceiveRejectsMissingSignature(t *testing.T) {
 	t.Setenv("OWLMAIL_WEBHOOK_SECRET", "example-secret")
 	recorder := httptest.NewRecorder()

--- a/examples/webhooks/receiver/main_test.go
+++ b/examples/webhooks/receiver/main_test.go
@@ -74,10 +74,10 @@ func TestReceiveRejectsReplayedSignature(t *testing.T) {
 	}
 }
 
-func TestFutureSkewNonceLivesThroughSignatureWindow(t *testing.T) {
+func TestNonceExpiresAtSignatureValidityBoundary(t *testing.T) {
 	const secret = "example-secret"
 	body := []byte(`{"event":"email.received"}`)
-	now := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
+	now := time.Date(2026, time.August, 30, 12, 0, 0, 0, time.UTC)
 	signedAt := now.Add(time.Minute)
 	timestamp := signedAt.Format(time.RFC3339)
 	nonce := "future-skew-nonce"
@@ -87,12 +87,30 @@ func TestFutureSkewNonceLivesThroughSignatureWindow(t *testing.T) {
 	signature := "v2=" + hex.EncodeToString(mac.Sum(nil))
 	cache := &nonceCache{seen: make(map[string]time.Time)}
 
-	if verified, err := verifySignature(signature, timestamp, nonce, body, secret, now, cache); !verified || err != nil {
-		t.Fatalf("first verification failed: verified=%v err=%v", verified, err)
+	ok, err := verifySignature(signature, timestamp, nonce, body, secret, now, cache)
+	if err != nil || !ok {
+		t.Fatalf("verifySignature() = %v, %v", ok, err)
 	}
-	replayAt := now.Add(5*time.Minute + 30*time.Second)
-	if verified, err := verifySignature(signature, timestamp, nonce, body, secret, replayAt, cache); verified || err == nil {
-		t.Fatalf("replay inside signature window was accepted: verified=%v err=%v", verified, err)
+	if got, want := cache.seen[nonce], signedAt.Add(maxSignatureAge); !got.Equal(want) {
+		t.Fatalf("nonce expiry = %s, want %s", got, want)
+	}
+}
+
+func TestSignatureValidityBoundaryIsExclusive(t *testing.T) {
+	const secret = "example-secret"
+	body := []byte(`{"event":"email.received"}`)
+	signedAt := time.Date(2026, time.August, 30, 12, 0, 0, 0, time.UTC)
+	timestamp := signedAt.Format(time.RFC3339)
+	nonce := "boundary-nonce"
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(timestamp + "." + nonce + "."))
+	_, _ = mac.Write(body)
+	signature := "v2=" + hex.EncodeToString(mac.Sum(nil))
+	cache := &nonceCache{seen: make(map[string]time.Time)}
+
+	ok, err := verifySignature(signature, timestamp, nonce, body, secret, signedAt.Add(maxSignatureAge), cache)
+	if err == nil || ok {
+		t.Fatalf("verifySignature() = %v, %v; want expired", ok, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- expire replay nonces at `signedAt + maxSignatureAge` instead of receipt time plus age
- make the accepted signature window exclusive at its expiry boundary
- preserve replay protection when the sender clock is within the accepted future-skew allowance
- add regressions for replay before expiry and rejection at the boundary

## Validation

- `git diff --check`
- `go test ./...`
- `bun test`

Addresses one unresolved review finding from #34.