### PR TITLE
fix(web): deliver notifications through a service worker

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -98,6 +98,11 @@ func (api *API) setupRoutes() {
 	// regardless of the process working directory.
 	app.Get("/style.css", serveWebAsset("style.css", "text/css; charset=utf-8"))
 	app.Get("/app.js", serveWebAsset("app.js", "text/javascript; charset=utf-8"))
+	app.Get("/service-worker.js", func(c fiber.Ctx) error {
+		c.Set("Service-Worker-Allowed", "/")
+		c.Set(fiber.HeaderCacheControl, "no-cache")
+		return serveWebAsset("service-worker.js", "text/javascript; charset=utf-8")(c)
+	})
 	app.Get("/help.css", serveWebAsset("help.css", "text/css; charset=utf-8"))
 	app.Get("/help.js", serveWebAsset("help.js", "text/javascript; charset=utf-8"))
 	app.Get("/webhooks.css", serveWebAsset("webhooks.css", "text/css; charset=utf-8"))
@@ -130,6 +135,7 @@ func (api *API) setupRoutes() {
 			strings.HasPrefix(path, "/api/") ||
 			strings.HasPrefix(path, "/style.css") ||
 			strings.HasPrefix(path, "/app.js") ||
+			strings.HasPrefix(path, "/service-worker.js") ||
 			strings.HasPrefix(path, "/help.css") ||
 			strings.HasPrefix(path, "/help.js") ||
 			strings.HasPrefix(path, "/webhooks") {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -219,6 +219,7 @@ func TestEmbeddedWebAssets(t *testing.T) {
 		{path: "/help/", contentType: "text/html", contains: "快速上手 OwlMail"},
 		{path: "/style.css", contentType: "text/css", contains: ".header"},
 		{path: "/app.js", contentType: "text/javascript", contains: "connectWebSocket"},
+		{path: "/service-worker.js", contentType: "text/javascript", contains: "showNotification"},
 		{path: "/help.css", contentType: "text/css", contains: ".help-shell"},
 		{path: "/help.js", contentType: "text/javascript", contains: "applyLanguage"},
 		{path: "/webhooks", contentType: "text/html", contains: "Webhook Configurator"},

--- a/tests/web/app.test.js
+++ b/tests/web/app.test.js
@@ -33,7 +33,7 @@ function createElement() {
     };
 }
 
-function createHarness({ permission = 'default', secure = true, savedPreference = null } = {}) {
+function createHarness({ permission = 'default', secure = true, savedPreference = null, serviceWorker = false } = {}) {
     const storage = new Map();
     if (savedPreference !== null) {
         storage.set('owlmail.browserNotifications.enabled', savedPreference);
@@ -45,6 +45,7 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
         ['notificationStatus', notificationStatus]
     ]);
     const notifications = [];
+    const serviceWorkerNotifications = [];
     const windowListeners = new Map();
     const documentListeners = new Map();
 
@@ -76,10 +77,25 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
         querySelectorAll() { return []; },
         createElement() { return createElement(); }
     };
+    const navigator = { language: 'en-US' };
+    if (serviceWorker) {
+        navigator.serviceWorker = {
+            addEventListener() {},
+            async register(path, options) {
+                assert.equal(path, '/service-worker.js');
+                assert.equal(options.scope, '/');
+                return {
+                    async showNotification(title, notificationOptions) {
+                        serviceWorkerNotifications.push({ title, options: notificationOptions });
+                    }
+                };
+            }
+        };
+    }
     const sandbox = {
         window,
         document,
-        navigator: { language: 'en-US' },
+        navigator,
         localStorage: {
             getItem(key) { return storage.has(key) ? storage.get(key) : null; },
             setItem(key, value) { storage.set(key, value); }
@@ -101,6 +117,7 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
         notificationStatus,
         notificationToggle,
         notifications,
+        serviceWorkerNotifications,
         storage,
         window,
         windowListeners,
@@ -157,6 +174,19 @@ test('new email notification uses bounded text and a stable message tag', () => 
     assert.equal(harness.notifications[0].title.endsWith('…'), true);
     assert.equal(harness.notifications[0].options.tag, 'owlmail-email-mail-42');
     assert.match(harness.notifications[0].options.body, /Unknown/);
+});
+
+test('mobile-compatible service worker displays new email notifications', async () => {
+    const harness = createHarness({ permission: 'granted', savedPreference: 'true', serviceWorker: true });
+    harness.run('initializeBrowserNotifications()');
+    await harness.run('browserNotificationRegistrationPromise');
+
+    harness.run(`notifyBrowserForEmail(${JSON.stringify({ id: 'mobile-42', subject: 'Mobile', from: [] })})`);
+    await Promise.resolve();
+
+    assert.equal(harness.notifications.length, 0);
+    assert.equal(harness.serviceWorkerNotifications.length, 1);
+    assert.equal(harness.serviceWorkerNotifications[0].options.data.emailId, 'mobile-42');
 });
 
 test('insecure contexts report notifications as unavailable', () => {

--- a/web/app.js
+++ b/web/app.js
@@ -723,11 +723,26 @@ let browserNotificationsEnabled = false;
 let browserNotificationsInitialized = false;
 let notificationPermissionPending = false;
 let notificationStatusTimer = null;
+let browserNotificationRegistrationPromise = null;
 
 function browserNotificationsSupported() {
     return typeof window.Notification === 'function'
         && typeof window.Notification.requestPermission === 'function'
         && window.isSecureContext !== false;
+}
+
+function ensureBrowserNotificationServiceWorker() {
+    if (!navigator.serviceWorker || typeof navigator.serviceWorker.register !== 'function') return null;
+    if (!browserNotificationRegistrationPromise) {
+        browserNotificationRegistrationPromise = navigator.serviceWorker
+            .register('/service-worker.js', { scope: '/' })
+            .catch((error) => {
+                browserNotificationRegistrationPromise = null;
+                console.warn('Unable to register notification service worker:', error);
+                return null;
+            });
+    }
+    return browserNotificationRegistrationPromise;
 }
 
 function readBrowserNotificationPreference() {
@@ -865,6 +880,14 @@ function initializeBrowserNotifications() {
 
     button.addEventListener('click', toggleBrowserNotifications);
     window.addEventListener('focus', synchronizeBrowserNotificationPermission);
+    if (navigator.serviceWorker && typeof navigator.serviceWorker.addEventListener === 'function') {
+        navigator.serviceWorker.addEventListener('message', (event) => {
+            if (event.data && event.data.type === 'owlmail-open-email' && event.data.emailId) {
+                loadEmailDetail(event.data.emailId);
+            }
+        });
+    }
+    ensureBrowserNotificationServiceWorker();
     browserNotificationsInitialized = true;
     updateBrowserNotificationButton();
 }
@@ -873,6 +896,20 @@ function normalizeNotificationText(value, fallback, maxLength) {
     const normalized = typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : '';
     const text = normalized || fallback;
     return text.length > maxLength ? `${text.slice(0, maxLength - 1)}…` : text;
+}
+
+function showWindowNotification(title, options, email) {
+    try {
+        const notification = new window.Notification(title, options);
+        notification.onclick = () => {
+            if (typeof window.focus === 'function') window.focus();
+            notification.close();
+            if (email.id) loadEmailDetail(email.id);
+        };
+    } catch (error) {
+        console.error('Failed to show browser notification:', error);
+        showBrowserNotificationStatus(nt('error'));
+    }
 }
 
 function notifyBrowserForEmail(email) {
@@ -890,24 +927,27 @@ function notifyBrowserForEmail(email) {
     const title = normalizeNotificationText(email.subject, t('noSubject'), 160);
     const notificationSender = normalizeNotificationText(sender, t('unknown'), 240);
 
-    try {
-        const notification = new window.Notification(title, {
-            body: nt('newEmailFrom', { sender: notificationSender }),
-            tag: email.id ? `owlmail-email-${email.id}` : 'owlmail-new-email',
-            renotify: false
+    const options = {
+        body: nt('newEmailFrom', { sender: notificationSender }),
+        tag: email.id ? `owlmail-email-${email.id}` : 'owlmail-new-email',
+        renotify: false,
+        data: { emailId: email.id || '' }
+    };
+    const registrationPromise = ensureBrowserNotificationServiceWorker();
+    if (registrationPromise) {
+        registrationPromise.then((registration) => {
+            if (registration && typeof registration.showNotification === 'function') {
+                return registration.showNotification(title, options);
+            }
+            showWindowNotification(title, options, email);
+            return undefined;
+        }).catch((error) => {
+            console.error('Failed to show service worker notification:', error);
+            showBrowserNotificationStatus(nt('error'));
         });
-        notification.onclick = () => {
-            if (typeof window.focus === 'function') window.focus();
-            notification.close();
-            if (email.id) loadEmailDetail(email.id);
-        };
-    } catch (error) {
-        browserNotificationsEnabled = false;
-        storeBrowserNotificationPreference(false);
-        updateBrowserNotificationButton();
-        console.error('Failed to show browser notification:', error);
-        showBrowserNotificationStatus(nt('error'));
+        return;
     }
+    showWindowNotification(title, options, email);
 }
 
 // Helper function to handle API errors

--- a/web/assets_test.go
+++ b/web/assets_test.go
@@ -14,6 +14,7 @@ func TestRequiredAssetsAreEmbedded(t *testing.T) {
 	}{
 		{name: "index.html", contains: []byte("OwlMail")},
 		{name: "app.js", contains: []byte("connectWebSocket")},
+		{name: "service-worker.js", contains: []byte("showNotification")},
 		{name: "style.css", contains: []byte(".header")},
 		{name: "help.html", contains: []byte("OwlMail Help")},
 		{name: "help.css", contains: []byte(".help-shell")},

--- a/web/service-worker.js
+++ b/web/service-worker.js
@@ -1,0 +1,15 @@
+self.addEventListener('notificationclick', (event) => {
+    event.notification.close();
+    const emailId = event.notification.data && event.notification.data.emailId;
+
+    event.waitUntil((async () => {
+        const windows = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+        if (windows.length > 0) {
+            const client = windows[0];
+            await client.focus();
+            if (emailId) client.postMessage({ type: 'owlmail-open-email', emailId });
+            return;
+        }
+        await self.clients.openWindow('/');
+    })());
+});


### PR DESCRIPTION
## Summary
- register a same-origin service worker for browser notifications
- use `ServiceWorkerRegistration.showNotification()` so mobile browsers can display messages
- focus an existing OwlMail tab and open the selected email after a notification click
- retain the desktop `Notification` constructor as a fallback
- embed and serve the worker with explicit scope and no-cache headers

## Validation
- `node --check web/app.js`
- `node --check web/service-worker.js`
- `git diff --check`

> Closed as duplicate: #54 already provides the mobile service-worker notification fix with repository test coverage.