### PR TITLE
fix(storage): preserve quarantine when clearing inbox

### DIFF
--- a/internal/mailserver/mailserver_store_test.go
+++ b/internal/mailserver/mailserver_store_test.go
@@ -208,14 +208,6 @@ func TestMailServerGetAllEmail(t *testing.T) {
 	if err := server.SaveEmailToStore("id2", false, envelope, email2); err != nil {
 		t.Fatalf("Failed to save email 2: %v", err)
 	}
-	quarantinePath := filepath.Join(tmpDir, quarantineDirName, "recoverable-message", "message.eml")
-	if err := os.MkdirAll(filepath.Dir(quarantinePath), 0750); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(quarantinePath, []byte("recoverable"), 0600); err != nil {
-		t.Fatal(err)
-	}
-
 	emails = server.GetAllEmail()
 	if len(emails) != 2 {
 		t.Errorf("Expected 2 emails, got %d", len(emails))
@@ -291,6 +283,13 @@ func TestMailServerDeleteAllEmail(t *testing.T) {
 	}
 	if err := server.SaveEmailToStore("id2", false, envelope, email2); err != nil {
 		t.Fatalf("Failed to save email 2: %v", err)
+	}
+	quarantinePath := filepath.Join(tmpDir, quarantineDirName, "recoverable-message", "message.eml")
+	if err := os.MkdirAll(filepath.Dir(quarantinePath), 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(quarantinePath, []byte("recoverable"), 0600); err != nil {
+		t.Fatal(err)
 	}
 
 	// Delete all

--- a/internal/mailserver/mailserver_store_test.go
+++ b/internal/mailserver/mailserver_store_test.go
@@ -208,6 +208,13 @@ func TestMailServerGetAllEmail(t *testing.T) {
 	if err := server.SaveEmailToStore("id2", false, envelope, email2); err != nil {
 		t.Fatalf("Failed to save email 2: %v", err)
 	}
+	quarantinePath := filepath.Join(tmpDir, quarantineDirName, "recoverable-message", "message.eml")
+	if err := os.MkdirAll(filepath.Dir(quarantinePath), 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(quarantinePath, []byte("recoverable"), 0600); err != nil {
+		t.Fatal(err)
+	}
 
 	emails = server.GetAllEmail()
 	if len(emails) != 2 {
@@ -296,6 +303,9 @@ func TestMailServerDeleteAllEmail(t *testing.T) {
 	emails := server.GetAllEmail()
 	if len(emails) != 0 {
 		t.Errorf("Expected 0 emails, got %d", len(emails))
+	}
+	if content, err := os.ReadFile(quarantinePath); err != nil || string(content) != "recoverable" {
+		t.Fatalf("quarantine was removed by DeleteAllEmail: content=%q err=%v", content, err)
 	}
 }
 

--- a/internal/mailserver/store.go
+++ b/internal/mailserver/store.go
@@ -232,6 +232,9 @@ func (ms *MailServer) DeleteAllEmail() error {
 	files, err := os.ReadDir(ms.mailDir)
 	if err == nil {
 		for _, file := range files {
+			if file.IsDir() && file.Name() == quarantineDirName {
+				continue
+			}
 			if err := os.RemoveAll(filepath.Join(ms.mailDir, file.Name())); err != nil {
 				common.Verbose("Failed to remove file: %v", err)
 			}


### PR DESCRIPTION
## Summary

- exclude the recovery quarantine directory from `DeleteAllEmail`
- continue removing committed mail and attachment artifacts normally
- add a regression test proving recoverable quarantine contents survive an inbox clear

## Validation

- `git diff --check`
- `go test ./...`
- `bun test`

Addresses the P1 review finding from #32.