### PR TITLE
ci: prevent older releases from moving stable image tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,16 @@ jobs:
           echo "notes=${NOTES}" >> "${GITHUB_OUTPUT}"
           if [[ "${VERSION}" == *-* ]]; then
             echo "prerelease=true" >> "${GITHUB_OUTPUT}"
+            echo "publish-moving-tags=false" >> "${GITHUB_OUTPUT}"
           else
             echo "prerelease=false" >> "${GITHUB_OUTPUT}"
+            LATEST_STABLE="$(git tag --list 'v*' --sort=-v:refname | grep -E '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$' | head -n 1)"
+            if [ "${VERSION}" = "${LATEST_STABLE}" ]; then
+              echo "publish-moving-tags=true" >> "${GITHUB_OUTPUT}"
+            else
+              echo "publish-moving-tags=false" >> "${GITHUB_OUTPUT}"
+              echo "Older stable release ${VERSION}; keeping moving image tags on ${LATEST_STABLE}"
+            fi
           fi
 
       - name: Set up Go
@@ -265,10 +273,10 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}},value=${{ steps.release.outputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ steps.release.outputs.version }}
-            type=semver,pattern={{major}},value=${{ steps.release.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.release.outputs.version }},enable=${{ steps.release.outputs.publish-moving-tags == 'true' }}
+            type=semver,pattern={{major}},value=${{ steps.release.outputs.version }},enable=${{ steps.release.outputs.publish-moving-tags == 'true' }}
             type=sha,prefix=sha-
-            type=raw,value=latest,enable=${{ steps.release.outputs.prerelease == 'false' }}
+            type=raw,value=latest,enable=${{ steps.release.outputs.publish-moving-tags == 'true' }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ steps.release.outputs.commit }}

--- a/docs/en/Releasing.md
+++ b/docs/en/Releasing.md
@@ -66,6 +66,10 @@ dependency verification, formatting, `go vet`, race-enabled Go tests,
 generates SPDX SBOMs, GitHub artifact attestations, and keyless Sigstore
 signatures before publishing the release.
 
+Retrying an older stable tag republishes only its exact semantic-version and
+commit-SHA image tags. The moving major, minor, and `latest` tags are updated
+only when the requested tag is the newest stable tag in the repository.
+
 ## Verify published artifacts
 
 In addition to GitHub's automatic source archives, a release made with the

--- a/docs/zh-CN/Releasing.md
+++ b/docs/zh-CN/Releasing.md
@@ -60,6 +60,9 @@ gh workflow run release.yml --ref v0.5.0 -f version=v0.5.0
 `govulncheck` 以及 Bun 浏览器/文档检查，随后生成 SPDX SBOM、GitHub Artifact
 Attestation 与 Sigstore 无密钥签名，再正式发布。
 
+重试旧的稳定标签时，只会重新发布精确语义版本和提交 SHA 镜像标签。
+只有请求的标签仍是仓库中最新的稳定版本时，才会更新主版本、次版本和 `latest` 移动标签。
+
 ## 验证发布文件
 
 除 GitHub 自动生成的源码归档外，使用当前工作流发布的版本应包含：

--- a/tests/docs/markdown.test.js
+++ b/tests/docs/markdown.test.js
@@ -422,6 +422,16 @@ test("release workflow preserves supply-chain evidence", () => {
   }
 });
 
+test("older release retries cannot move floating image tags", () => {
+  const workflow = fs.readFileSync(path.join(root, ".github/workflows/release.yml"), "utf8");
+  assert.match(workflow, /LATEST_STABLE=/);
+  assert.match(workflow, /publish-moving-tags=true/);
+  assert.equal(
+    (workflow.match(/enable=\$\{\{ steps\.release\.outputs\.publish-moving-tags == 'true' \}\}/g) || []).length,
+    3,
+  );
+});
+
 test("browser and documentation tests use the pinned Bun runner", () => {
   const legacyRunner = `node:${"test"}`;
   for (const testFile of [


### PR DESCRIPTION
## Summary

- determine the newest stable semantic-version tag during release metadata generation
- publish `latest`, major, and minor moving tags only for that newest stable release
- keep immutable version tags available when an older release workflow is retried
- document the behavior in both release guides

## Verification

- adds a workflow regression test for all moving-tag guards
- `go test ./...` and `bun test`

> Closed as duplicate: #47 has already merged the moving-tag protection into main.