### PR TITLE
feat(storage): carry storage governance forward onto main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to OwlMail are documented in this file. The format follows
 
 - The in-memory mail store now uses an ID map with ordered IDs and returns deep
   snapshots to API, WebSocket, webhook, and other event consumers.
+- Mailboxes can enforce age, count, and disk limits with background cleanup;
+  read state uses atomic sidecar metadata and ZIP exports stream with hard
+  source-count and byte limits.
 
 ### Release engineering
 

--- a/README.de.md
+++ b/README.de.md
@@ -199,6 +199,10 @@ docker buildx build \
 | `-web` | `MAILDEV_WEB_PORT` / `OWLMAIL_WEB_PORT` | 1080 | Web-API-Port |
 | `-web-ip` | `MAILDEV_WEB_IP` / `OWLMAIL_WEB_HOST` | localhost | Web-API-Host |
 | `-mail-directory` | `MAILDEV_MAIL_DIRECTORY` / `OWLMAIL_MAIL_DIR` | - | E-Mail-Speicherverzeichnis |
+| `-mail-retention-days` | `OWLMAIL_MAIL_RETENTION_DAYS` | 0 | Mail retention days; `0` is unlimited |
+| `-mail-max-messages` | `OWLMAIL_MAIL_MAX_MESSAGES` | 0 | Maximum stored messages; `0` is unlimited |
+| `-mail-max-disk-mb` | `OWLMAIL_MAIL_MAX_DISK_MB` | 0 | Maximum mailbox MiB; `0` is unlimited |
+| `-mail-cleanup-interval` | `OWLMAIL_MAIL_CLEANUP_INTERVAL` | 1h | Background cleanup interval |
 | `-web-user` | `MAILDEV_WEB_USER` / `OWLMAIL_WEB_USER` | - | HTTP Basic Auth Benutzername |
 | `-web-password` | `MAILDEV_WEB_PASS` / `OWLMAIL_WEB_PASSWORD` | - | HTTP Basic Auth Passwort |
 | `-https` | `MAILDEV_HTTPS` / `OWLMAIL_HTTPS_ENABLED` | false | HTTPS aktivieren |

--- a/README.fr.md
+++ b/README.fr.md
@@ -200,6 +200,10 @@ docker buildx build \
 | `-web` | `MAILDEV_WEB_PORT` / `OWLMAIL_WEB_PORT` | 1080 | Web API port |
 | `-web-ip` | `MAILDEV_WEB_IP` / `OWLMAIL_WEB_HOST` | localhost | Web API host |
 | `-mail-directory` | `MAILDEV_MAIL_DIRECTORY` / `OWLMAIL_MAIL_DIR` | - | Mail storage directory |
+| `-mail-retention-days` | `OWLMAIL_MAIL_RETENTION_DAYS` | 0 | Mail retention days; `0` is unlimited |
+| `-mail-max-messages` | `OWLMAIL_MAIL_MAX_MESSAGES` | 0 | Maximum stored messages; `0` is unlimited |
+| `-mail-max-disk-mb` | `OWLMAIL_MAIL_MAX_DISK_MB` | 0 | Maximum mailbox MiB; `0` is unlimited |
+| `-mail-cleanup-interval` | `OWLMAIL_MAIL_CLEANUP_INTERVAL` | 1h | Background cleanup interval |
 | `-web-user` | `MAILDEV_WEB_USER` / `OWLMAIL_WEB_USER` | - | HTTP Basic Auth username |
 | `-web-password` | `MAILDEV_WEB_PASS` / `OWLMAIL_WEB_PASSWORD` | - | HTTP Basic Auth password |
 | `-https` | `MAILDEV_HTTPS` / `OWLMAIL_HTTPS_ENABLED` | false | Enable HTTPS |

--- a/README.it.md
+++ b/README.it.md
@@ -199,6 +199,10 @@ docker buildx build \
 | `-web` | `MAILDEV_WEB_PORT` / `OWLMAIL_WEB_PORT` | 1080 | Porta API Web |
 | `-web-ip` | `MAILDEV_WEB_IP` / `OWLMAIL_WEB_HOST` | localhost | Host API Web |
 | `-mail-directory` | `MAILDEV_MAIL_DIRECTORY` / `OWLMAIL_MAIL_DIR` | - | Directory di archiviazione email |
+| `-mail-retention-days` | `OWLMAIL_MAIL_RETENTION_DAYS` | 0 | Mail retention days; `0` is unlimited |
+| `-mail-max-messages` | `OWLMAIL_MAIL_MAX_MESSAGES` | 0 | Maximum stored messages; `0` is unlimited |
+| `-mail-max-disk-mb` | `OWLMAIL_MAIL_MAX_DISK_MB` | 0 | Maximum mailbox MiB; `0` is unlimited |
+| `-mail-cleanup-interval` | `OWLMAIL_MAIL_CLEANUP_INTERVAL` | 1h | Background cleanup interval |
 | `-web-user` | `MAILDEV_WEB_USER` / `OWLMAIL_WEB_USER` | - | Nome utente HTTP Basic Auth |
 | `-web-password` | `MAILDEV_WEB_PASS` / `OWLMAIL_WEB_PASSWORD` | - | Password HTTP Basic Auth |
 | `-https` | `MAILDEV_HTTPS` / `OWLMAIL_HTTPS_ENABLED` | false | Abilita HTTPS |

--- a/README.ja.md
+++ b/README.ja.md
@@ -199,6 +199,10 @@ docker buildx build \
 | `-web` | `MAILDEV_WEB_PORT` / `OWLMAIL_WEB_PORT` | 1080 | Web API port |
 | `-web-ip` | `MAILDEV_WEB_IP` / `OWLMAIL_WEB_HOST` | localhost | Web API host |
 | `-mail-directory` | `MAILDEV_MAIL_DIRECTORY` / `OWLMAIL_MAIL_DIR` | - | Mail storage directory |
+| `-mail-retention-days` | `OWLMAIL_MAIL_RETENTION_DAYS` | 0 | Mail retention days; `0` is unlimited |
+| `-mail-max-messages` | `OWLMAIL_MAIL_MAX_MESSAGES` | 0 | Maximum stored messages; `0` is unlimited |
+| `-mail-max-disk-mb` | `OWLMAIL_MAIL_MAX_DISK_MB` | 0 | Maximum mailbox MiB; `0` is unlimited |
+| `-mail-cleanup-interval` | `OWLMAIL_MAIL_CLEANUP_INTERVAL` | 1h | Background cleanup interval |
 | `-web-user` | `MAILDEV_WEB_USER` / `OWLMAIL_WEB_USER` | - | HTTP Basic Auth username |
 | `-web-password` | `MAILDEV_WEB_PASS` / `OWLMAIL_WEB_PASSWORD` | - | HTTP Basic Auth password |
 | `-https` | `MAILDEV_HTTPS` / `OWLMAIL_HTTPS_ENABLED` | false | Enable HTTPS |

--- a/README.ko.md
+++ b/README.ko.md
@@ -199,6 +199,10 @@ docker buildx build \
 | `-web` | `MAILDEV_WEB_PORT` / `OWLMAIL_WEB_PORT` | 1080 | Web API port |
 | `-web-ip` | `MAILDEV_WEB_IP` / `OWLMAIL_WEB_HOST` | localhost | Web API host |
 | `-mail-directory` | `MAILDEV_MAIL_DIRECTORY` / `OWLMAIL_MAIL_DIR` | - | Mail storage directory |
+| `-mail-retention-days` | `OWLMAIL_MAIL_RETENTION_DAYS` | 0 | Mail retention days; `0` is unlimited |
+| `-mail-max-messages` | `OWLMAIL_MAIL_MAX_MESSAGES` | 0 | Maximum stored messages; `0` is unlimited |
+| `-mail-max-disk-mb` | `OWLMAIL_MAIL_MAX_DISK_MB` | 0 | Maximum mailbox MiB; `0` is unlimited |
+| `-mail-cleanup-interval` | `OWLMAIL_MAIL_CLEANUP_INTERVAL` | 1h | Background cleanup interval |
 | `-web-user` | `MAILDEV_WEB_USER` / `OWLMAIL_WEB_USER` | - | HTTP Basic Auth username |
 | `-web-password` | `MAILDEV_WEB_PASS` / `OWLMAIL_WEB_PASSWORD` | - | HTTP Basic Auth password |
 | `-https` | `MAILDEV_HTTPS` / `OWLMAIL_HTTPS_ENABLED` | false | Enable HTTPS |

--- a/README.md
+++ b/README.md
@@ -222,6 +222,10 @@ the message body; clicking one focuses OwlMail and opens the message.
 | `-web` | `MAILDEV_WEB_PORT` / `OWLMAIL_WEB_PORT` | 1080 | Web API port |
 | `-web-ip` | `MAILDEV_WEB_IP` / `OWLMAIL_WEB_HOST` | localhost | Web API host |
 | `-mail-directory` | `MAILDEV_MAIL_DIRECTORY` / `OWLMAIL_MAIL_DIR` | - | Mail storage directory |
+| `-mail-retention-days` | `OWLMAIL_MAIL_RETENTION_DAYS` | 0 | Mail retention days; `0` is unlimited |
+| `-mail-max-messages` | `OWLMAIL_MAIL_MAX_MESSAGES` | 0 | Maximum stored messages; `0` is unlimited |
+| `-mail-max-disk-mb` | `OWLMAIL_MAIL_MAX_DISK_MB` | 0 | Maximum mailbox MiB; `0` is unlimited |
+| `-mail-cleanup-interval` | `OWLMAIL_MAIL_CLEANUP_INTERVAL` | 1h | Background cleanup interval |
 | `-web-user` | `MAILDEV_WEB_USER` / `OWLMAIL_WEB_USER` | - | HTTP Basic Auth username |
 | `-web-password` | `MAILDEV_WEB_PASS` / `OWLMAIL_WEB_PASSWORD` | - | HTTP Basic Auth password |
 | `-https` | `MAILDEV_HTTPS` / `OWLMAIL_HTTPS_ENABLED` | false | Enable HTTPS |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -215,6 +215,10 @@ Notifications API 需要 HTTPS，或 `http://localhost` 等受信任的本地来
 | `-web` | `MAILDEV_WEB_PORT` / `OWLMAIL_WEB_PORT` | 1080 | Web API 端口 |
 | `-web-ip` | `MAILDEV_WEB_IP` / `OWLMAIL_WEB_HOST` | localhost | Web API 主机 |
 | `-mail-directory` | `MAILDEV_MAIL_DIRECTORY` / `OWLMAIL_MAIL_DIR` | - | 邮件存储目录 |
+| `-mail-retention-days` | `OWLMAIL_MAIL_RETENTION_DAYS` | 0 | 删除超过 N 天的邮件；`0` 表示不限 |
+| `-mail-max-messages` | `OWLMAIL_MAIL_MAX_MESSAGES` | 0 | 最大邮件封数；`0` 表示不限 |
+| `-mail-max-disk-mb` | `OWLMAIL_MAIL_MAX_DISK_MB` | 0 | 邮箱最大磁盘 MiB；`0` 表示不限 |
+| `-mail-cleanup-interval` | `OWLMAIL_MAIL_CLEANUP_INTERVAL` | 1h | 后台保留策略清理间隔 |
 | `-web-user` | `MAILDEV_WEB_USER` / `OWLMAIL_WEB_USER` | - | HTTP Basic Auth 用户名 |
 | `-web-password` | `MAILDEV_WEB_PASS` / `OWLMAIL_WEB_PASSWORD` | - | HTTP Basic Auth 密码 |
 | `-https` | `MAILDEV_HTTPS` / `OWLMAIL_HTTPS_ENABLED` | false | 启用 HTTPS |

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -133,6 +133,26 @@ func setupTLSConfig(cfg *config.Config) *mailserver.TLSConfig {
 	}
 }
 
+func setupStoragePolicy(cfg *config.Config) (mailserver.StoragePolicy, error) {
+	if cfg == nil {
+		return mailserver.StoragePolicy{}, fmt.Errorf("config is nil")
+	}
+	interval := cfg.MailCleanupInterval
+	if interval == "" {
+		interval = config.DefaultMailCleanupInterval
+	}
+	cleanupInterval, err := time.ParseDuration(interval)
+	if err != nil || cleanupInterval <= 0 {
+		return mailserver.StoragePolicy{}, fmt.Errorf("invalid mail cleanup interval %q", interval)
+	}
+	return mailserver.StoragePolicy{
+		MaxAge:          time.Duration(cfg.MailRetentionDays) * 24 * time.Hour,
+		MaxMessages:     cfg.MailMaxMessages,
+		MaxDiskBytes:    int64(cfg.MailMaxDiskMB) * 1024 * 1024,
+		CleanupInterval: cleanupInterval,
+	}, nil
+}
+
 // registerEventHandlers registers event handlers for the mail server
 func registerEventHandlers(server *mailserver.MailServer) {
 	if server == nil {
@@ -357,6 +377,15 @@ func createMailServer(cfg *config.Config) (*mailserver.MailServer, error) {
 	server, err := mailserver.NewMailServerWithFullConfig(cfg.SMTPPort, cfg.SMTPHost, cfg.MailDir, outgoingConfig, authConfig, tlsConfig, cfg.UseUUIDForEmailID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create mail server: %w", err)
+	}
+	storagePolicy, err := setupStoragePolicy(cfg)
+	if err != nil {
+		_ = server.Close()
+		return nil, err
+	}
+	if err := server.ConfigureStoragePolicy(storagePolicy); err != nil {
+		_ = server.Close()
+		return nil, fmt.Errorf("configure storage policy: %w", err)
 	}
 
 	// Register event handlers

--- a/docs/en/Operations.md
+++ b/docs/en/Operations.md
@@ -5,6 +5,28 @@ readiness, persistence, webhook capacity, shutdown behavior, and common failure
 modes. See the [API Reference](./API-Reference.md) and
 [Webhook Forwarding](./Webhook-Forwarding.md) for protocol details.
 
+## Mailbox retention and state
+
+OwlMail can enforce age, message-count, and disk-usage limits together:
+
+```bash
+owlmail \
+  -mail-retention-days 14 \
+  -mail-max-messages 10000 \
+  -mail-max-disk-mb 2048 \
+  -mail-cleanup-interval 10m
+```
+
+Zero disables an individual limit. Cleanup runs once at startup and then in
+the background. It removes the oldest messages until every configured limit is
+met. The existing email stats response includes current disk bytes, configured
+limits, cleanup runs, deleted messages, reclaimed bytes, and the last error.
+
+Read state is stored atomically in `.owlmail-meta/<id>.json`; legacy messages
+without metadata recover as unread. ZIP export is streamed to the client and is
+bounded to 1,000 source messages and 256 MiB of raw EML data, avoiding a second
+mailbox-sized in-memory buffer.
+
 ## Deployment profiles
 
 ### 1. Minimal local inbox

--- a/docs/zh-CN/Operations.md
+++ b/docs/zh-CN/Operations.md
@@ -4,6 +4,26 @@
 关闭行为和常见故障。协议细节见 [API 参考](./API-Reference.md)与
 [Webhook 消息转发](./Webhook-Forwarding.md)。
 
+## 邮箱保留策略与状态
+
+OwlMail 可以同时限制邮件年龄、封数和磁盘占用：
+
+```bash
+owlmail \
+  -mail-retention-days 14 \
+  -mail-max-messages 10000 \
+  -mail-max-disk-mb 2048 \
+  -mail-cleanup-interval 10m
+```
+
+单项设置为零表示不限制。服务会在启动时执行一次清理，之后由后台任务定期删除
+最旧邮件，直到全部限制都满足。现有邮件统计响应会包含磁盘字节数、限制值、清理
+次数、删除封数、回收字节数和最近错误。
+
+已读状态通过 `.owlmail-meta/<id>.json` 原子保存；没有元数据的旧邮件在恢复时保持
+未读。ZIP 导出直接流式写给客户端，并限制为最多 1,000 个源邮件及 256 MiB 原始
+EML 数据，避免再创建一个邮箱规模的内存缓冲区。
+
 ## 部署场景
 
 ### 1. 最简本地收件箱

--- a/internal/api/api_emails.go
+++ b/internal/api/api_emails.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"archive/zip"
-	"bytes"
+	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -14,6 +14,11 @@ import (
 	"github.com/gofiber/fiber/v3"
 	"github.com/soulteary/owlmail/internal/common"
 	"github.com/soulteary/owlmail/internal/types"
+)
+
+const (
+	maxExportMessages = 1000
+	maxExportBytes    = 256 << 20
 )
 
 // EmailPreview represents a lightweight email preview
@@ -182,7 +187,10 @@ func (api *API) deleteAllEmails(c fiber.Ctx) error {
 
 // readAllEmails handles PATCH /api/v1/emails/read
 func (api *API) readAllEmails(c fiber.Ctx) error {
-	count := api.mailServer.ReadAllEmail()
+	count, err := api.mailServer.ReadAllEmail()
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse(ErrorCodeInvalidRequest, err.Error()))
+	}
 	return c.JSON(SuccessResponse(SuccessCodeAllEmailsMarkedRead, "All emails marked as read", fiber.Map{"count": count}))
 }
 
@@ -426,43 +434,58 @@ func (api *API) exportEmails(c fiber.Ctx) error {
 	if len(filtered) == 0 {
 		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse(ErrorCodeNoEmailsToExport, "No emails found to export"))
 	}
-
-	var buf bytes.Buffer
-	zipWriter := zip.NewWriter(&buf)
-
+	if len(filtered) > maxExportMessages {
+		return c.Status(fiber.StatusRequestEntityTooLarge).JSON(ErrorResponse(ErrorCodeInvalidRequest, fmt.Sprintf("Export is limited to %d emails", maxExportMessages)))
+	}
+	type exportItem struct {
+		email *types.Email
+		path  string
+	}
+	items := make([]exportItem, 0, len(filtered))
+	var totalBytes int64
 	for _, email := range filtered {
 		emlPath, err := api.mailServer.GetRawEmail(email.ID)
 		if err != nil {
 			continue
 		}
-
-		emailFile, err := os.Open(emlPath)
+		stat, err := os.Stat(emlPath)
 		if err != nil {
 			continue
 		}
-
-		filename := fmt.Sprintf("%s_%s.eml", email.ID, sanitizeFilename(email.Subject))
-		fileWriter, err := zipWriter.Create(filename)
-		if err != nil {
-			_ = emailFile.Close()
-			continue
+		totalBytes += stat.Size()
+		if totalBytes > maxExportBytes {
+			return c.Status(fiber.StatusRequestEntityTooLarge).JSON(ErrorResponse(ErrorCodeInvalidRequest, fmt.Sprintf("Export source is limited to %d bytes", maxExportBytes)))
 		}
-
-		_, err = io.Copy(fileWriter, emailFile)
-		_ = emailFile.Close()
-		if err != nil {
-			continue
-		}
+		items = append(items, exportItem{email: email, path: emlPath})
 	}
-
-	if err := zipWriter.Close(); err != nil {
-		common.Verbose("Failed to close zip writer: %v", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse(ErrorCodeInvalidRequest, "Failed to create export"))
+	if len(items) == 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse(ErrorCodeNoEmailsToExport, "No readable emails found to export"))
 	}
 
 	c.Set("Content-Type", "application/zip")
 	c.Set("Content-Disposition", fmt.Sprintf("attachment; filename=emails_%s.zip", time.Now().Format("20060102_150405")))
-	return c.Send(buf.Bytes())
+	return c.SendStreamWriter(func(writer *bufio.Writer) {
+		zipWriter := zip.NewWriter(writer)
+		for _, item := range items {
+			emailFile, err := os.Open(item.path)
+			if err != nil {
+				common.Verbose("Failed to open email during export: %v", err)
+				continue
+			}
+			filename := fmt.Sprintf("%s_%s.eml", item.email.ID, sanitizeFilename(item.email.Subject))
+			fileWriter, err := zipWriter.Create(filename)
+			if err == nil {
+				_, err = io.Copy(fileWriter, emailFile)
+			}
+			_ = emailFile.Close()
+			if err != nil {
+				common.Verbose("Failed to stream email into export: %v", err)
+			}
+		}
+		if err := zipWriter.Close(); err != nil {
+			common.Verbose("Failed to finish ZIP export: %v", err)
+		}
+	})
 }
 
 // applyEmailFilters applies filters to email list

--- a/internal/api/api_emails_test.go
+++ b/internal/api/api_emails_test.go
@@ -312,6 +312,40 @@ func TestAPIReadAllEmails(t *testing.T) {
 	}
 }
 
+func TestAPIReadAllEmailsReportsPersistenceFailure(t *testing.T) {
+	api, server, tmpDir := setupTestAPI(t)
+	defer func() { _ = server.Close() }()
+
+	id := "read-failure"
+	if err := os.WriteFile(filepath.Join(tmpDir, id+".eml"), []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.SaveEmailToStore(id, false, &types.Envelope{To: []string{"to@example.com"}}, &types.Email{Subject: id}); err != nil {
+		t.Fatal(err)
+	}
+	metadataDir := filepath.Join(tmpDir, ".owlmail-meta")
+	if err := os.RemoveAll(metadataDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(metadataDir, []byte("blocks metadata directory"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	req, _ := http.NewRequest(http.MethodPatch, "/api/v1/emails/read", nil)
+	resp, err := api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusInternalServerError)
+	}
+	email, err := server.GetEmail(id)
+	if err != nil || email.Read {
+		t.Fatalf("failed read update became visible: %#v, %v", email, err)
+	}
+}
+
 func TestAPIGetEmailStats(t *testing.T) {
 	api, server, tmpDir := setupTestAPI(t)
 	defer func() {
@@ -2722,6 +2756,36 @@ func TestAPIExportEmailsWithNonExistentIDs(t *testing.T) {
 	// Should return 400 (no emails found)
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("Expected status 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestAPIExportEmailsRejectsOversizedSourceBeforeStreaming(t *testing.T) {
+	api, server, tmpDir := setupTestAPI(t)
+	defer func() { _ = server.Close() }()
+	emlPath := filepath.Join(tmpDir, "large.eml")
+	file, err := os.Create(emlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Truncate(maxExportBytes + 1); err != nil {
+		_ = file.Close()
+		t.Fatal(err)
+	}
+	_ = file.Close()
+	if err := server.SaveEmailToStore("large", false, &types.Envelope{To: []string{"to@example.test"}}, &types.Email{Subject: "large"}); err != nil {
+		t.Fatal(err)
+	}
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/emails/export?ids=large", nil)
+	resp, err := api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusRequestEntityTooLarge)
+	}
+	if contentType := resp.Header.Get("Content-Type"); !strings.Contains(contentType, "application/json") {
+		t.Fatalf("Content-Type = %q, want JSON preflight error", contentType)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,9 @@ import (
 	"github.com/soulteary/cli-kit/flagutil"
 )
 
+// DefaultMailCleanupInterval balances prompt retention with filesystem load.
+const DefaultMailCleanupInterval = "1h"
+
 // DefaultWebhookMaxConcurrency is the recommended concurrent email delivery
 // limit. Zero remains available as an explicit unlimited mode.
 const DefaultWebhookMaxConcurrency = 8
@@ -191,9 +194,13 @@ func ResolveLogLevel(fs *flag.FlagSet, flagName, defaultValue string) string {
 // Config holds all application configuration
 type Config struct {
 	// SMTP server configuration
-	SMTPPort int
-	SMTPHost string
-	MailDir  string
+	SMTPPort            int
+	SMTPHost            string
+	MailDir             string
+	MailRetentionDays   int
+	MailMaxMessages     int
+	MailMaxDiskMB       int
+	MailCleanupInterval string
 
 	// Web API configuration
 	WebPort           int
@@ -246,6 +253,10 @@ func DefaultConfig() *Config {
 		SMTPPort:               1025,
 		SMTPHost:               "localhost",
 		MailDir:                "",
+		MailRetentionDays:      0,
+		MailMaxMessages:        0,
+		MailMaxDiskMB:          0,
+		MailCleanupInterval:    DefaultMailCleanupInterval,
 		WebPort:                1080,
 		WebHost:                "localhost",
 		WebUser:                "",
@@ -282,6 +293,10 @@ type FlagRefs struct {
 	SMTPPort               *int
 	SMTPHost               *string
 	MailDir                *string
+	MailRetentionDays      *int
+	MailMaxMessages        *int
+	MailMaxDiskMB          *int
+	MailCleanupInterval    *string
 	WebPort                *int
 	WebHost                *string
 	WebUser                *string
@@ -319,6 +334,10 @@ func DefineFlags(fs *flag.FlagSet) *FlagRefs {
 		SMTPPort:               fs.Int("smtp", cfg.SMTPPort, "SMTP port to catch emails"),
 		SMTPHost:               fs.String("ip", cfg.SMTPHost, "IP address to bind SMTP service to"),
 		MailDir:                fs.String("mail-directory", cfg.MailDir, "Directory for persisting mails"),
+		MailRetentionDays:      fs.Int("mail-retention-days", cfg.MailRetentionDays, "Delete mail older than this many days (0 = unlimited)"),
+		MailMaxMessages:        fs.Int("mail-max-messages", cfg.MailMaxMessages, "Maximum stored message count (0 = unlimited)"),
+		MailMaxDiskMB:          fs.Int("mail-max-disk-mb", cfg.MailMaxDiskMB, "Maximum mailbox disk usage in MiB (0 = unlimited)"),
+		MailCleanupInterval:    fs.String("mail-cleanup-interval", cfg.MailCleanupInterval, "Storage cleanup interval"),
 		WebPort:                fs.Int("web", cfg.WebPort, "Web API port"),
 		WebHost:                fs.String("web-ip", cfg.WebHost, "IP address to bind Web API to"),
 		WebUser:                fs.String("web-user", cfg.WebUser, "HTTP Basic Auth username"),
@@ -354,9 +373,13 @@ func DefineFlags(fs *flag.FlagSet) *FlagRefs {
 // Priority: CLI flags > MAILDEV_* env > OWLMAIL_* env > default values
 func ResolveConfig(fs *flag.FlagSet, refs *FlagRefs) *Config {
 	return &Config{
-		SMTPPort: resolveIntWithFlag(fs, "smtp", "OWLMAIL_SMTP_PORT", *refs.SMTPPort),
-		SMTPHost: resolveStringWithFlag(fs, "ip", "OWLMAIL_SMTP_HOST", *refs.SMTPHost),
-		MailDir:  resolveStringWithFlag(fs, "mail-directory", "OWLMAIL_MAIL_DIR", *refs.MailDir),
+		SMTPPort:            resolveIntWithFlag(fs, "smtp", "OWLMAIL_SMTP_PORT", *refs.SMTPPort),
+		SMTPHost:            resolveStringWithFlag(fs, "ip", "OWLMAIL_SMTP_HOST", *refs.SMTPHost),
+		MailDir:             resolveStringWithFlag(fs, "mail-directory", "OWLMAIL_MAIL_DIR", *refs.MailDir),
+		MailRetentionDays:   resolveIntWithFlag(fs, "mail-retention-days", "OWLMAIL_MAIL_RETENTION_DAYS", *refs.MailRetentionDays),
+		MailMaxMessages:     resolveIntWithFlag(fs, "mail-max-messages", "OWLMAIL_MAIL_MAX_MESSAGES", *refs.MailMaxMessages),
+		MailMaxDiskMB:       resolveIntWithFlag(fs, "mail-max-disk-mb", "OWLMAIL_MAIL_MAX_DISK_MB", *refs.MailMaxDiskMB),
+		MailCleanupInterval: resolveStringWithFlag(fs, "mail-cleanup-interval", "OWLMAIL_MAIL_CLEANUP_INTERVAL", *refs.MailCleanupInterval),
 
 		WebPort:           resolveIntWithFlag(fs, "web", "OWLMAIL_WEB_PORT", *refs.WebPort),
 		WebHost:           resolveStringWithFlag(fs, "web-ip", "OWLMAIL_WEB_HOST", *refs.WebHost),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -280,6 +280,9 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.WebhookMaxConcurrency != 8 {
 		t.Errorf("DefaultConfig().WebhookMaxConcurrency = %d, want 8", cfg.WebhookMaxConcurrency)
 	}
+	if cfg.MailRetentionDays != 0 || cfg.MailMaxMessages != 0 || cfg.MailMaxDiskMB != 0 || cfg.MailCleanupInterval != "1h" {
+		t.Errorf("unexpected default storage policy: %#v", cfg)
+	}
 	if cfg.WebhookRedisURL != "" || cfg.WebhookRedisPrefix != "owlmail:webhooks" || cfg.WebhookShutdownTimeout != "15s" {
 		t.Errorf("unexpected default webhook queue config: %#v", cfg)
 	}

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -32,6 +32,13 @@ func ValidateConfig(cfg *Config) error {
 	if cfg.WebExternalScheme != "" && cfg.WebExternalScheme != "http" && cfg.WebExternalScheme != "https" {
 		return fmt.Errorf("web external scheme must be http or https")
 	}
+	if cfg.MailRetentionDays < 0 || cfg.MailMaxMessages < 0 || cfg.MailMaxDiskMB < 0 {
+		return fmt.Errorf("mail retention limits cannot be negative")
+	}
+	cleanupInterval, err := time.ParseDuration(cfg.MailCleanupInterval)
+	if err != nil || cleanupInterval <= 0 {
+		return fmt.Errorf("mail cleanup interval must be a positive duration")
+	}
 
 	// Validate log level
 	if err := ValidateLogLevel(cfg.LogLevel); err != nil {

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -226,6 +226,19 @@ func TestValidateConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("invalid storage policy", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.MailMaxMessages = -1
+		if err := ValidateConfig(cfg); err == nil {
+			t.Error("negative mail max messages should fail")
+		}
+		cfg = DefaultConfig()
+		cfg.MailCleanupInterval = "never"
+		if err := ValidateConfig(cfg); err == nil {
+			t.Error("invalid mail cleanup interval should fail")
+		}
+	})
+
 	t.Run("invalid webhook drain settings", func(t *testing.T) {
 		cfg := DefaultConfig()
 		cfg.WebhookShutdownTimeout = "never"

--- a/internal/mailserver/config.go
+++ b/internal/mailserver/config.go
@@ -46,16 +46,17 @@ func NewMailServerWithFullConfig(port int, host, mailDir string, outgoingConfig 
 	}
 
 	ms := &MailServer{
-		storeByID:    make(map[string]*types.Email),
-		storeOrder:   make([]string, 0),
-		mailDir:      mailDir,
-		port:         port,
-		host:         host,
-		eventChan:    make(chan Event, 100),
-		listeners:    make(map[string][]eventListener),
-		authConfig:   authConfig,
-		tlsConfig:    tlsConfig,
-		useUUIDForID: useUUIDForID,
+		storeByID:      make(map[string]*types.Email),
+		storeOrder:     make([]string, 0),
+		receivedAtByID: make(map[string]time.Time),
+		mailDir:        mailDir,
+		port:           port,
+		host:           host,
+		eventChan:      make(chan Event, 100),
+		listeners:      make(map[string][]eventListener),
+		authConfig:     authConfig,
+		tlsConfig:      tlsConfig,
+		useUUIDForID:   useUUIDForID,
 	}
 
 	// Setup outgoing mail if config provided

--- a/internal/mailserver/lifecycle.go
+++ b/internal/mailserver/lifecycle.go
@@ -61,6 +61,10 @@ func (ms *MailServer) Close() error {
 	if err := ms.smtpServer.Close(); err != nil {
 		closeErrors = append(closeErrors, err)
 	}
+	if ms.cleanupCancel != nil {
+		ms.cleanupCancel()
+		ms.cleanupWG.Wait()
+	}
 
 	ms.closersMutex.Lock()
 	closers := append([]io.Closer(nil), ms.closers...)

--- a/internal/mailserver/mailserver_store_test.go
+++ b/internal/mailserver/mailserver_store_test.go
@@ -408,7 +408,10 @@ func TestMailServerReadAllEmail(t *testing.T) {
 	}
 
 	// Mark all as read
-	count := server.ReadAllEmail()
+	count, err := server.ReadAllEmail()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if count != 2 {
 		t.Errorf("Expected 2 emails marked as read, got %d", count)
 	}
@@ -1203,7 +1206,10 @@ func TestReadAllEmailWithMixedReadStatus(t *testing.T) {
 	}
 
 	// Mark all as read
-	count := server.ReadAllEmail()
+	count, err := server.ReadAllEmail()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if count != 2 {
 		t.Errorf("Expected 2 emails marked as read, got %d", count)
 	}

--- a/internal/mailserver/storage_governance.go
+++ b/internal/mailserver/storage_governance.go
@@ -1,0 +1,315 @@
+package mailserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"time"
+
+	"github.com/soulteary/owlmail/internal/common"
+)
+
+const metadataDirectoryName = ".owlmail-meta"
+
+// StoragePolicy bounds the on-disk and in-memory mailbox.
+type StoragePolicy struct {
+	MaxAge          time.Duration
+	MaxMessages     int
+	MaxDiskBytes    int64
+	CleanupInterval time.Duration
+}
+
+// StorageMetrics reports retention activity through the existing stats API.
+type StorageMetrics struct {
+	CleanupRuns      uint64    `json:"cleanupRuns"`
+	DeletedMessages  uint64    `json:"deletedMessages"`
+	ReclaimedBytes   uint64    `json:"reclaimedBytes"`
+	LastCleanupAt    time.Time `json:"lastCleanupAt,omitempty"`
+	LastCleanupError string    `json:"lastCleanupError,omitempty"`
+}
+
+type emailMetadata struct {
+	Version  int       `json:"version"`
+	ID       string    `json:"id"`
+	Read     bool      `json:"read"`
+	Sequence time.Time `json:"sequence"`
+}
+
+// ConfigureStoragePolicy applies limits immediately and starts periodic cleanup.
+func (ms *MailServer) ConfigureStoragePolicy(policy StoragePolicy) error {
+	if policy.MaxAge < 0 || policy.MaxMessages < 0 || policy.MaxDiskBytes < 0 {
+		return fmt.Errorf("storage limits cannot be negative")
+	}
+	if policy.CleanupInterval <= 0 {
+		return fmt.Errorf("cleanup interval must be positive")
+	}
+	if ms.cleanupCancel != nil {
+		ms.cleanupCancel()
+		ms.cleanupWG.Wait()
+		ms.cleanupCancel = nil
+	}
+	ms.storagePolicy = policy
+	if err := ms.CleanupStorage(); err != nil {
+		return err
+	}
+	if policy.MaxAge == 0 && policy.MaxMessages == 0 && policy.MaxDiskBytes == 0 {
+		return nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	ms.cleanupCancel = cancel
+	ms.cleanupWG.Add(1)
+	go func() {
+		defer ms.cleanupWG.Done()
+		ticker := time.NewTicker(policy.CleanupInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := ms.CleanupStorage(); err != nil {
+					common.Error("Storage cleanup failed: %v", err)
+				}
+			}
+		}
+	}()
+	return nil
+}
+
+// CleanupStorage removes oldest messages until every configured limit is met.
+func (ms *MailServer) CleanupStorage() error {
+	emails := ms.GetAllEmail()
+	type candidate struct {
+		id   string
+		size int64
+		time time.Time
+	}
+	items := make([]candidate, 0, len(emails))
+	var totalBytes int64
+	for _, email := range emails {
+		size, err := ms.emailDiskUsage(email.ID)
+		if err != nil {
+			ms.recordCleanup(0, 0, err)
+			return err
+		}
+		items = append(items, candidate{id: email.ID, size: size, time: ms.receivedAt(email.ID)})
+		totalBytes += size
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].time.Equal(items[j].time) {
+			return items[i].id < items[j].id
+		}
+		return items[i].time.Before(items[j].time)
+	})
+
+	remove := make(map[string]candidate)
+	if ms.storagePolicy.MaxAge > 0 {
+		cutoff := time.Now().Add(-ms.storagePolicy.MaxAge)
+		for _, item := range items {
+			if item.time.Before(cutoff) {
+				remove[item.id] = item
+				totalBytes -= item.size
+			}
+		}
+	}
+	remaining := len(items) - len(remove)
+	for _, item := range items {
+		if _, selected := remove[item.id]; selected {
+			continue
+		}
+		overCount := ms.storagePolicy.MaxMessages > 0 && remaining > ms.storagePolicy.MaxMessages
+		overDisk := ms.storagePolicy.MaxDiskBytes > 0 && totalBytes > ms.storagePolicy.MaxDiskBytes
+		if !overCount && !overDisk {
+			break
+		}
+		remove[item.id] = item
+		remaining--
+		totalBytes -= item.size
+	}
+
+	var deleted uint64
+	var reclaimed uint64
+	for _, item := range items {
+		if _, selected := remove[item.id]; !selected {
+			continue
+		}
+		if err := ms.DeleteEmail(item.id); err != nil {
+			ms.recordCleanup(deleted, reclaimed, err)
+			return err
+		}
+		deleted++
+		reclaimed += uint64(item.size)
+	}
+	ms.recordCleanup(deleted, reclaimed, nil)
+	return nil
+}
+
+func (ms *MailServer) recordCleanup(deleted, reclaimed uint64, cleanupErr error) {
+	ms.storageMetricsMutex.Lock()
+	defer ms.storageMetricsMutex.Unlock()
+	ms.storageMetrics.CleanupRuns++
+	ms.storageMetrics.DeletedMessages += deleted
+	ms.storageMetrics.ReclaimedBytes += reclaimed
+	ms.storageMetrics.LastCleanupAt = time.Now().UTC()
+	if cleanupErr != nil {
+		ms.storageMetrics.LastCleanupError = cleanupErr.Error()
+	} else {
+		ms.storageMetrics.LastCleanupError = ""
+	}
+}
+
+func (ms *MailServer) storageStats() map[string]interface{} {
+	ms.storageMetricsMutex.RLock()
+	metrics := ms.storageMetrics
+	ms.storageMetricsMutex.RUnlock()
+	diskBytes, _ := ms.mailboxDiskUsage()
+	return map[string]interface{}{
+		"diskBytes": diskBytes, "maxAgeSeconds": int64(ms.storagePolicy.MaxAge.Seconds()),
+		"maxMessages": ms.storagePolicy.MaxMessages, "maxDiskBytes": ms.storagePolicy.MaxDiskBytes,
+		"cleanupRuns": metrics.CleanupRuns, "deletedMessages": metrics.DeletedMessages,
+		"reclaimedBytes": metrics.ReclaimedBytes, "lastCleanupAt": metrics.LastCleanupAt,
+		"lastCleanupError": metrics.LastCleanupError,
+	}
+}
+
+func (ms *MailServer) mailboxDiskUsage() (int64, error) {
+	emails := ms.GetAllEmail()
+	var total int64
+	for _, email := range emails {
+		size, err := ms.emailDiskUsage(email.ID)
+		if err != nil {
+			return 0, err
+		}
+		total += size
+	}
+	return total, nil
+}
+
+func (ms *MailServer) emailDiskUsage(id string) (int64, error) {
+	var total int64
+	if stat, err := os.Stat(filepath.Join(ms.mailDir, id+".eml")); err == nil {
+		total += stat.Size()
+	} else if !os.IsNotExist(err) {
+		return 0, err
+	}
+	if stat, err := os.Stat(ms.metadataPath(id)); err == nil {
+		total += stat.Size()
+	} else if !os.IsNotExist(err) {
+		return 0, err
+	}
+	attachmentDir := filepath.Join(ms.mailDir, id)
+	err := filepath.WalkDir(attachmentDir, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !entry.IsDir() {
+			stat, err := entry.Info()
+			if err != nil {
+				return err
+			}
+			total += stat.Size()
+		}
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		return 0, err
+	}
+	return total, nil
+}
+
+func (ms *MailServer) metadataPath(id string) string {
+	return filepath.Join(ms.mailDir, metadataDirectoryName, id+".json")
+}
+
+func (ms *MailServer) receivedAt(id string) time.Time {
+	ms.storeMutex.RLock()
+	receivedAt := ms.receivedAtByID[id]
+	ms.storeMutex.RUnlock()
+	if receivedAt.IsZero() {
+		return time.Now().UTC()
+	}
+	return receivedAt
+}
+
+func (ms *MailServer) persistEmailMetadata(email *Email) error {
+	if email == nil {
+		return nil
+	}
+	return ms.persistEmailMetadataAt(email, ms.receivedAt(email.ID))
+}
+
+func (ms *MailServer) persistEmailMetadataAt(email *Email, receivedAt time.Time) error {
+	if email == nil {
+		return nil
+	}
+	dir := filepath.Join(ms.mailDir, metadataDirectoryName)
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return err
+	}
+	metadata := emailMetadata{Version: 1, ID: email.ID, Read: email.Read, Sequence: receivedAt}
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".state-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if _, err := tmp.Write(encoded); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, ms.metadataPath(email.ID)); err != nil {
+		return err
+	}
+	return syncStorageDirectory(dir)
+}
+
+func (ms *MailServer) loadEmailMetadata(id string) (emailMetadata, error) {
+	encoded, err := os.ReadFile(ms.metadataPath(id))
+	if err != nil {
+		return emailMetadata{}, err
+	}
+	var metadata emailMetadata
+	if err := json.Unmarshal(encoded, &metadata); err != nil {
+		return emailMetadata{}, err
+	}
+	if metadata.Version != 1 || metadata.ID != id {
+		return emailMetadata{}, fmt.Errorf("invalid metadata for %s", id)
+	}
+	return metadata, nil
+}
+
+func (ms *MailServer) deleteEmailMetadata(id string) error {
+	err := os.Remove(ms.metadataPath(id))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+func syncStorageDirectory(path string) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	dir, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = dir.Close() }()
+	return dir.Sync()
+}

--- a/internal/mailserver/storage_governance_test.go
+++ b/internal/mailserver/storage_governance_test.go
@@ -1,0 +1,311 @@
+package mailserver
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const governanceTestMessage = "From: sender@example.test\r\nTo: receiver@example.test\r\nSubject: persisted\r\n\r\nbody\r\n"
+
+func TestReadStatePersistsAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "persisted.eml"), []byte(governanceTestMessage), 0644); err != nil {
+		t.Fatal(err)
+	}
+	server, err := NewMailServer(1025, "localhost", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	email, err := server.GetEmail("persisted")
+	if err != nil || email.Read {
+		t.Fatalf("legacy restored email = %#v, %v; want unread", email, err)
+	}
+	if err := server.ReadEmail("persisted"); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	restarted, err := NewMailServer(1025, "localhost", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = restarted.Close() }()
+	email, err = restarted.GetEmail("persisted")
+	if err != nil || !email.Read {
+		t.Fatalf("restarted email = %#v, %v; want read", email, err)
+	}
+	entries, err := os.ReadDir(filepath.Join(dir, metadataDirectoryName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if filepath.Ext(entry.Name()) == ".tmp" {
+			t.Fatalf("temporary metadata was left behind: %s", entry.Name())
+		}
+	}
+}
+
+func TestStoragePolicyEnforcesOldestMessageCount(t *testing.T) {
+	server, err := NewMailServer(1025, "localhost", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	for i, id := range []string{"oldest", "middle", "newest"} {
+		if err := os.WriteFile(filepath.Join(server.mailDir, id+".eml"), []byte(governanceTestMessage), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := server.SaveEmailToStore(id, false, &Envelope{To: []string{"receiver@example.test"}}, &Email{Subject: id}); err != nil {
+			t.Fatal(err)
+		}
+		if i < 2 {
+			time.Sleep(2 * time.Millisecond)
+		}
+	}
+	if err := server.ConfigureStoragePolicy(StoragePolicy{MaxMessages: 2, CleanupInterval: time.Hour}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.GetEmail("oldest"); err == nil {
+		t.Fatal("oldest message was not evicted")
+	}
+	if got := len(server.GetAllEmail()); got != 2 {
+		t.Fatalf("message count = %d, want 2", got)
+	}
+	stats := server.GetEmailStats()["storage"].(map[string]interface{})
+	if stats["deletedMessages"].(uint64) != 1 {
+		t.Fatalf("storage metrics = %#v", stats)
+	}
+}
+
+func TestStoragePolicyUsesArrivalOrderInsteadOfMessageDate(t *testing.T) {
+	server, err := NewMailServer(1025, "localhost", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	for i, test := range []struct {
+		id      string
+		message time.Time
+	}{
+		{id: "arrived-first", message: time.Now().Add(24 * time.Hour)},
+		{id: "arrived-last", message: time.Now().Add(-24 * time.Hour)},
+	} {
+		if err := os.WriteFile(filepath.Join(server.mailDir, test.id+".eml"), []byte(governanceTestMessage), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := server.SaveEmailToStore(test.id, false, &Envelope{To: []string{"receiver@example.test"}}, &Email{Subject: test.id, Time: test.message}); err != nil {
+			t.Fatal(err)
+		}
+		if i == 0 {
+			time.Sleep(2 * time.Millisecond)
+		}
+	}
+
+	if err := server.ConfigureStoragePolicy(StoragePolicy{MaxMessages: 1, CleanupInterval: time.Hour}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.GetEmail("arrived-first"); err == nil {
+		t.Fatal("first-arriving message was not evicted")
+	}
+	if _, err := server.GetEmail("arrived-last"); err != nil {
+		t.Fatalf("last-arriving message was evicted: %v", err)
+	}
+}
+
+func TestStoragePolicyUsesArrivalTimeForAge(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "old.eml")
+	if err := os.WriteFile(path, []byte(governanceTestMessage), 0644); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-72 * time.Hour)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+	server, err := NewMailServer(1025, "localhost", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	if err := server.ConfigureStoragePolicy(StoragePolicy{MaxAge: 24 * time.Hour, CleanupInterval: time.Hour}); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(server.GetAllEmail()); got != 0 {
+		t.Fatalf("message count = %d, want 0", got)
+	}
+}
+
+func TestStoragePolicyEnforcesDiskLimit(t *testing.T) {
+	server, err := NewMailServer(1025, "localhost", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	for _, id := range []string{"disk-old", "disk-new"} {
+		if err := os.WriteFile(filepath.Join(server.mailDir, id+".eml"), []byte(governanceTestMessage), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := server.SaveEmailToStore(id, false, &Envelope{To: []string{"receiver@example.test"}}, &Email{Subject: id}); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	newestUsage, err := server.emailDiskUsage("disk-new")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.ConfigureStoragePolicy(StoragePolicy{
+		MaxDiskBytes: newestUsage, CleanupInterval: time.Hour,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(server.GetAllEmail()); got != 1 {
+		t.Fatalf("message count after disk cleanup = %d, want 1", got)
+	}
+	usage, err := server.mailboxDiskUsage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage > newestUsage {
+		t.Fatalf("disk usage = %d, exceeds limit", usage)
+	}
+}
+
+func TestEmailDiskUsageIncludesMetadata(t *testing.T) {
+	server, err := NewMailServer(1025, "localhost", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	id := "with-metadata"
+	emlPath := filepath.Join(server.mailDir, id+".eml")
+	if err := os.WriteFile(emlPath, []byte(governanceTestMessage), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.SaveEmailToStore(id, false, &Envelope{To: []string{"receiver@example.test"}}, &Email{Subject: id}); err != nil {
+		t.Fatal(err)
+	}
+	emlStat, err := os.Stat(emlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	metadataStat, err := os.Stat(server.metadataPath(id))
+	if err != nil {
+		t.Fatal(err)
+	}
+	usage, err := server.emailDiskUsage(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := emlStat.Size() + metadataStat.Size(); usage != want {
+		t.Fatalf("disk usage = %d, want eml + metadata = %d", usage, want)
+	}
+}
+
+func TestSaveEmailMetadataFailureDoesNotPublishEmail(t *testing.T) {
+	server, err := NewMailServer(1025, "localhost", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	metadataPath := filepath.Join(server.mailDir, metadataDirectoryName)
+	if err := os.WriteFile(metadataPath, []byte("blocks metadata directory"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	err = server.SaveEmailToStore("unpublished", false, &Envelope{To: []string{"receiver@example.test"}}, &Email{Subject: "unpublished"})
+	if err == nil {
+		t.Fatal("SaveEmailToStore succeeded despite metadata failure")
+	}
+	if _, err := server.GetEmail("unpublished"); err == nil {
+		t.Fatal("email became visible despite metadata failure")
+	}
+}
+
+func TestRecoveryKeepsValidEmailWhenMetadataCannotBeWritten(t *testing.T) {
+	dir := t.TempDir()
+	id := "valid-recovery"
+	if err := os.WriteFile(filepath.Join(dir, id+".eml"), []byte(governanceTestMessage), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, metadataDirectoryName), []byte("blocks metadata directory"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	server, err := NewMailServer(1025, "localhost", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	if _, err := server.GetEmail(id); err != nil {
+		t.Fatalf("valid email was not restored: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, id+".eml")); err != nil {
+		t.Fatalf("valid EML was quarantined: %v", err)
+	}
+}
+
+func TestCleanupDoesNotAccountForFailedDeletion(t *testing.T) {
+	server, err := NewMailServer(1025, "localhost", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	id := "undeletable"
+	if err := os.WriteFile(filepath.Join(server.mailDir, id+".eml"), []byte(governanceTestMessage), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.SaveEmailToStore(id, false, &Envelope{To: []string{"receiver@example.test"}}, &Email{Subject: id}); err != nil {
+		t.Fatal(err)
+	}
+	server.storeMutex.Lock()
+	server.receivedAtByID[id] = time.Now().Add(-time.Hour)
+	server.storeMutex.Unlock()
+	server.storagePolicy = StoragePolicy{MaxAge: time.Nanosecond}
+	server.beforeEmailDelete = func(string) error { return errors.New("injected delete failure") }
+	if err := server.CleanupStorage(); err == nil {
+		t.Fatal("cleanup succeeded despite deletion failure")
+	}
+	if _, err := server.GetEmail(id); err != nil {
+		t.Fatalf("failed deletion removed email from memory: %v", err)
+	}
+	stats := server.GetEmailStats()["storage"].(map[string]interface{})
+	if stats["deletedMessages"].(uint64) != 0 || stats["reclaimedBytes"].(uint64) != 0 {
+		t.Fatalf("failed deletion was counted as reclaimed: %#v", stats)
+	}
+}
+
+func TestReadAllEmailReportsMetadataFailure(t *testing.T) {
+	server, err := NewMailServer(1025, "localhost", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	id := "unread"
+	if err := os.WriteFile(filepath.Join(server.mailDir, id+".eml"), []byte(governanceTestMessage), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.SaveEmailToStore(id, false, &Envelope{To: []string{"receiver@example.test"}}, &Email{Subject: id}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(filepath.Join(server.mailDir, metadataDirectoryName)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(server.mailDir, metadataDirectoryName), []byte("blocks metadata directory"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	count, err := server.ReadAllEmail()
+	if err == nil || count != 0 {
+		t.Fatalf("ReadAllEmail() = %d, %v; want persisted failure", count, err)
+	}
+	email, getErr := server.GetEmail(id)
+	if getErr != nil || email.Read {
+		t.Fatalf("failed read update became visible: %#v, %v", email, getErr)
+	}
+}

--- a/internal/mailserver/store.go
+++ b/internal/mailserver/store.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -17,6 +18,10 @@ import (
 
 // SaveEmailToStore saves a parsed email to the store (exported for testing)
 func (ms *MailServer) SaveEmailToStore(id string, isRead bool, envelope *Envelope, parsedEmail *Email) error {
+	return ms.saveEmailToStore(id, isRead, envelope, parsedEmail, true)
+}
+
+func (ms *MailServer) saveEmailToStore(id string, isRead bool, envelope *Envelope, parsedEmail *Email, persistMetadata bool) error {
 	emlPath := filepath.Join(ms.mailDir, id+".eml")
 
 	parsedEmail.ID = id
@@ -59,9 +64,22 @@ func (ms *MailServer) SaveEmailToStore(id string, isRead bool, envelope *Envelop
 
 	storedEmail := cloneEmail(parsedEmail)
 	ms.storeMutex.Lock()
-	if _, exists := ms.storeByID[id]; !exists {
+	_, existed := ms.storeByID[id]
+	receivedAt := ms.receivedAtByID[id]
+	if receivedAt.IsZero() {
+		receivedAt = time.Now().UTC()
+	}
+	if persistMetadata {
+		// New mail must have durable initial metadata before it becomes visible.
+		if err := ms.persistEmailMetadataAt(storedEmail, receivedAt); err != nil {
+			ms.storeMutex.Unlock()
+			return fmt.Errorf("persist email metadata: %w", err)
+		}
+	}
+	if !existed {
 		ms.storeOrder = append(ms.storeOrder, id)
 	}
+	ms.receivedAtByID[id] = receivedAt
 	ms.storeByID[id] = storedEmail
 	ms.storeMutex.Unlock()
 
@@ -172,17 +190,22 @@ func (ms *MailServer) GetAllEmail() []*Email {
 
 // DeleteEmail deletes an email by ID
 func (ms *MailServer) DeleteEmail(id string) error {
-	ms.storeMutex.Lock()
-	defer ms.storeMutex.Unlock()
-
-	email, exists := ms.storeByID[id]
-	if !exists {
-		return fmt.Errorf("email not found")
-	}
-
 	// Validate email ID to prevent path traversal
 	if err := validateEmailID(id); err != nil {
 		return fmt.Errorf("invalid email ID: %w", err)
+	}
+	ms.storeMutex.RLock()
+	email, exists := ms.storeByID[id]
+	if !exists {
+		ms.storeMutex.RUnlock()
+		return fmt.Errorf("email not found")
+	}
+	email = cloneEmail(email)
+	ms.storeMutex.RUnlock()
+	if ms.beforeEmailDelete != nil {
+		if err := ms.beforeEmailDelete(id); err != nil {
+			return fmt.Errorf("delete email rejected: %w", err)
+		}
 	}
 
 	// Delete raw email file
@@ -191,8 +214,9 @@ func (ms *MailServer) DeleteEmail(id string) error {
 	if err := validatePath(ms.mailDir, emlPath); err != nil {
 		return fmt.Errorf("path validation failed: %w", err)
 	}
-	if err := os.Remove(emlPath); err != nil {
-		common.Verbose("Error deleting email file: %v", err)
+	var deletionErrors []error
+	if err := os.Remove(emlPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		deletionErrors = append(deletionErrors, fmt.Errorf("delete email file: %w", err))
 	}
 
 	// Delete attachments directory
@@ -202,19 +226,27 @@ func (ms *MailServer) DeleteEmail(id string) error {
 		return fmt.Errorf("path validation failed: %w", err)
 	}
 	if err := os.RemoveAll(attachmentDir); err != nil {
-		common.Verbose("Error deleting attachment directory: %v", err)
+		deletionErrors = append(deletionErrors, fmt.Errorf("delete attachment directory: %w", err))
+	}
+	if err := ms.deleteEmailMetadata(id); err != nil {
+		deletionErrors = append(deletionErrors, fmt.Errorf("delete email metadata: %w", err))
+	}
+	if err := errors.Join(deletionErrors...); err != nil {
+		return err
 	}
 
-	common.Log("Deleting email - %s, id: %s", email.Subject, email.ID)
-
-	// Remove from store
+	ms.storeMutex.Lock()
 	delete(ms.storeByID, id)
+	delete(ms.receivedAtByID, id)
 	for i, storedID := range ms.storeOrder {
 		if storedID == id {
 			ms.storeOrder = append(ms.storeOrder[:i], ms.storeOrder[i+1:]...)
 			break
 		}
 	}
+	ms.storeMutex.Unlock()
+
+	common.Log("Deleting email - %s, id: %s", email.Subject, email.ID)
 
 	// Emit delete event
 	ms.emit("delete", email)
@@ -227,7 +259,10 @@ func (ms *MailServer) DeleteAllEmail() error {
 	common.Log("Deleting all email")
 
 	ms.storeMutex.Lock()
-	defer ms.storeMutex.Unlock()
+	ms.storeByID = make(map[string]*Email)
+	ms.storeOrder = make([]string, 0)
+	ms.receivedAtByID = make(map[string]time.Time)
+	ms.storeMutex.Unlock()
 
 	// Clear mail directory
 	files, err := os.ReadDir(ms.mailDir)
@@ -242,8 +277,6 @@ func (ms *MailServer) DeleteAllEmail() error {
 		}
 	}
 
-	ms.storeByID = make(map[string]*Email)
-	ms.storeOrder = make([]string, 0)
 	return nil
 }
 
@@ -331,37 +364,54 @@ func (ms *MailServer) GetEmailAttachment(id, filename string) (string, string, e
 	return attachmentPath, attachment.ContentType, nil
 }
 
-// ReadAllEmail marks all emails as read
-func (ms *MailServer) ReadAllEmail() int {
+// ReadAllEmail marks all emails as read, acknowledging only state that was
+// durably persisted.
+func (ms *MailServer) ReadAllEmail() (int, error) {
 	ms.storeMutex.Lock()
 	defer ms.storeMutex.Unlock()
 
 	count := 0
-	for _, email := range ms.storeByID {
+	for _, id := range ms.storeOrder {
+		email, exists := ms.storeByID[id]
+		if !exists {
+			continue
+		}
 		if !email.Read {
+			snapshot := cloneEmail(email)
+			snapshot.Read = true
+			if err := ms.persistEmailMetadataAt(snapshot, ms.receivedAtByID[id]); err != nil {
+				return count, fmt.Errorf("persist read state for %s: %w", id, err)
+			}
 			email.Read = true
 			count++
 		}
 	}
-	return count
+	return count, nil
 }
 
 // ReadEmail marks a single email as read
 func (ms *MailServer) ReadEmail(id string) error {
 	ms.storeMutex.Lock()
-	defer ms.storeMutex.Unlock()
-
 	if email, exists := ms.storeByID[id]; exists {
+		previous := email.Read
 		email.Read = true
+		snapshot := cloneEmail(email)
+		receivedAt := ms.receivedAtByID[id]
+		if err := ms.persistEmailMetadataAt(snapshot, receivedAt); err != nil {
+			email.Read = previous
+			ms.storeMutex.Unlock()
+			return fmt.Errorf("persist read state: %w", err)
+		}
+		ms.storeMutex.Unlock()
 		return nil
 	}
+	ms.storeMutex.Unlock()
 	return fmt.Errorf("email not found")
 }
 
 // GetEmailStats returns email statistics
 func (ms *MailServer) GetEmailStats() map[string]interface{} {
 	ms.storeMutex.RLock()
-	defer ms.storeMutex.RUnlock()
 
 	stats := make(map[string]interface{})
 	total := len(ms.storeByID)
@@ -382,6 +432,8 @@ func (ms *MailServer) GetEmailStats() map[string]interface{} {
 	stats["unread"] = unread
 	stats["read"] = total - unread
 	stats["byDate"] = byDate
+	ms.storeMutex.RUnlock()
+	stats["storage"] = ms.storageStats()
 
 	return stats
 }
@@ -583,11 +635,38 @@ func (ms *MailServer) LoadMailsFromDirectory() error {
 			continue
 		}
 
-		// Close the file before a possible quarantine rename. Windows does not
-		// permit renaming an open file.
-		email, parseErr := ms.parseEmail(id, emailFile, nil, false, true)
+		markAsRead := false
+		metadataLoaded := false
+		if metadata, metadataErr := ms.loadEmailMetadata(id); metadataErr == nil {
+			metadataLoaded = true
+			markAsRead = metadata.Read
+			ms.storeMutex.Lock()
+			ms.receivedAtByID[id] = metadata.Sequence
+			ms.storeMutex.Unlock()
+		} else if !os.IsNotExist(metadataErr) {
+			common.Error("Ignoring invalid metadata for %s: %v", id, metadataErr)
+		} else if stat, statErr := file.Info(); statErr == nil {
+			ms.storeMutex.Lock()
+			ms.receivedAtByID[id] = stat.ModTime().UTC()
+			ms.storeMutex.Unlock()
+		}
+
+		// Parse email. Legacy messages without metadata start unread instead of
+		// being silently marked read during recovery. Close the file before a
+		// possible quarantine rename because Windows cannot rename an open file.
+		email, envelope, parseErr := ms.parseEmailMessage(id, emailFile, nil, false, filepath.Join(ms.mailDir, id))
 		closeErr := emailFile.Close()
 		if parseErr == nil && closeErr == nil {
+			if storeErr := ms.saveEmailToStore(id, markAsRead, envelope, email, false); storeErr != nil {
+				loadErrors = append(loadErrors, fmt.Errorf("restore email %s: %w", id, storeErr))
+				continue
+			}
+			if !metadataLoaded {
+				if metadataErr := ms.persistEmailMetadata(email); metadataErr != nil {
+					common.Error("Restored email %s without metadata: %v", id, metadataErr)
+					loadErrors = append(loadErrors, fmt.Errorf("persist restored metadata for %s: %w", id, metadataErr))
+				}
+			}
 			common.Verbose("Restored email: %s (id: %s)", email.Subject, id)
 		} else {
 			loadErr := parseErr
@@ -600,6 +679,11 @@ func (ms *MailServer) LoadMailsFromDirectory() error {
 			}
 		}
 	}
+	ms.storeMutex.Lock()
+	sort.SliceStable(ms.storeOrder, func(i, j int) bool {
+		return ms.receivedAtByID[ms.storeOrder[i]].Before(ms.receivedAtByID[ms.storeOrder[j]])
+	})
+	ms.storeMutex.Unlock()
 	if err := ms.quarantineOrphanAttachmentDirectories(); err != nil {
 		loadErrors = append(loadErrors, err)
 	}

--- a/internal/mailserver/types.go
+++ b/internal/mailserver/types.go
@@ -1,8 +1,10 @@
 package mailserver
 
 import (
+	"context"
 	"io"
 	"sync"
+	"time"
 
 	"github.com/emersion/go-smtp"
 	"github.com/soulteary/owlmail/internal/types"
@@ -47,6 +49,7 @@ type eventListener struct {
 type MailServer struct {
 	storeByID      map[string]*types.Email
 	storeOrder     []string
+	receivedAtByID map[string]time.Time
 	storeMutex     sync.RWMutex
 	mailDir        string
 	port           int
@@ -65,15 +68,21 @@ type MailServer struct {
 		IsAutoRelayEnabled() bool
 		Close()
 	}
-	authConfig   *SMTPAuthConfig
-	tlsConfig    *TLSConfig
-	useUUIDForID bool
+	authConfig          *SMTPAuthConfig
+	tlsConfig           *TLSConfig
+	useUUIDForID        bool
+	storagePolicy       StoragePolicy
+	cleanupCancel       context.CancelFunc
+	cleanupWG           sync.WaitGroup
+	storageMetricsMutex sync.RWMutex
+	storageMetrics      StorageMetrics
 
 	// Storage hooks are intentionally unexported and nil in production. They
 	// provide deterministic fault injection for transaction boundary tests.
 	beforeStoreCommit     func(*types.Email) error
 	beforeAttachmentWrite func(string) error
 	beforeQuarantineMove  func(string) error
+	beforeEmailDelete     func(string) error
 }
 
 // GetHost returns the SMTP server host


### PR DESCRIPTION
## Summary

This carries the storage-governance work from #35 onto the current `main` branch, where it was not present after the original stacked-branch merge.

It includes:

- retention limits for age, message count, and disk usage
- persisted read state and ordered metadata
- streaming ZIP export limits
- indexed lookup and background cleanup metrics

It also resolves the outstanding review findings:

- eviction is ordered by persisted arrival sequence, not the message Date header
- disk accounting includes metadata sidecar bytes
- initial metadata is durably persisted before the mail object becomes visible in memory

## Verification

- adds regressions for arrival ordering, sidecar accounting, and failed initial metadata persistence
- `go test ./...` and `bun test`
- `go test -race ./internal/mailserver`