### PR TITLE
fix(storage): preserve quarantine evidence and continue safe recovery

### DIFF
--- a/internal/mailserver/mailserver_store_test.go
+++ b/internal/mailserver/mailserver_store_test.go
@@ -208,6 +208,13 @@ func TestMailServerGetAllEmail(t *testing.T) {
 	if err := server.SaveEmailToStore("id2", false, envelope, email2); err != nil {
 		t.Fatalf("Failed to save email 2: %v", err)
 	}
+	quarantineFile := filepath.Join(tmpDir, quarantineDirName, "evidence", "message.eml")
+	if err := os.MkdirAll(filepath.Dir(quarantineFile), 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(quarantineFile, []byte("corrupt evidence"), 0600); err != nil {
+		t.Fatal(err)
+	}
 
 	emails = server.GetAllEmail()
 	if len(emails) != 2 {
@@ -285,6 +292,14 @@ func TestMailServerDeleteAllEmail(t *testing.T) {
 	if err := server.SaveEmailToStore("id2", false, envelope, email2); err != nil {
 		t.Fatalf("Failed to save email 2: %v", err)
 	}
+	quarantineDir := filepath.Join(tmpDir, quarantineDirName)
+	if err := os.MkdirAll(quarantineDir, 0755); err != nil {
+		t.Fatalf("Failed to create quarantine directory: %v", err)
+	}
+	quarantineFile := filepath.Join(quarantineDir, "damaged.eml")
+	if err := os.WriteFile(quarantineFile, []byte("evidence"), 0600); err != nil {
+		t.Fatalf("Failed to create quarantine evidence: %v", err)
+	}
 
 	// Delete all
 	err = server.DeleteAllEmail()
@@ -296,6 +311,9 @@ func TestMailServerDeleteAllEmail(t *testing.T) {
 	emails := server.GetAllEmail()
 	if len(emails) != 0 {
 		t.Errorf("Expected 0 emails, got %d", len(emails))
+	}
+	if _, err := os.Stat(quarantineFile); err != nil {
+		t.Fatalf("quarantine evidence was removed: %v", err)
 	}
 }
 

--- a/internal/mailserver/storage_transaction.go
+++ b/internal/mailserver/storage_transaction.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/soulteary/owlmail/internal/common"
 )
 
 const (
@@ -132,7 +134,7 @@ func (ms *MailServer) recoverStorageArtifacts() error {
 			continue
 		}
 		if err := ms.quarantinePath(filepath.Join(ms.mailDir, entry.Name()), "incomplete"); err != nil {
-			return fmt.Errorf("quarantine incomplete artifact %s: %w", entry.Name(), err)
+			common.Error("Failed to quarantine incomplete artifact %s: %v", entry.Name(), err)
 		}
 	}
 	return nil
@@ -199,7 +201,7 @@ func (ms *MailServer) quarantineOrphanAttachmentDirectories() error {
 		if !entry.IsDir() || entry.Name() == quarantineDirName || strings.HasPrefix(entry.Name(), storageTempPrefix) {
 			continue
 		}
-		if err := validateEmailID(entry.Name()); err != nil {
+		if !isGeneratedEmailID(entry.Name()) {
 			continue
 		}
 		if _, err := os.Stat(filepath.Join(ms.mailDir, entry.Name()+".eml")); err == nil {

--- a/internal/mailserver/storage_transaction_test.go
+++ b/internal/mailserver/storage_transaction_test.go
@@ -113,7 +113,10 @@ func TestLoadMailsQuarantinesCorruptIncompleteAndOrphanArtifacts(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, storageTempPrefix+"partial.eml.tmp"), []byte("partial"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(filepath.Join(dir, "orphan-id"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(dir, "orphan01"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "backups"), 0755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -124,7 +127,7 @@ func TestLoadMailsQuarantinesCorruptIncompleteAndOrphanArtifacts(t *testing.T) {
 	if got := len(server.GetAllEmail()); got != 0 {
 		t.Fatalf("corrupt email was published: %d", got)
 	}
-	for _, name := range []string{"corrupt.eml", storageTempPrefix + "partial.eml.tmp", "orphan-id"} {
+	for _, name := range []string{"corrupt.eml", storageTempPrefix + "partial.eml.tmp", "orphan01"} {
 		if _, err := os.Stat(filepath.Join(dir, name)); !os.IsNotExist(err) {
 			t.Fatalf("artifact %s was not moved to quarantine: %v", name, err)
 		}
@@ -135,5 +138,30 @@ func TestLoadMailsQuarantinesCorruptIncompleteAndOrphanArtifacts(t *testing.T) {
 	}
 	if len(quarantined) != 3 {
 		t.Fatalf("expected three quarantine entries, got %d", len(quarantined))
+	}
+	if _, err := os.Stat(filepath.Join(dir, "backups")); err != nil {
+		t.Fatalf("unrelated directory was quarantined: %v", err)
+	}
+}
+
+func TestRecoveryFailureDoesNotHideCommittedMail(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "valid001.eml"), validMessage("valid"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, storageTempPrefix+"partial.eml.tmp"), []byte("partial"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, quarantineDirName), []byte("blocks quarantine directory"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	server, err := NewMailServer(1025, "localhost", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	if got := len(server.GetAllEmail()); got != 1 {
+		t.Fatalf("valid committed mail count = %d, want 1", got)
 	}
 }

--- a/internal/mailserver/store.go
+++ b/internal/mailserver/store.go
@@ -232,6 +232,9 @@ func (ms *MailServer) DeleteAllEmail() error {
 	files, err := os.ReadDir(ms.mailDir)
 	if err == nil {
 		for _, file := range files {
+			if file.Name() == quarantineDirName {
+				continue
+			}
 			if err := os.RemoveAll(filepath.Join(ms.mailDir, file.Name())); err != nil {
 				common.Verbose("Failed to remove file: %v", err)
 			}

--- a/internal/mailserver/utils.go
+++ b/internal/mailserver/utils.go
@@ -170,6 +170,22 @@ func validateEmailID(id string) error {
 	return nil
 }
 
+// isGeneratedEmailID reports whether id has one of the two formats emitted by
+// makeID. It is intentionally stricter than validateEmailID, which also accepts
+// human-readable IDs used by API clients and tests.
+func isGeneratedEmailID(id string) bool {
+	if len(id) == 8 {
+		for _, r := range id {
+			if (r < 'A' || r > 'Z') && (r < 'a' || r > 'z') && (r < '0' || r > '9') {
+				return false
+			}
+		}
+		return true
+	}
+	parsed, err := uuid.Parse(id)
+	return err == nil && parsed.String() == strings.ToLower(id)
+}
+
 // validatePath ensures the resolved path is within the base directory to prevent path traversal
 func validatePath(baseDir, resolvedPath string) error {
 	// Get absolute paths


### PR DESCRIPTION
## Summary

- only treat directories with OwlMail-generated IDs as orphan attachment directories
- keep unrelated directories such as backups untouched
- continue scanning valid messages when quarantining one damaged entry fails, while logging the failure
- preserve the quarantine directory during delete-all operations

## Verification

- covers failed quarantine moves, unrelated directories, and delete-all preservation
- `go test ./...` and `bun test`
- `go test -race ./internal/mailserver`

> Superseded by the separately reviewable #50 and #51, which cover quarantine preservation and recovery resilience independently.