### PR TITLE
fix(release): prevent old retries from moving image aliases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,11 +75,25 @@ jobs:
           echo "app-version=${VERSION#v}" >> "${GITHUB_OUTPUT}"
           echo "commit=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
           echo "notes=${NOTES}" >> "${GITHUB_OUTPUT}"
+
+          LATEST_STABLE=""
+          while IFS= read -r TAG; do
+            if [[ "${TAG}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+              LATEST_STABLE="${TAG}"
+              break
+            fi
+          done < <(git tag --list 'v*' --sort=-version:refname)
+
+          MOVING_TAGS=false
           if [[ "${VERSION}" == *-* ]]; then
             echo "prerelease=true" >> "${GITHUB_OUTPUT}"
           else
             echo "prerelease=false" >> "${GITHUB_OUTPUT}"
+            if [ "${VERSION}" = "${LATEST_STABLE}" ]; then
+              MOVING_TAGS=true
+            fi
           fi
+          echo "moving-tags=${MOVING_TAGS}" >> "${GITHUB_OUTPUT}"
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
@@ -265,10 +279,10 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}},value=${{ steps.release.outputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ steps.release.outputs.version }}
-            type=semver,pattern={{major}},value=${{ steps.release.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.release.outputs.version }},enable=${{ steps.release.outputs.moving-tags == 'true' }}
+            type=semver,pattern={{major}},value=${{ steps.release.outputs.version }},enable=${{ steps.release.outputs.moving-tags == 'true' }}
             type=sha,prefix=sha-
-            type=raw,value=latest,enable=${{ steps.release.outputs.prerelease == 'false' }}
+            type=raw,value=latest,enable=${{ steps.release.outputs.moving-tags == 'true' }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ steps.release.outputs.commit }}

--- a/docs/en/Releasing.md
+++ b/docs/en/Releasing.md
@@ -66,6 +66,11 @@ dependency verification, formatting, `go vet`, race-enabled Go tests,
 generates SPDX SBOMs, GitHub artifact attestations, and keyless Sigstore
 signatures before publishing the release.
 
+A retry of an older stable tag republishes only its immutable version and
+commit-SHA tags. The workflow updates `latest`, major, and minor aliases only
+when the requested tag is still the repository's newest stable SemVer tag, so
+an operational retry cannot downgrade users of moving image tags.
+
 ## Verify published artifacts
 
 In addition to GitHub's automatic source archives, a release made with the

--- a/docs/zh-CN/Releasing.md
+++ b/docs/zh-CN/Releasing.md
@@ -60,6 +60,10 @@ gh workflow run release.yml --ref v0.5.0 -f version=v0.5.0
 `govulncheck` 以及 Bun 浏览器/文档检查，随后生成 SPDX SBOM、GitHub Artifact
 Attestation 与 Sigstore 无密钥签名，再正式发布。
 
+重试较旧的稳定标签时，只会重新发布不可变版本标签和提交 SHA 标签。只有请求标签
+仍是仓库中最新的稳定 SemVer 标签时，工作流才会更新 `latest`、主版本和次版本别名，
+避免运维重试导致使用移动镜像标签的部署被降级。
+
 ## 验证发布文件
 
 除 GitHub 自动生成的源码归档外，使用当前工作流发布的版本应包含：

--- a/tests/docs/markdown.test.js
+++ b/tests/docs/markdown.test.js
@@ -364,6 +364,8 @@ test("0.5.0 release documentation and workflow stay connected", () => {
     "govulncheck@${GOVULNCHECK_VERSION}",
     "body_path: ${{ steps.release.outputs.notes }}",
     "fail_on_unmatched_files: true",
+    "moving-tags=${MOVING_TAGS}",
+    "enable=${{ steps.release.outputs.moving-tags == 'true' }}",
   ]) {
     assert.ok(workflow.includes(marker), `.github/workflows/release.yml is missing ${marker}`);
   }


### PR DESCRIPTION
## Summary

- determine the newest stable SemVer tag before publishing
- always publish immutable version and commit-SHA tags
- update `latest`, major, and minor aliases only for the newest stable release
- document retry behavior in English and Chinese and protect it with a contract test

## Validation

- parsed `.github/workflows/release.yml` as YAML
- `node --check tests/docs/markdown.test.js`
- `git diff --check`
- full release checks are delegated to repository CI

Addresses the unresolved review finding from #37.