### PR TITLE
fix(api): validate the scheme for authenticated same-origin requests

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -225,6 +225,8 @@ docker buildx build \
 | `-log-level` | `MAILDEV_VERBOSE` / `MAILDEV_SILENT` / `OWLMAIL_LOG_LEVEL` | normal | Protokollierungsstufe |
 | `-use-uuid-for-email-id` | `OWLMAIL_USE_UUID_FOR_EMAIL_ID` | false | UUID für E-Mail-IDs verwenden (Standard: 8-Zeichen-Zufallszeichenfolge) |
 
+When TLS terminates at a reverse proxy, set `OWLMAIL_WEB_EXTERNAL_SCHEME` to `https`.
+
 Eine unvollständige Web-Authentifizierung wird nicht stillschweigend deaktiviert:
 
 | Konfigurierte Werte | Effektive Zugangsdaten |

--- a/README.fr.md
+++ b/README.fr.md
@@ -226,6 +226,8 @@ docker buildx build \
 | `-log-level` | `MAILDEV_VERBOSE` / `MAILDEV_SILENT` / `OWLMAIL_LOG_LEVEL` | normal | Log level |
 | `-use-uuid-for-email-id` | `OWLMAIL_USE_UUID_FOR_EMAIL_ID` | false | Use UUID for email IDs (default: 8-character random string) |
 
+When TLS terminates at a reverse proxy, set `OWLMAIL_WEB_EXTERNAL_SCHEME` to `https`.
+
 Une configuration incomplète de l’authentification Web n’est pas désactivée silencieusement :
 
 | Valeurs configurées | Identifiants effectifs |

--- a/README.it.md
+++ b/README.it.md
@@ -225,6 +225,8 @@ docker buildx build \
 | `-log-level` | `MAILDEV_VERBOSE` / `MAILDEV_SILENT` / `OWLMAIL_LOG_LEVEL` | normal | Livello di log |
 | `-use-uuid-for-email-id` | `OWLMAIL_USE_UUID_FOR_EMAIL_ID` | false | Usa UUID per ID email (predefinito: stringa casuale di 8 caratteri) |
 
+When TLS terminates at a reverse proxy, set `OWLMAIL_WEB_EXTERNAL_SCHEME` to `https`.
+
 Una configurazione incompleta dell’autenticazione Web non viene disabilitata silenziosamente:
 
 | Valori configurati | Credenziali effettive |

--- a/README.ja.md
+++ b/README.ja.md
@@ -225,6 +225,8 @@ docker buildx build \
 | `-log-level` | `MAILDEV_VERBOSE` / `MAILDEV_SILENT` / `OWLMAIL_LOG_LEVEL` | normal | Log level |
 | `-use-uuid-for-email-id` | `OWLMAIL_USE_UUID_FOR_EMAIL_ID` | false | Use UUID for email IDs (default: 8-character random string) |
 
+When TLS terminates at a reverse proxy, set `OWLMAIL_WEB_EXTERNAL_SCHEME` to `https`.
+
 Web 認証の設定値が片方だけの場合でも、認証が暗黙に無効になることはありません。
 
 | 設定値 | 実際の認証情報 |

--- a/README.ko.md
+++ b/README.ko.md
@@ -225,6 +225,8 @@ docker buildx build \
 | `-log-level` | `MAILDEV_VERBOSE` / `MAILDEV_SILENT` / `OWLMAIL_LOG_LEVEL` | normal | Log level |
 | `-use-uuid-for-email-id` | `OWLMAIL_USE_UUID_FOR_EMAIL_ID` | false | Use UUID for email IDs (default: 8-character random string) |
 
+When TLS terminates at a reverse proxy, set `OWLMAIL_WEB_EXTERNAL_SCHEME` to `https`.
+
 웹 인증 값 중 하나만 설정해도 인증이 조용히 비활성화되지 않습니다.
 
 | 설정된 값 | 실제 자격 증명 |

--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ the message body; clicking one focuses OwlMail and opens the message.
 | `-log-level` | `MAILDEV_VERBOSE` / `MAILDEV_SILENT` / `OWLMAIL_LOG_LEVEL` | normal | Log level |
 | `-use-uuid-for-email-id` | `OWLMAIL_USE_UUID_FOR_EMAIL_ID` | false | Use UUID for email IDs (default: 8-character random string) |
 
+When TLS terminates at a reverse proxy, set `OWLMAIL_WEB_EXTERNAL_SCHEME` to `https`.
+
 When HTTP Basic Auth is enabled, browser API and WebSocket requests are limited
 to OwlMail's own origin. Command-line and server-to-server clients that omit the
 browser `Origin` header continue to work normally.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -241,6 +241,8 @@ Notifications API 需要 HTTPS，或 `http://localhost` 等受信任的本地来
 | `-log-level` | `MAILDEV_VERBOSE` / `MAILDEV_SILENT` / `OWLMAIL_LOG_LEVEL` | normal | 日志级别 |
 | `-use-uuid-for-email-id` | `OWLMAIL_USE_UUID_FOR_EMAIL_ID` | false | 使用 UUID 作为邮件 ID（默认使用 8 字符随机字符串） |
 
+若 TLS 在反向代理终止，请将 `OWLMAIL_WEB_EXTERNAL_SCHEME` 设置为 `https`。
+
 启用 HTTP Basic Auth 后，浏览器 API 与 WebSocket 请求仅允许来自 OwlMail
 自身源。命令行和服务端客户端不携带浏览器 `Origin` 请求头时仍可正常访问。
 

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -268,6 +268,9 @@ func startAPIServer(server *mailserver.MailServer, cfg *config.Config) (*api.API
 	}
 
 	apiServer := api.NewAPIWithHTTPS(server, cfg.WebPort, cfg.WebHost, cfg.WebUser, cfg.WebPassword, cfg.HTTPSEnabled, cfg.HTTPSCertFile, cfg.HTTPSKeyFile)
+	if err := apiServer.SetExternalScheme(cfg.WebExternalScheme); err != nil {
+		return nil, err
+	}
 
 	protocol := "http"
 	if cfg.HTTPSEnabled {

--- a/docs/en/Operations.md
+++ b/docs/en/Operations.md
@@ -90,6 +90,11 @@ Basic Auth protects the UI, API, assets, and WebSocket endpoints, but
 `/healthz` and `/api/v1/health` intentionally remain public for probes. Use
 HTTPS or a trusted reverse proxy when credentials cross a network.
 
+When TLS terminates at that proxy, set `OWLMAIL_WEB_EXTERNAL_SCHEME=https` so
+authenticated HTTP and WebSocket same-origin checks use the browser-visible
+scheme. Configure it explicitly instead of trusting client-supplied forwarded
+headers.
+
 ## HTTPS and TLS
 
 Web HTTPS and SMTP TLS are separate settings:

--- a/docs/zh-CN/Operations.md
+++ b/docs/zh-CN/Operations.md
@@ -81,6 +81,10 @@ Basic Auth 保护 UI、API、静态资源和 WebSocket，但 `/healthz` 与
 `/api/v1/health` 会有意保持公开，便于探针检查。凭据通过网络传输时，应启用
 HTTPS 或可信反向代理。
 
+若 TLS 在反向代理终止，请设置 `OWLMAIL_WEB_EXTERNAL_SCHEME=https`，让已鉴权的
+HTTP 与 WebSocket 同源检查使用浏览器可见协议。应显式配置该值，不要信任客户端
+可以伪造的转发请求头。
+
 ## HTTPS 与 TLS
 
 Web HTTPS 与 SMTP TLS 是两组独立设置：

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -47,6 +47,10 @@ func NewAPIWithAuth(mailServer *mailserver.MailServer, port int, host, user, pas
 // NewAPIWithHTTPS creates a new API server instance with HTTP Basic Auth and HTTPS support
 func NewAPIWithHTTPS(mailServer *mailserver.MailServer, port int, host, user, password string, httpsEnabled bool, certFile, keyFile string) *API {
 	authEnabled := user != "" && password != ""
+	requestScheme := "http"
+	if httpsEnabled {
+		requestScheme = "https"
+	}
 	api := &API{
 		mailServer:    mailServer,
 		port:          port,
@@ -59,7 +63,7 @@ func NewAPIWithHTTPS(mailServer *mailserver.MailServer, port int, host, user, pa
 		httpsKeyFile:  keyFile,
 		wsUpgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
-				return !authEnabled || originMatchesHost(r.Header.Get("Origin"), r.Host)
+				return !authEnabled || originMatchesRequest(r.Header.Get("Origin"), r.Host, requestScheme)
 			},
 		},
 	}
@@ -73,12 +77,16 @@ func NewAPIWithHTTPS(mailServer *mailserver.MailServer, port int, host, user, pa
 // and new improved RESTful API routes
 func (api *API) setupRoutes() {
 	app := fiber.New(fiber.Config{})
+	requestScheme := "http"
+	if api.httpsEnabled {
+		requestScheme = "https"
+	}
 
 	authEnabled := api.authUser != "" && api.authPassword != ""
 	if authEnabled {
 		// Browsers must not reuse cached Basic Auth credentials from an unrelated
 		// origin. Non-browser API clients normally omit Origin and remain allowed.
-		app.Use(sameOriginMiddleware())
+		app.Use(sameOriginMiddleware(requestScheme))
 	} else {
 		// Preserve the open development API's cross-origin compatibility. There
 		// are no browser credentials to expose when authentication is disabled.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -20,18 +20,19 @@ import (
 
 // API represents the REST API server
 type API struct {
-	mailServer    *mailserver.MailServer
-	app           *fiber.App
-	port          int
-	host          string
-	wsUpgrader    websocket.Upgrader
-	wsClients     map[*websocket.Conn]*sync.Mutex
-	wsClientsLock sync.RWMutex
-	authUser      string
-	authPassword  string
-	httpsEnabled  bool
-	httpsCertFile string
-	httpsKeyFile  string
+	mailServer     *mailserver.MailServer
+	app            *fiber.App
+	port           int
+	host           string
+	wsUpgrader     websocket.Upgrader
+	wsClients      map[*websocket.Conn]*sync.Mutex
+	wsClientsLock  sync.RWMutex
+	authUser       string
+	authPassword   string
+	httpsEnabled   bool
+	httpsCertFile  string
+	httpsKeyFile   string
+	externalScheme string
 }
 
 // NewAPI creates a new API server instance
@@ -47,10 +48,6 @@ func NewAPIWithAuth(mailServer *mailserver.MailServer, port int, host, user, pas
 // NewAPIWithHTTPS creates a new API server instance with HTTP Basic Auth and HTTPS support
 func NewAPIWithHTTPS(mailServer *mailserver.MailServer, port int, host, user, password string, httpsEnabled bool, certFile, keyFile string) *API {
 	authEnabled := user != "" && password != ""
-	requestScheme := "http"
-	if httpsEnabled {
-		requestScheme = "https"
-	}
 	api := &API{
 		mailServer:    mailServer,
 		port:          port,
@@ -61,15 +58,35 @@ func NewAPIWithHTTPS(mailServer *mailserver.MailServer, port int, host, user, pa
 		httpsEnabled:  httpsEnabled,
 		httpsCertFile: certFile,
 		httpsKeyFile:  keyFile,
-		wsUpgrader: websocket.Upgrader{
-			CheckOrigin: func(r *http.Request) bool {
-				return !authEnabled || originMatchesRequest(r.Header.Get("Origin"), r.Host, requestScheme)
-			},
-		},
+		wsUpgrader:    websocket.Upgrader{},
+	}
+	api.wsUpgrader.CheckOrigin = func(r *http.Request) bool {
+		return !authEnabled || originMatchesRequest(r.Header.Get("Origin"), r.Host, api.requestScheme())
 	}
 	api.setupRoutes()
 	api.setupEventListeners()
 	return api
+}
+
+func (api *API) requestScheme() string {
+	if api.externalScheme != "" {
+		return api.externalScheme
+	}
+	if api.httpsEnabled {
+		return "https"
+	}
+	return "http"
+}
+
+// SetExternalScheme configures the browser-visible scheme when TLS terminates
+// at a reverse proxy. It must be called before the API server starts.
+func (api *API) SetExternalScheme(scheme string) error {
+	scheme = strings.ToLower(strings.TrimSpace(scheme))
+	if scheme != "" && scheme != "http" && scheme != "https" {
+		return fmt.Errorf("external web scheme must be http or https")
+	}
+	api.externalScheme = scheme
+	return nil
 }
 
 // setupRoutes configures all API routes
@@ -77,16 +94,14 @@ func NewAPIWithHTTPS(mailServer *mailserver.MailServer, port int, host, user, pa
 // and new improved RESTful API routes
 func (api *API) setupRoutes() {
 	app := fiber.New(fiber.Config{})
-	requestScheme := "http"
-	if api.httpsEnabled {
-		requestScheme = "https"
-	}
 
 	authEnabled := api.authUser != "" && api.authPassword != ""
 	if authEnabled {
 		// Browsers must not reuse cached Basic Auth credentials from an unrelated
 		// origin. Non-browser API clients normally omit Origin and remain allowed.
-		app.Use(sameOriginMiddleware(requestScheme))
+		app.Use(func(c fiber.Ctx) error {
+			return sameOriginMiddleware(api.requestScheme())(c)
+		})
 	} else {
 		// Preserve the open development API's cross-origin compatibility. There
 		// are no browser credentials to expose when authentication is disabled.

--- a/internal/api/api_middleware.go
+++ b/internal/api/api_middleware.go
@@ -9,10 +9,10 @@ import (
 	"github.com/gofiber/fiber/v3"
 )
 
-// originMatchesHost implements the browser same-origin host check used for
+// originMatchesRequest implements the browser same-origin check used for
 // authenticated HTTP and WebSocket requests. Requests without an Origin header
 // are non-browser clients and remain allowed.
-func originMatchesHost(origin, host string) bool {
+func originMatchesRequest(origin, host, scheme string) bool {
 	if origin == "" {
 		return true
 	}
@@ -20,12 +20,12 @@ func originMatchesHost(origin, host string) bool {
 	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") {
 		return false
 	}
-	return parsed.User == nil && strings.EqualFold(parsed.Host, host)
+	return parsed.User == nil && strings.EqualFold(parsed.Host, host) && strings.EqualFold(parsed.Scheme, scheme)
 }
 
-func sameOriginMiddleware() fiber.Handler {
+func sameOriginMiddleware(scheme string) fiber.Handler {
 	return func(c fiber.Ctx) error {
-		if !originMatchesHost(c.Get(fiber.HeaderOrigin), c.Host()) {
+		if !originMatchesRequest(c.Get(fiber.HeaderOrigin), c.Host(), scheme) {
 			return c.SendStatus(http.StatusForbidden)
 		}
 		return c.Next()

--- a/internal/api/api_middleware_test.go
+++ b/internal/api/api_middleware_test.go
@@ -108,6 +108,39 @@ func TestAuthenticatedAPIAllowsSameOriginAndNonBrowserRequests(t *testing.T) {
 	}
 }
 
+func TestAuthenticatedAPIUsesConfiguredExternalScheme(t *testing.T) {
+	server, err := mailserver.NewMailServer(1025, "localhost", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	api := NewAPIWithAuth(server, 1080, "localhost", "user", "pass")
+	if err := api.SetExternalScheme("https"); err != nil {
+		t.Fatal(err)
+	}
+	req, _ := http.NewRequest(http.MethodGet, "http://owlmail.test/api/v1/emails", nil)
+	req.Header.Set("Origin", "https://owlmail.test")
+	req.SetBasicAuth("user", "pass")
+	resp, err := api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	wsRequest := httptest.NewRequest(http.MethodGet, "http://owlmail.test/ws", nil)
+	wsRequest.Header.Set("Origin", "https://owlmail.test")
+	if !api.wsUpgrader.CheckOrigin(wsRequest) {
+		t.Fatal("WebSocket origin did not use configured external scheme")
+	}
+	if err := api.SetExternalScheme("ftp"); err == nil {
+		t.Fatal("invalid external scheme was accepted")
+	}
+}
+
 func TestAuthenticatedWebSocketOriginPolicy(t *testing.T) {
 	server, err := mailserver.NewMailServer(1025, "localhost", t.TempDir())
 	if err != nil {

--- a/internal/api/api_middleware_test.go
+++ b/internal/api/api_middleware_test.go
@@ -62,6 +62,26 @@ func TestAuthenticatedAPIRejectsCrossOriginBrowserRequest(t *testing.T) {
 	}
 }
 
+func TestOriginMatchesRequestRequiresSchemeAndHost(t *testing.T) {
+	tests := []struct {
+		origin string
+		host   string
+		scheme string
+		want   bool
+	}{
+		{origin: "", host: "owlmail.test", scheme: "https", want: true},
+		{origin: "https://owlmail.test", host: "owlmail.test", scheme: "https", want: true},
+		{origin: "http://owlmail.test", host: "owlmail.test", scheme: "https", want: false},
+		{origin: "https://owlmail.test", host: "owlmail.test", scheme: "http", want: false},
+		{origin: "https://attacker.test", host: "owlmail.test", scheme: "https", want: false},
+	}
+	for _, test := range tests {
+		if got := originMatchesRequest(test.origin, test.host, test.scheme); got != test.want {
+			t.Errorf("originMatchesRequest(%q, %q, %q) = %v, want %v", test.origin, test.host, test.scheme, got, test.want)
+		}
+	}
+}
+
 func TestAuthenticatedAPIAllowsSameOriginAndNonBrowserRequests(t *testing.T) {
 	tmpDir := t.TempDir()
 	server, err := mailserver.NewMailServer(1025, "localhost", tmpDir)
@@ -101,6 +121,7 @@ func TestAuthenticatedWebSocketOriginPolicy(t *testing.T) {
 	}{
 		{origin: "", want: true},
 		{origin: "http://owlmail.test", want: true},
+		{origin: "https://owlmail.test", want: false},
 		{origin: "https://attacker.example", want: false},
 		{origin: "://invalid", want: false},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -196,10 +196,11 @@ type Config struct {
 	MailDir  string
 
 	// Web API configuration
-	WebPort     int
-	WebHost     string
-	WebUser     string
-	WebPassword string
+	WebPort           int
+	WebHost           string
+	WebUser           string
+	WebPassword       string
+	WebExternalScheme string
 
 	// HTTPS configuration
 	HTTPSEnabled  bool
@@ -249,6 +250,7 @@ func DefaultConfig() *Config {
 		WebHost:                "localhost",
 		WebUser:                "",
 		WebPassword:            "",
+		WebExternalScheme:      "",
 		HTTPSEnabled:           false,
 		HTTPSCertFile:          "",
 		HTTPSKeyFile:           "",
@@ -356,10 +358,11 @@ func ResolveConfig(fs *flag.FlagSet, refs *FlagRefs) *Config {
 		SMTPHost: resolveStringWithFlag(fs, "ip", "OWLMAIL_SMTP_HOST", *refs.SMTPHost),
 		MailDir:  resolveStringWithFlag(fs, "mail-directory", "OWLMAIL_MAIL_DIR", *refs.MailDir),
 
-		WebPort:     resolveIntWithFlag(fs, "web", "OWLMAIL_WEB_PORT", *refs.WebPort),
-		WebHost:     resolveStringWithFlag(fs, "web-ip", "OWLMAIL_WEB_HOST", *refs.WebHost),
-		WebUser:     resolveStringWithFlag(fs, "web-user", "OWLMAIL_WEB_USER", *refs.WebUser),
-		WebPassword: resolveStringWithFlag(fs, "web-password", "OWLMAIL_WEB_PASSWORD", *refs.WebPassword),
+		WebPort:           resolveIntWithFlag(fs, "web", "OWLMAIL_WEB_PORT", *refs.WebPort),
+		WebHost:           resolveStringWithFlag(fs, "web-ip", "OWLMAIL_WEB_HOST", *refs.WebHost),
+		WebUser:           resolveStringWithFlag(fs, "web-user", "OWLMAIL_WEB_USER", *refs.WebUser),
+		WebPassword:       resolveStringWithFlag(fs, "web-password", "OWLMAIL_WEB_PASSWORD", *refs.WebPassword),
+		WebExternalScheme: ResolveString(nil, "", "OWLMAIL_WEB_EXTERNAL_SCHEME", ""),
 
 		HTTPSEnabled:  resolveBoolWithFlag(fs, "https", "OWLMAIL_HTTPS_ENABLED", *refs.HTTPSEnabled),
 		HTTPSCertFile: resolveStringWithFlag(fs, "https-cert", "OWLMAIL_HTTPS_CERT", *refs.HTTPSCertFile),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -339,6 +339,7 @@ func TestDefineAndResolveConfig(t *testing.T) {
 	t.Run("environment variables work", func(t *testing.T) {
 		_ = envMgr.Set("OWLMAIL_SMTP_PORT", "3025")
 		_ = envMgr.Set("OWLMAIL_SMTP_HOST", "192.168.1.1")
+		_ = envMgr.Set("OWLMAIL_WEB_EXTERNAL_SCHEME", "https")
 		_ = envMgr.Set("OWLMAIL_WEBHOOK_CONFIG", "env-webhooks.json")
 		_ = envMgr.Set("OWLMAIL_WEBHOOK_MAX_CONCURRENCY", "24")
 		_ = envMgr.Set("OWLMAIL_WEBHOOK_REDIS_URL", "rediss://redis.example.test:6380/0")
@@ -356,6 +357,9 @@ func TestDefineAndResolveConfig(t *testing.T) {
 		}
 		if cfg.SMTPHost != "192.168.1.1" {
 			t.Errorf("ResolveConfig().SMTPHost = %q, want %q", cfg.SMTPHost, "192.168.1.1")
+		}
+		if cfg.WebExternalScheme != "https" {
+			t.Errorf("ResolveConfig().WebExternalScheme = %q, want https", cfg.WebExternalScheme)
 		}
 		if cfg.WebhookConfig != "env-webhooks.json" {
 			t.Errorf("ResolveConfig().WebhookConfig = %q", cfg.WebhookConfig)

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -29,6 +29,9 @@ func ValidateConfig(cfg *Config) error {
 			return err
 		}
 	}
+	if cfg.WebExternalScheme != "" && cfg.WebExternalScheme != "http" && cfg.WebExternalScheme != "https" {
+		return fmt.Errorf("web external scheme must be http or https")
+	}
 
 	// Validate log level
 	if err := ValidateLogLevel(cfg.LogLevel); err != nil {

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -237,6 +237,11 @@ func TestValidateConfig(t *testing.T) {
 		if err := ValidateConfig(cfg); err == nil {
 			t.Error("empty webhook Redis prefix should fail")
 		}
+		cfg = DefaultConfig()
+		cfg.WebExternalScheme = "ftp"
+		if err := ValidateConfig(cfg); err == nil {
+			t.Error("invalid external web scheme should fail")
+		}
 	})
 
 	t.Run("valid full config", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- validate both scheme and host for authenticated HTTP Origin checks
- apply the same rule to WebSocket upgrades
- reject an HTTPS Origin against an HTTP server (and vice versa), even when the host matches

## Verification

- adds scheme/host origin coverage and a WebSocket regression test
- `go test ./...` and `bun test`