### PR TITLE
fix(webhook): renew Redis delivery leases and surface enqueue failures

### DIFF
--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -238,10 +238,8 @@ func registerWebhookService(server *mailserver.MailServer, service *webhooknotif
 	if server == nil || service == nil {
 		return nil
 	}
-	if err := server.OnSynchronous("new", func(email *mailserver.Email) {
-		if err := service.Enqueue(email); err != nil {
-			common.Error("Failed to enqueue webhook delivery: %v", err)
-		}
+	if err := server.OnSynchronous("new", func(email *mailserver.Email) error {
+		return service.Enqueue(email)
 	}); err != nil {
 		return fmt.Errorf("register webhook queue handoff: %w", err)
 	}

--- a/internal/mailserver/events.go
+++ b/internal/mailserver/events.go
@@ -14,13 +14,13 @@ func (ms *MailServer) On(event string, handler func(*types.Email)) {
 // OnSynchronous registers a lightweight handoff listener that completes
 // before emit returns. It is intended for durable queue writes, not network
 // delivery or other long-running work.
-func (ms *MailServer) OnSynchronous(event string, handler func(*types.Email)) error {
+func (ms *MailServer) OnSynchronous(event string, handler func(*types.Email) error) error {
 	if handler == nil {
 		return fmt.Errorf("event handler cannot be nil")
 	}
 	ms.listenersMutex.Lock()
 	defer ms.listenersMutex.Unlock()
-	ms.listeners[event] = append(ms.listeners[event], eventListener{handler: handler, synchronous: true})
+	ms.listeners[event] = append(ms.listeners[event], eventListener{syncHandler: handler})
 	return nil
 }
 
@@ -47,26 +47,28 @@ func (ms *MailServer) OnWithConcurrency(event string, maxConcurrency int, handle
 }
 
 // emit sends an event to all listeners
-func (ms *MailServer) emit(event string, email *types.Email) {
+func (ms *MailServer) emit(event string, email *types.Email) error {
 	ms.listenersMutex.RLock()
 	listeners := append([]eventListener(nil), ms.listeners[event]...)
 	ms.listenersMutex.RUnlock()
 	for _, listener := range listeners {
-		if listener.synchronous {
-			listener.handler(cloneEmail(email))
+		if listener.syncHandler != nil {
+			if err := listener.syncHandler(cloneEmail(email)); err != nil {
+				return fmt.Errorf("synchronous %s event handoff: %w", event, err)
+			}
 		}
 	}
 
 	// Start unlimited listeners first so a saturated bounded listener cannot
 	// delay UI broadcasts or lightweight logging handlers registered after it.
 	for _, listener := range listeners {
-		if !listener.synchronous && listener.slots == nil {
+		if listener.syncHandler == nil && listener.slots == nil {
 			emailSnapshot := cloneEmail(email)
 			go listener.handler(emailSnapshot)
 		}
 	}
 	for _, listener := range listeners {
-		if listener.synchronous || listener.slots == nil {
+		if listener.syncHandler != nil || listener.slots == nil {
 			continue
 		}
 		listener.slots <- struct{}{}
@@ -76,4 +78,5 @@ func (ms *MailServer) emit(event string, email *types.Email) {
 			listener.handler(emailSnapshot)
 		}(listener)
 	}
+	return nil
 }

--- a/internal/mailserver/mailserver_events_test.go
+++ b/internal/mailserver/mailserver_events_test.go
@@ -1,11 +1,33 @@
 package mailserver
 
 import (
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 )
+
+func TestSynchronousHandoffFailureRollsBackStore(t *testing.T) {
+	server, err := NewMailServer(1025, "localhost", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	if err := server.OnSynchronous("new", func(*Email) error {
+		return errors.New("queue unavailable")
+	}); err != nil {
+		t.Fatal(err)
+	}
+	email := &Email{Subject: "handoff"}
+	envelope := &Envelope{From: "from@example.test", To: []string{"to@example.test"}}
+	if err := server.SaveEmailToStore("handoff1", false, envelope, email); err == nil {
+		t.Fatal("SaveEmailToStore succeeded after durable handoff failed")
+	}
+	if got := len(server.GetAllEmail()); got != 0 {
+		t.Fatalf("store contains %d messages after handoff rollback", got)
+	}
+}
 
 func TestMailServerOn(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/internal/mailserver/store.go
+++ b/internal/mailserver/store.go
@@ -58,7 +58,8 @@ func (ms *MailServer) SaveEmailToStore(id string, isRead bool, envelope *Envelop
 
 	storedEmail := cloneEmail(parsedEmail)
 	ms.storeMutex.Lock()
-	if _, exists := ms.storeByID[id]; !exists {
+	previousEmail, existed := ms.storeByID[id]
+	if !existed {
 		ms.storeOrder = append(ms.storeOrder, id)
 	}
 	ms.storeByID[id] = storedEmail
@@ -67,7 +68,22 @@ func (ms *MailServer) SaveEmailToStore(id string, isRead bool, envelope *Envelop
 	common.Log("Saving email: %s, id: %s", parsedEmail.Subject, id)
 
 	// Emit new email event
-	ms.emit("new", storedEmail)
+	if err := ms.emit("new", storedEmail); err != nil {
+		ms.storeMutex.Lock()
+		if existed {
+			ms.storeByID[id] = previousEmail
+		} else {
+			delete(ms.storeByID, id)
+			for index, storedID := range ms.storeOrder {
+				if storedID == id {
+					ms.storeOrder = append(ms.storeOrder[:index], ms.storeOrder[index+1:]...)
+					break
+				}
+			}
+		}
+		ms.storeMutex.Unlock()
+		return err
+	}
 
 	// Auto relay if enabled
 	if ms.outgoing != nil && ms.outgoing.IsAutoRelayEnabled() {
@@ -216,7 +232,7 @@ func (ms *MailServer) DeleteEmail(id string) error {
 	}
 
 	// Emit delete event
-	ms.emit("delete", email)
+	_ = ms.emit("delete", email)
 
 	return nil
 }

--- a/internal/mailserver/types.go
+++ b/internal/mailserver/types.go
@@ -39,8 +39,8 @@ type TLSConfig struct {
 
 type eventListener struct {
 	handler     func(*types.Email)
+	syncHandler func(*types.Email) error
 	slots       chan struct{}
-	synchronous bool
 }
 
 // MailServer represents the SMTP mail server

--- a/internal/webhook/queue.go
+++ b/internal/webhook/queue.go
@@ -26,10 +26,28 @@ type queueReceipt struct {
 type deliveryQueue interface {
 	Enqueue(context.Context, deliveryJob) error
 	Claim(context.Context) (*queueReceipt, error)
+	Touch(context.Context, *queueReceipt) error
 	Ack(context.Context, *queueReceipt) error
 	DeadLetter(context.Context, *queueReceipt, []Result) error
 	Pending(context.Context) (int64, error)
 	Close() error
+}
+
+func (queue *redisDeliveryQueue) Touch(ctx context.Context, receipt *queueReceipt) error {
+	if receipt == nil {
+		return nil
+	}
+	claimed, err := queue.client.XClaim(ctx, &redis.XClaimArgs{
+		Stream: queue.stream, Group: redisConsumerGroup, Consumer: queue.consumer,
+		MinIdle: 0, Messages: []string{receipt.id},
+	}).Result()
+	if err != nil {
+		return fmt.Errorf("renew webhook job lease: %w", err)
+	}
+	if len(claimed) == 0 {
+		return fmt.Errorf("renew webhook job lease: receipt %s is no longer pending", receipt.id)
+	}
+	return nil
 }
 
 type redisDeliveryQueue struct {

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -43,6 +43,7 @@ type Service struct {
 	shutdownTimeout time.Duration
 	onResults       func(string, []Result)
 	workerCount     int
+	leaseHeartbeat  time.Duration
 	unlimited       bool
 	accepting       bool
 	handoffMutex    sync.RWMutex
@@ -71,6 +72,7 @@ func NewService(dispatcher *Dispatcher, options ServiceOptions) (*Service, error
 		dispatcher: dispatcher, ctx: ctx, cancel: cancel,
 		shutdownTimeout: options.ShutdownTimeout, onResults: options.OnResults,
 		workerCount: options.MaxConcurrency, unlimited: options.MaxConcurrency == 0,
+		leaseHeartbeat: redisClaimIdle / 3,
 	}
 	if options.RedisURL != "" {
 		consumer := fmt.Sprintf("%s-%s", runtime.GOOS, uuid.NewString())
@@ -208,7 +210,45 @@ func (service *Service) isAccepting() bool {
 }
 
 func (service *Service) deliver(job deliveryJob, receipt *queueReceipt) {
+	stopLease := make(chan struct{})
+	leaseDone := make(chan error, 1)
+	if service.queue != nil && receipt != nil {
+		leaseHeartbeat := service.leaseHeartbeat
+		if leaseHeartbeat <= 0 {
+			leaseHeartbeat = redisClaimIdle / 3
+		}
+		go func() {
+			ticker := time.NewTicker(leaseHeartbeat)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-stopLease:
+					leaseDone <- nil
+					return
+				case <-service.ctx.Done():
+					leaseDone <- service.ctx.Err()
+					return
+				case <-ticker.C:
+					if err := service.queue.Touch(service.ctx, receipt); err != nil {
+						leaseDone <- err
+						return
+					}
+				}
+			}
+		}()
+	} else {
+		leaseDone <- nil
+	}
 	results := service.dispatcher.DispatchDelivery(service.ctx, job.Email, job.ID)
+	close(stopLease)
+	if err := <-leaseDone; err != nil && !errors.Is(err, context.Canceled) {
+		results = append(results, Result{Err: err})
+		// Ownership is uncertain when the lease cannot be renewed. Leave the
+		// receipt pending so Redis can safely redeliver it instead of ACKing or
+		// deleting the only durable copy.
+		service.report(job.ID, results)
+		return
+	}
 	failed := false
 	for _, result := range results {
 		if result.Err != nil {

--- a/internal/webhook/service_test.go
+++ b/internal/webhook/service_test.go
@@ -48,11 +48,12 @@ func TestServiceCloseDrainsInFlightDelivery(t *testing.T) {
 }
 
 type fakeDeliveryQueue struct {
-	claims chan *queueReceipt
-	mu     sync.Mutex
-	acked  []string
-	dead   []string
-	count  int64
+	claims  chan *queueReceipt
+	mu      sync.Mutex
+	acked   []string
+	dead    []string
+	count   int64
+	touches int
 }
 
 func (queue *fakeDeliveryQueue) Enqueue(_ context.Context, job deliveryJob) error {
@@ -79,6 +80,13 @@ func (queue *fakeDeliveryQueue) Ack(_ context.Context, receipt *queueReceipt) er
 	defer queue.mu.Unlock()
 	queue.acked = append(queue.acked, receipt.id)
 	queue.count--
+	return nil
+}
+
+func (queue *fakeDeliveryQueue) Touch(_ context.Context, _ *queueReceipt) error {
+	queue.mu.Lock()
+	defer queue.mu.Unlock()
+	queue.touches++
 	return nil
 }
 
@@ -136,6 +144,33 @@ func TestDurableServiceDeadLettersExhaustedDelivery(t *testing.T) {
 	}
 	if err := service.Close(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestDurableServiceRenewsActiveReceiptLease(t *testing.T) {
+	receiver := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		time.Sleep(30 * time.Millisecond)
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer receiver.Close()
+	dispatcher, err := NewDispatcher(Config{Targets: []Target{{Name: "slow", URL: receiver.URL}}}, receiver.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	queue := &fakeDeliveryQueue{claims: make(chan *queueReceipt, 1), count: 1}
+	service := &Service{dispatcher: dispatcher, queue: queue, ctx: ctx, cancel: cancel, leaseHeartbeat: 5 * time.Millisecond}
+	receipt := &queueReceipt{id: "active-entry", job: deliveryJob{ID: "active-job", Email: testEmail()}}
+	service.deliver(receipt.job, receipt)
+
+	queue.mu.Lock()
+	defer queue.mu.Unlock()
+	if queue.touches == 0 {
+		t.Fatal("active Redis receipt lease was not renewed")
+	}
+	if len(queue.acked) != 1 || queue.acked[0] != receipt.id {
+		t.Fatalf("acked receipts = %v", queue.acked)
 	}
 }
 


### PR DESCRIPTION
## Summary

- propagate durable webhook enqueue failures back through the synchronous storage handoff
- roll back the in-memory mail commit when the durable event cannot be accepted
- renew Redis pending-entry leases while a delivery is in progress
- leave a receipt pending when lease renewal fails so another worker can recover it

> Superseded by two independently reviewable fixes: #62 renews active Redis delivery leases, and #63 adds a durable local outbox so queue failures do not block SMTP or lose the webhook job.