### PR TITLE
fix(web): deliver browser notifications through a service worker

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -98,6 +98,10 @@ func (api *API) setupRoutes() {
 	// regardless of the process working directory.
 	app.Get("/style.css", serveWebAsset("style.css", "text/css; charset=utf-8"))
 	app.Get("/app.js", serveWebAsset("app.js", "text/javascript; charset=utf-8"))
+	app.Get("/service-worker.js", func(c fiber.Ctx) error {
+		c.Set("Service-Worker-Allowed", "/")
+		return serveWebAsset("service-worker.js", "text/javascript; charset=utf-8")(c)
+	})
 	app.Get("/help.css", serveWebAsset("help.css", "text/css; charset=utf-8"))
 	app.Get("/help.js", serveWebAsset("help.js", "text/javascript; charset=utf-8"))
 	app.Get("/webhooks.css", serveWebAsset("webhooks.css", "text/css; charset=utf-8"))
@@ -130,6 +134,7 @@ func (api *API) setupRoutes() {
 			strings.HasPrefix(path, "/api/") ||
 			strings.HasPrefix(path, "/style.css") ||
 			strings.HasPrefix(path, "/app.js") ||
+			strings.HasPrefix(path, "/service-worker.js") ||
 			strings.HasPrefix(path, "/help.css") ||
 			strings.HasPrefix(path, "/help.js") ||
 			strings.HasPrefix(path, "/webhooks") {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -219,6 +219,7 @@ func TestEmbeddedWebAssets(t *testing.T) {
 		{path: "/help/", contentType: "text/html", contains: "快速上手 OwlMail"},
 		{path: "/style.css", contentType: "text/css", contains: ".header"},
 		{path: "/app.js", contentType: "text/javascript", contains: "connectWebSocket"},
+		{path: "/service-worker.js", contentType: "text/javascript", contains: "notificationclick"},
 		{path: "/help.css", contentType: "text/css", contains: ".help-shell"},
 		{path: "/help.js", contentType: "text/javascript", contains: "applyLanguage"},
 		{path: "/webhooks", contentType: "text/html", contains: "Webhook Configurator"},

--- a/tests/web/app.test.js
+++ b/tests/web/app.test.js
@@ -63,7 +63,7 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
     const window = {
         Notification,
         isSecureContext: secure,
-        location: { origin: 'http://owlmail.test', protocol: 'http:', host: 'owlmail.test' },
+        location: { origin: 'http://owlmail.test', protocol: 'http:', host: 'owlmail.test', search: '' },
         addEventListener(name, handler) { windowListeners.set(name, handler); },
         focus() {}
     };
@@ -79,15 +79,17 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
     };
     const navigator = { language: 'en-US' };
     if (serviceWorker) {
+		const activeRegistration = {
+			async showNotification(title, options) {
+				serviceNotifications.push({ title, options });
+			}
+		};
         navigator.serviceWorker = {
             addEventListener() {},
             async register() {
-                return {
-                    async showNotification(title, options) {
-                        serviceNotifications.push({ title, options });
-                    }
-                };
-            }
+				return { installing: {} };
+			},
+			ready: Promise.resolve(activeRegistration)
         };
     }
     const sandbox = {

--- a/tests/web/app.test.js
+++ b/tests/web/app.test.js
@@ -33,7 +33,7 @@ function createElement() {
     };
 }
 
-function createHarness({ permission = 'default', secure = true, savedPreference = null } = {}) {
+function createHarness({ permission = 'default', secure = true, savedPreference = null, serviceWorker = false } = {}) {
     const storage = new Map();
     if (savedPreference !== null) {
         storage.set('owlmail.browserNotifications.enabled', savedPreference);
@@ -47,6 +47,7 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
     const notifications = [];
     const windowListeners = new Map();
     const documentListeners = new Map();
+    const serviceNotifications = [];
 
     function Notification(title, options) {
         const instance = { title, options, closed: false, close() { this.closed = true; } };
@@ -76,10 +77,23 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
         querySelectorAll() { return []; },
         createElement() { return createElement(); }
     };
+    const navigator = { language: 'en-US' };
+    if (serviceWorker) {
+        navigator.serviceWorker = {
+            addEventListener() {},
+            async register() {
+                return {
+                    async showNotification(title, options) {
+                        serviceNotifications.push({ title, options });
+                    }
+                };
+            }
+        };
+    }
     const sandbox = {
         window,
         document,
-        navigator: { language: 'en-US' },
+        navigator,
         localStorage: {
             getItem(key) { return storage.has(key) ? storage.get(key) : null; },
             setItem(key, value) { storage.set(key, value); }
@@ -101,6 +115,7 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
         notificationStatus,
         notificationToggle,
         notifications,
+        serviceNotifications,
         storage,
         window,
         windowListeners,
@@ -145,18 +160,33 @@ test('a revoked permission clears a previously enabled preference', () => {
     assert.equal(harness.notificationToggle.attributes.get('aria-pressed'), 'false');
 });
 
-test('new email notification uses bounded text and a stable message tag', () => {
+test('new email notification uses bounded text and a stable message tag', async () => {
     const harness = createHarness({ permission: 'granted', savedPreference: 'true' });
     harness.run('initializeBrowserNotifications()');
     const longSubject = `  ${'subject '.repeat(30)}  `;
 
-    harness.run(`notifyBrowserForEmail(${JSON.stringify({ id: 'mail-42', subject: longSubject, from: [] })})`);
+    await harness.run(`notifyBrowserForEmail(${JSON.stringify({ id: 'mail-42', subject: longSubject, from: [] })})`);
 
     assert.equal(harness.notifications.length, 1);
     assert.equal(harness.notifications[0].title.length, 160);
     assert.equal(harness.notifications[0].title.endsWith('…'), true);
     assert.equal(harness.notifications[0].options.tag, 'owlmail-email-mail-42');
     assert.match(harness.notifications[0].options.body, /Unknown/);
+});
+
+test('mobile-compatible notifications use the service worker registration', async () => {
+    const harness = createHarness({ permission: 'granted', savedPreference: 'true', serviceWorker: true });
+    harness.run('initializeBrowserNotifications()');
+
+    await harness.run(`notifyBrowserForEmail({
+        id: 'mobile-message',
+        subject: 'Mobile message',
+        from: [{ address: 'sender@example.com' }]
+    })`);
+
+    assert.equal(harness.serviceNotifications.length, 1);
+    assert.equal(harness.serviceNotifications[0].title, 'Mobile message');
+    assert.equal(harness.serviceNotifications[0].options.data.emailID, 'mobile-message');
 });
 
 test('insecure contexts report notifications as unavailable', () => {

--- a/tests/web/service-worker.test.js
+++ b/tests/web/service-worker.test.js
@@ -1,0 +1,53 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { test } = require('bun:test');
+const vm = require('node:vm');
+
+const source = fs.readFileSync(path.join(__dirname, '../../web/service-worker.js'), 'utf8');
+
+function loadWorker(windows) {
+  let clickHandler;
+  let opened;
+  const self = {
+    location: { origin: 'https://owlmail.test' },
+    addEventListener(name, handler) {
+      if (name === 'notificationclick') clickHandler = handler;
+    },
+    clients: {
+      async matchAll() { return windows; },
+      async openWindow(url) { opened = url; return null; }
+    }
+  };
+  vm.runInNewContext(source, { self, URL, encodeURIComponent });
+  return { clickHandler, opened: () => opened };
+}
+
+async function click(worker, emailID) {
+  let completion;
+  worker.clickHandler({
+    notification: { data: { emailID }, close() {} },
+    waitUntil(promise) { completion = promise; }
+  });
+  await completion;
+}
+
+test('notification clicks focus only an inbox client', async () => {
+  const messages = [];
+  const help = { url: 'https://owlmail.test/help', async focus() { throw new Error('focused help'); } };
+  const inbox = {
+    url: 'https://owlmail.test/',
+    async focus() {},
+    postMessage(message) { messages.push(message); }
+  };
+  const worker = loadWorker([help, inbox]);
+  await click(worker, 'mail-42');
+  assert.equal(JSON.stringify(messages), JSON.stringify([{ type: 'owlmail-notification-click', emailID: 'mail-42' }]));
+  assert.equal(worker.opened(), undefined);
+});
+
+test('notification clicks open a durable email deep link without an inbox client', async () => {
+  const worker = loadWorker([{ url: 'https://owlmail.test/webhooks', async focus() {} }]);
+  await click(worker, 'mail/42');
+  assert.equal(worker.opened(), '/?email=mail%2F42');
+});

--- a/web/app.js
+++ b/web/app.js
@@ -732,10 +732,11 @@ function notificationServiceWorkerSupported() {
 
 function getNotificationServiceWorker() {
     if (!notificationServiceWorkerSupported()) return Promise.resolve(null);
-    if (!notificationServiceWorkerPromise) {
-        notificationServiceWorkerPromise = navigator.serviceWorker
-            .register('/service-worker.js', { scope: '/' })
-            .catch((error) => {
+	if (!notificationServiceWorkerPromise) {
+		notificationServiceWorkerPromise = navigator.serviceWorker
+			.register('/service-worker.js', { scope: '/' })
+			.then((registration) => navigator.serviceWorker.ready || registration)
+			.catch((error) => {
                 console.warn('Unable to register notification service worker:', error);
                 return null;
             });
@@ -1598,8 +1599,12 @@ document.addEventListener('DOMContentLoaded', () => {
     // Initialize opt-in browser notifications without prompting on page load.
     initializeBrowserNotifications();
 
-    // Load initial emails
-    loadEmails();
+    // Load initial emails, then honor a service-worker notification deep link.
+    const initialEmailID = new URLSearchParams(window.location.search || '').get('email');
+    const initialLoad = loadEmails();
+    if (initialEmailID) {
+        void Promise.resolve(initialLoad).then(() => loadEmailDetail(initialEmailID));
+    }
 
     // Connect WebSocket
     connectWebSocket();

--- a/web/app.js
+++ b/web/app.js
@@ -723,11 +723,31 @@ let browserNotificationsEnabled = false;
 let browserNotificationsInitialized = false;
 let notificationPermissionPending = false;
 let notificationStatusTimer = null;
+let notificationServiceWorkerPromise = null;
+
+function notificationServiceWorkerSupported() {
+    return typeof navigator !== 'undefined' && navigator.serviceWorker
+        && typeof navigator.serviceWorker.register === 'function';
+}
+
+function getNotificationServiceWorker() {
+    if (!notificationServiceWorkerSupported()) return Promise.resolve(null);
+    if (!notificationServiceWorkerPromise) {
+        notificationServiceWorkerPromise = navigator.serviceWorker
+            .register('/service-worker.js', { scope: '/' })
+            .catch((error) => {
+                console.warn('Unable to register notification service worker:', error);
+                return null;
+            });
+    }
+    return notificationServiceWorkerPromise;
+}
 
 function browserNotificationsSupported() {
     return typeof window.Notification === 'function'
         && typeof window.Notification.requestPermission === 'function'
-        && window.isSecureContext !== false;
+        && window.isSecureContext !== false
+        && (notificationServiceWorkerSupported() || typeof window.Notification === 'function');
 }
 
 function readBrowserNotificationPreference() {
@@ -865,6 +885,14 @@ function initializeBrowserNotifications() {
 
     button.addEventListener('click', toggleBrowserNotifications);
     window.addEventListener('focus', synchronizeBrowserNotificationPermission);
+    if (notificationServiceWorkerSupported()) {
+        navigator.serviceWorker.addEventListener('message', (event) => {
+            if (!event.data || event.data.type !== 'owlmail-notification-click') return;
+            if (typeof window.focus === 'function') window.focus();
+            if (event.data.emailID) loadEmailDetail(event.data.emailID);
+        });
+        void getNotificationServiceWorker();
+    }
     browserNotificationsInitialized = true;
     updateBrowserNotificationButton();
 }
@@ -875,7 +903,7 @@ function normalizeNotificationText(value, fallback, maxLength) {
     return text.length > maxLength ? `${text.slice(0, maxLength - 1)}…` : text;
 }
 
-function notifyBrowserForEmail(email) {
+async function notifyBrowserForEmail(email) {
     if (!email || !browserNotificationsEnabled || !browserNotificationsSupported()) return;
     if (window.Notification.permission !== 'granted') {
         browserNotificationsEnabled = false;
@@ -891,11 +919,18 @@ function notifyBrowserForEmail(email) {
     const notificationSender = normalizeNotificationText(sender, t('unknown'), 240);
 
     try {
-        const notification = new window.Notification(title, {
+        const options = {
             body: nt('newEmailFrom', { sender: notificationSender }),
             tag: email.id ? `owlmail-email-${email.id}` : 'owlmail-new-email',
-            renotify: false
-        });
+            renotify: false,
+            data: { emailID: email.id || '' }
+        };
+        const registration = await getNotificationServiceWorker();
+        if (registration && typeof registration.showNotification === 'function') {
+            await registration.showNotification(title, options);
+            return;
+        }
+        const notification = new window.Notification(title, options);
         notification.onclick = () => {
             if (typeof window.focus === 'function') window.focus();
             notification.close();

--- a/web/assets_test.go
+++ b/web/assets_test.go
@@ -14,6 +14,7 @@ func TestRequiredAssetsAreEmbedded(t *testing.T) {
 	}{
 		{name: "index.html", contains: []byte("OwlMail")},
 		{name: "app.js", contains: []byte("connectWebSocket")},
+		{name: "service-worker.js", contains: []byte("notificationclick")},
 		{name: "style.css", contains: []byte(".header")},
 		{name: "help.html", contains: []byte("OwlMail Help")},
 		{name: "help.css", contains: []byte(".help-shell")},

--- a/web/service-worker.js
+++ b/web/service-worker.js
@@ -3,13 +3,21 @@ self.addEventListener('notificationclick', (event) => {
     const emailID = event.notification.data && event.notification.data.emailID;
     event.waitUntil((async () => {
         const windows = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
-        if (windows.length > 0) {
-            const client = windows[0];
-            await client.focus();
-            client.postMessage({ type: 'owlmail-notification-click', emailID });
+        const mailbox = windows.find((client) => {
+            try {
+                const url = new URL(client.url);
+                return url.origin === self.location.origin
+                    && (url.pathname === '/' || url.pathname === '/index.html');
+            } catch (_) {
+                return false;
+            }
+        });
+        if (mailbox) {
+            await mailbox.focus();
+            mailbox.postMessage({ type: 'owlmail-notification-click', emailID });
             return;
         }
-        const client = await self.clients.openWindow('/');
-        if (client) client.postMessage({ type: 'owlmail-notification-click', emailID });
+        const target = emailID ? `/?email=${encodeURIComponent(emailID)}` : '/';
+        await self.clients.openWindow(target);
     })());
 });

--- a/web/service-worker.js
+++ b/web/service-worker.js
@@ -1,0 +1,15 @@
+self.addEventListener('notificationclick', (event) => {
+    event.notification.close();
+    const emailID = event.notification.data && event.notification.data.emailID;
+    event.waitUntil((async () => {
+        const windows = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+        if (windows.length > 0) {
+            const client = windows[0];
+            await client.focus();
+            client.postMessage({ type: 'owlmail-notification-click', emailID });
+            return;
+        }
+        const client = await self.clients.openWindow('/');
+        if (client) client.postMessage({ type: 'owlmail-notification-click', emailID });
+    })());
+});


### PR DESCRIPTION
## Summary

- serve and register a root-scoped service worker
- use `ServiceWorkerRegistration.showNotification` when available for mobile browser compatibility
- focus an existing OwlMail tab or open the selected email when a notification is clicked
- retain the desktop Notification constructor as a fallback

## Verification

- covers the service-worker asset, API route, registration, and mobile notification path
- `go test ./...` and `bun test`