### PR TITLE
fix(storage): continue recovery after quarantine failures

### DIFF
--- a/internal/mailserver/storage_transaction.go
+++ b/internal/mailserver/storage_transaction.go
@@ -183,7 +183,7 @@ func (ms *MailServer) quarantinePath(source, reason string) error {
 func isGeneratedEmailID(value string) bool {
 	if len(value) == 8 {
 		for _, char := range value {
-			if !((char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || (char >= '0' && char <= '9')) {
+			if (char < 'a' || char > 'z') && (char < 'A' || char > 'Z') && (char < '0' || char > '9') {
 				return false
 			}
 		}

--- a/internal/mailserver/storage_transaction.go
+++ b/internal/mailserver/storage_transaction.go
@@ -1,6 +1,7 @@
 package mailserver
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -8,6 +9,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const (
@@ -127,15 +130,16 @@ func (ms *MailServer) recoverStorageArtifacts() error {
 	if err != nil {
 		return fmt.Errorf("read mail directory for recovery: %w", err)
 	}
+	var recoveryErrors []error
 	for _, entry := range entries {
 		if !strings.HasPrefix(entry.Name(), storageTempPrefix) {
 			continue
 		}
 		if err := ms.quarantinePath(filepath.Join(ms.mailDir, entry.Name()), "incomplete"); err != nil {
-			return fmt.Errorf("quarantine incomplete artifact %s: %w", entry.Name(), err)
+			recoveryErrors = append(recoveryErrors, fmt.Errorf("quarantine incomplete artifact %s: %w", entry.Name(), err))
 		}
 	}
-	return nil
+	return errors.Join(recoveryErrors...)
 }
 
 func (ms *MailServer) quarantineEmail(id, emlPath, reason string) error {
@@ -158,6 +162,11 @@ func (ms *MailServer) quarantineEmail(id, emlPath, reason string) error {
 }
 
 func (ms *MailServer) quarantinePath(source, reason string) error {
+	if ms.beforeQuarantineMove != nil {
+		if err := ms.beforeQuarantineMove(source); err != nil {
+			return err
+		}
+	}
 	destination, err := ms.newQuarantineEntry(filepath.Base(source), reason)
 	if err != nil {
 		return err
@@ -166,6 +175,22 @@ func (ms *MailServer) quarantinePath(source, reason string) error {
 		return err
 	}
 	return syncDirectory(ms.mailDir)
+}
+
+// isGeneratedEmailID deliberately recognizes only the two ID formats OwlMail
+// creates. validateEmailID is a path-safety check and is intentionally broader,
+// so using it here would mistake arbitrary user directories for attachments.
+func isGeneratedEmailID(value string) bool {
+	if len(value) == 8 {
+		for _, char := range value {
+			if !((char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || (char >= '0' && char <= '9')) {
+				return false
+			}
+		}
+		return true
+	}
+	parsed, err := uuid.Parse(value)
+	return err == nil && parsed.String() == strings.ToLower(value)
 }
 
 func (ms *MailServer) newQuarantineEntry(id, reason string) (string, error) {
@@ -199,7 +224,7 @@ func (ms *MailServer) quarantineOrphanAttachmentDirectories() error {
 		if !entry.IsDir() || entry.Name() == quarantineDirName || strings.HasPrefix(entry.Name(), storageTempPrefix) {
 			continue
 		}
-		if err := validateEmailID(entry.Name()); err != nil {
+		if !isGeneratedEmailID(entry.Name()) {
 			continue
 		}
 		if _, err := os.Stat(filepath.Join(ms.mailDir, entry.Name()+".eml")); err == nil {

--- a/internal/mailserver/storage_transaction_test.go
+++ b/internal/mailserver/storage_transaction_test.go
@@ -113,7 +113,10 @@ func TestLoadMailsQuarantinesCorruptIncompleteAndOrphanArtifacts(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, storageTempPrefix+"partial.eml.tmp"), []byte("partial"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(filepath.Join(dir, "orphan-id"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(dir, "Ab12Cd34"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "archive"), 0755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -124,7 +127,7 @@ func TestLoadMailsQuarantinesCorruptIncompleteAndOrphanArtifacts(t *testing.T) {
 	if got := len(server.GetAllEmail()); got != 0 {
 		t.Fatalf("corrupt email was published: %d", got)
 	}
-	for _, name := range []string{"corrupt.eml", storageTempPrefix + "partial.eml.tmp", "orphan-id"} {
+	for _, name := range []string{"corrupt.eml", storageTempPrefix + "partial.eml.tmp", "Ab12Cd34"} {
 		if _, err := os.Stat(filepath.Join(dir, name)); !os.IsNotExist(err) {
 			t.Fatalf("artifact %s was not moved to quarantine: %v", name, err)
 		}
@@ -135,5 +138,42 @@ func TestLoadMailsQuarantinesCorruptIncompleteAndOrphanArtifacts(t *testing.T) {
 	}
 	if len(quarantined) != 3 {
 		t.Fatalf("expected three quarantine entries, got %d", len(quarantined))
+	}
+	if _, err := os.Stat(filepath.Join(dir, "archive")); err != nil {
+		t.Fatalf("unrelated directory was treated as an orphan: %v", err)
+	}
+}
+
+func TestLoadMailsContinuesAfterQuarantineFailure(t *testing.T) {
+	dir := t.TempDir()
+	server, err := NewMailServer(1025, "localhost", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validID := "Ef56Gh78"
+	if err := os.WriteFile(filepath.Join(dir, validID+".eml"), validMessage("recoverable"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	temporaryName := storageTempPrefix + "blocked.eml.tmp"
+	if err := os.WriteFile(filepath.Join(dir, temporaryName), []byte("partial"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	server.beforeQuarantineMove = func(path string) error {
+		if filepath.Base(path) == temporaryName {
+			return errors.New("injected quarantine failure")
+		}
+		return nil
+	}
+
+	err = server.LoadMailsFromDirectory()
+	if err == nil || !strings.Contains(err.Error(), "injected quarantine failure") {
+		t.Fatalf("expected recovery error, got %v", err)
+	}
+	if _, err := server.GetEmail(validID); err != nil {
+		t.Fatalf("valid email was not restored after recovery error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, temporaryName)); err != nil {
+		t.Fatalf("failed artifact should remain available for a later retry: %v", err)
 	}
 }

--- a/internal/mailserver/store.go
+++ b/internal/mailserver/store.go
@@ -1,6 +1,7 @@
 package mailserver
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -539,8 +540,10 @@ func (ms *MailServer) parseEmailMessage(id string, r io.Reader, s *Session, save
 
 // LoadMailsFromDirectory loads emails from the mail directory
 func (ms *MailServer) LoadMailsFromDirectory() error {
+	var loadErrors []error
 	if err := ms.recoverStorageArtifacts(); err != nil {
-		return err
+		common.Error("Storage recovery completed with errors: %v", err)
+		loadErrors = append(loadErrors, err)
 	}
 	files, err := os.ReadDir(ms.mailDir)
 	if err != nil {
@@ -595,8 +598,8 @@ func (ms *MailServer) LoadMailsFromDirectory() error {
 		}
 	}
 	if err := ms.quarantineOrphanAttachmentDirectories(); err != nil {
-		return err
+		loadErrors = append(loadErrors, err)
 	}
 
-	return nil
+	return errors.Join(loadErrors...)
 }

--- a/internal/mailserver/types.go
+++ b/internal/mailserver/types.go
@@ -73,6 +73,7 @@ type MailServer struct {
 	// provide deterministic fault injection for transaction boundary tests.
 	beforeStoreCommit     func(*types.Email) error
 	beforeAttachmentWrite func(string) error
+	beforeQuarantineMove  func(string) error
 }
 
 // GetHost returns the SMTP server host


### PR DESCRIPTION
## Summary

- continue loading valid mail when one recovery artifact cannot be quarantined
- aggregate recovery errors so every temporary artifact is attempted
- recognize only OwlMail-generated attachment directory IDs, preserving unrelated directories
- add deterministic regression coverage for quarantine failures and directory classification

## Validation

- `git diff --check`
- `go test ./...`
- `bun test`

Addresses the remaining recovery review findings from #32.