### PR TITLE
docs: bind webhook demo ports to loopback

### DIFF
--- a/examples/webhooks/soulteary-webhook/README.md
+++ b/examples/webhooks/soulteary-webhook/README.md
@@ -92,9 +92,11 @@ export OWLMAIL_WEBHOOK_MAX_CONCURRENCY=8
 owlmail -webhook-config owlmail.json
 ```
 
-For production, keep WebHook private or behind an authenticated reverse proxy,
-retain HMAC verification, restrict allowed command paths, bound execution and
-concurrency, and avoid logging full email bodies.
+The example binds every host port to `127.0.0.1`; do not remove that boundary on
+a shared host. For production, keep both OwlMail and WebHook private or behind
+an authenticated reverse proxy, configure OwlMail Web Basic Auth, restrict SMTP
+ingress, retain HMAC verification, restrict allowed command paths, bound
+execution and concurrency, and avoid logging full email bodies.
 
 [中文说明](./README.zh-CN.md) ·
 [Webhook forwarding reference](../../../docs/en/Webhook-Forwarding.md) ·

--- a/examples/webhooks/soulteary-webhook/README.zh-CN.md
+++ b/examples/webhooks/soulteary-webhook/README.zh-CN.md
@@ -85,8 +85,10 @@ export OWLMAIL_WEBHOOK_MAX_CONCURRENCY=8
 owlmail -webhook-config owlmail.json
 ```
 
-生产环境建议保持 WebHook 仅内网可访问或放在带鉴权的反向代理之后，继续启用 HMAC
-验证，限制允许执行的命令路径，设置执行时间和并发上限，并避免记录完整邮件正文。
+示例将所有宿主机端口绑定到 `127.0.0.1`，在共享主机上不要移除此边界。
+生产环境中，请将 OwlMail 和 WebHook 都保持为私有服务或置于经过身份验证的反向代理之后，
+为 OwlMail 配置 Web Basic Auth 并限制 SMTP 入口；同时保留 HMAC 校验，限制允许执行的
+命令路径、执行时间与并发，并避免记录完整邮件正文。
 
 [English](./README.md) ·
 [Webhook 消息转发参考](../../../docs/zh-CN/Webhook-Forwarding.md) ·

--- a/examples/webhooks/soulteary-webhook/compose.yaml
+++ b/examples/webhooks/soulteary-webhook/compose.yaml
@@ -2,7 +2,7 @@ services:
   webhook:
     image: soulteary/webhook:7.0.0
     ports:
-      - "9000:9000"
+      - "127.0.0.1:9000:9000"
     environment:
       HOST: "0.0.0.0"
       PORT: "9000"
@@ -28,8 +28,8 @@ services:
       webhook:
         condition: service_healthy
     ports:
-      - "1025:1025"
-      - "1080:1080"
+      - "127.0.0.1:1025:1025"
+      - "127.0.0.1:1080:1080"
     environment:
       OWLMAIL_SMTP_HOST: "0.0.0.0"
       OWLMAIL_WEB_HOST: "0.0.0.0"

--- a/tests/docs/markdown.test.js
+++ b/tests/docs/markdown.test.js
@@ -14,6 +14,17 @@ const translatedReadmes = [
   "README.ko.md",
 ];
 
+test("Webhook demo publishes host ports on loopback only", () => {
+  const compose = fs.readFileSync(
+    path.join(root, "examples/webhooks/soulteary-webhook/compose.yaml"),
+    "utf8",
+  );
+  for (const port of ["9000", "1025", "1080"]) {
+    assert.match(compose, new RegExp(`127\\.0\\.0\\.1:${port}:${port}`));
+  }
+  assert.doesNotMatch(compose, /^\s*-\s*["']?(?:9000|1025|1080):/m);
+});
+
 function walkMarkdown(directory) {
   const files = [];
   for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {


### PR DESCRIPTION
## Summary

- bind the demo's WebHook, SMTP, and OwlMail UI ports to `127.0.0.1`
- explain that OwlMail Basic Auth and SMTP network isolation are still required before remote exposure
- update both English and Chinese instructions

## Verification

- adds a documentation regression test for loopback-only published ports
- `go test ./...` and `bun test`