### PR TITLE
ci: run the main validation workflow on feature branch pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ "**" ]
   pull_request:
     branches: [ main, develop ]
 


### PR DESCRIPTION
## Summary

- run CI for pushes to every branch instead of only `main`
- retain pull-request validation and the existing concurrency behavior

> Closed as not required: pull requests already execute the validation workflow. Enabling push validation for every feature branch would duplicate runs and was not an unresolved correctness issue from the merged PR reviews.