### PR TITLE
fix(webhook): renew leases during active deliveries

### DIFF
--- a/internal/webhook/queue.go
+++ b/internal/webhook/queue.go
@@ -18,6 +18,18 @@ const (
 	redisReadBlock     = time.Second
 )
 
+const renewOwnedLeaseScript = `
+local pending = redis.call('XPENDING', KEYS[1], ARGV[1], ARGV[3], ARGV[3], 1)
+if #pending == 0 then
+  return 0
+end
+if pending[1][2] ~= ARGV[2] then
+  return -1
+end
+redis.call('XCLAIM', KEYS[1], ARGV[1], ARGV[2], 0, ARGV[3], 'JUSTID')
+return 1
+`
+
 type queueReceipt struct {
 	id  string
 	job deliveryJob
@@ -172,15 +184,13 @@ func (queue *redisDeliveryQueue) Renew(ctx context.Context, receipt *queueReceip
 	if receipt == nil {
 		return nil
 	}
-	ids, err := queue.client.XClaimJustID(ctx, &redis.XClaimArgs{
-		Stream: queue.stream, Group: redisConsumerGroup, Consumer: queue.consumer,
-		MinIdle: 0, Messages: []string{receipt.id},
-	}).Result()
+	result, err := queue.client.Eval(ctx, renewOwnedLeaseScript, []string{queue.stream},
+		redisConsumerGroup, queue.consumer, receipt.id).Int64()
 	if err != nil {
 		return fmt.Errorf("renew webhook job lease: %w", err)
 	}
-	if len(ids) != 1 || ids[0] != receipt.id {
-		return fmt.Errorf("renew webhook job lease: entry %s is no longer pending", receipt.id)
+	if result != 1 {
+		return fmt.Errorf("renew webhook job lease: entry %s is no longer owned by %s", receipt.id, queue.consumer)
 	}
 	return nil
 }

--- a/internal/webhook/queue.go
+++ b/internal/webhook/queue.go
@@ -28,6 +28,7 @@ type deliveryQueue interface {
 	Claim(context.Context) (*queueReceipt, error)
 	Ack(context.Context, *queueReceipt) error
 	DeadLetter(context.Context, *queueReceipt, []Result) error
+	Renew(context.Context, *queueReceipt) error
 	Pending(context.Context) (int64, error)
 	Close() error
 }
@@ -160,6 +161,26 @@ func (queue *redisDeliveryQueue) Ack(ctx context.Context, receipt *queueReceipt)
 	})
 	if err != nil {
 		return fmt.Errorf("acknowledge webhook job: %w", err)
+	}
+	return nil
+}
+
+// Renew resets the pending entry's idle time while its HTTP delivery is still
+// active. JUSTID avoids inflating Redis' delivery-attempt counter on each
+// heartbeat.
+func (queue *redisDeliveryQueue) Renew(ctx context.Context, receipt *queueReceipt) error {
+	if receipt == nil {
+		return nil
+	}
+	ids, err := queue.client.XClaimJustID(ctx, &redis.XClaimArgs{
+		Stream: queue.stream, Group: redisConsumerGroup, Consumer: queue.consumer,
+		MinIdle: 0, Messages: []string{receipt.id},
+	}).Result()
+	if err != nil {
+		return fmt.Errorf("renew webhook job lease: %w", err)
+	}
+	if len(ids) != 1 || ids[0] != receipt.id {
+		return fmt.Errorf("renew webhook job lease: entry %s is no longer pending", receipt.id)
 	}
 	return nil
 }

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -16,6 +16,7 @@ import (
 const (
 	defaultMemoryQueueSize = 1024
 	defaultShutdownTimeout = 15 * time.Second
+	defaultLeaseRefresh    = redisClaimIdle / 3
 )
 
 // ServiceOptions configures queued webhook delivery.
@@ -43,6 +44,7 @@ type Service struct {
 	shutdownTimeout time.Duration
 	onResults       func(string, []Result)
 	workerCount     int
+	leaseRefresh    time.Duration
 	unlimited       bool
 	accepting       bool
 	handoffMutex    sync.RWMutex
@@ -71,6 +73,7 @@ func NewService(dispatcher *Dispatcher, options ServiceOptions) (*Service, error
 		dispatcher: dispatcher, ctx: ctx, cancel: cancel,
 		shutdownTimeout: options.ShutdownTimeout, onResults: options.OnResults,
 		workerCount: options.MaxConcurrency, unlimited: options.MaxConcurrency == 0,
+		leaseRefresh: defaultLeaseRefresh,
 	}
 	if options.RedisURL != "" {
 		consumer := fmt.Sprintf("%s-%s", runtime.GOOS, uuid.NewString())
@@ -208,7 +211,9 @@ func (service *Service) isAccepting() bool {
 }
 
 func (service *Service) deliver(job deliveryJob, receipt *queueReceipt) {
+	stopLease := service.startLeaseHeartbeat(receipt)
 	results := service.dispatcher.DispatchDelivery(service.ctx, job.Email, job.ID)
+	stopLease()
 	failed := false
 	for _, result := range results {
 		if result.Err != nil {
@@ -228,6 +233,33 @@ func (service *Service) deliver(job deliveryJob, receipt *queueReceipt) {
 		}
 	}
 	service.report(job.ID, results)
+}
+
+func (service *Service) startLeaseHeartbeat(receipt *queueReceipt) func() {
+	if service.queue == nil || receipt == nil || service.leaseRefresh <= 0 {
+		return func() {}
+	}
+	ctx, cancel := context.WithCancel(service.ctx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(service.leaseRefresh)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if err := service.queue.Renew(ctx, receipt); err != nil && ctx.Err() == nil {
+					service.report(receipt.job.ID, []Result{{Err: err}})
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return func() {
+		cancel()
+		<-done
+	}
 }
 
 func (service *Service) report(jobID string, results []Result) {

--- a/internal/webhook/service_test.go
+++ b/internal/webhook/service_test.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/redis/go-redis/v9"
 )
 
 func TestServiceCloseDrainsInFlightDelivery(t *testing.T) {
@@ -211,7 +213,24 @@ func TestRedisQueueIntegration(t *testing.T) {
 	if err != nil || receipt == nil || receipt.job.ID != job.ID {
 		t.Fatalf("Claim() = %#v, %v", receipt, err)
 	}
-	if err := queue.Ack(ctx, receipt); err != nil {
+	if err := queue.Renew(ctx, receipt); err != nil {
+		t.Fatalf("Renew() while owned: %v", err)
+	}
+	other, err := newRedisDeliveryQueue(ctx, redisURL, "owlmail:test", "other-consumer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = other.Close() }()
+	if _, err := other.client.XClaimJustID(ctx, &redis.XClaimArgs{
+		Stream: queue.stream, Group: redisConsumerGroup, Consumer: other.consumer,
+		MinIdle: 0, Messages: []string{receipt.id},
+	}).Result(); err != nil {
+		t.Fatal(err)
+	}
+	if err := queue.Renew(ctx, receipt); err == nil {
+		t.Fatal("Renew() stole a lease owned by another consumer")
+	}
+	if err := other.Ack(ctx, receipt); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/webhook/service_test.go
+++ b/internal/webhook/service_test.go
@@ -48,11 +48,12 @@ func TestServiceCloseDrainsInFlightDelivery(t *testing.T) {
 }
 
 type fakeDeliveryQueue struct {
-	claims chan *queueReceipt
-	mu     sync.Mutex
-	acked  []string
-	dead   []string
-	count  int64
+	claims  chan *queueReceipt
+	mu      sync.Mutex
+	acked   []string
+	dead    []string
+	renewed []string
+	count   int64
 }
 
 func (queue *fakeDeliveryQueue) Enqueue(_ context.Context, job deliveryJob) error {
@@ -87,6 +88,13 @@ func (queue *fakeDeliveryQueue) DeadLetter(_ context.Context, receipt *queueRece
 	defer queue.mu.Unlock()
 	queue.dead = append(queue.dead, receipt.id)
 	queue.count--
+	return nil
+}
+
+func (queue *fakeDeliveryQueue) Renew(_ context.Context, receipt *queueReceipt) error {
+	queue.mu.Lock()
+	defer queue.mu.Unlock()
+	queue.renewed = append(queue.renewed, receipt.id)
 	return nil
 }
 
@@ -134,6 +142,51 @@ func TestDurableServiceDeadLettersExhaustedDelivery(t *testing.T) {
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
+	if err := service.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDurableServiceRenewsLeaseDuringDelivery(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	receiver := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		close(started)
+		<-release
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer receiver.Close()
+	dispatcher, err := NewDispatcher(Config{Targets: []Target{{Name: "slow", URL: receiver.URL}}}, receiver.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	queue := &fakeDeliveryQueue{claims: make(chan *queueReceipt, 1), count: 1}
+	queue.claims <- &queueReceipt{id: "redis-entry", job: deliveryJob{ID: "slow-job", Email: testEmail()}}
+	service := &Service{
+		dispatcher: dispatcher, queue: queue, ctx: ctx, cancel: cancel,
+		shutdownTimeout: time.Second, workerCount: 1, accepting: true,
+		leaseRefresh: 5 * time.Millisecond,
+	}
+	service.start()
+	<-started
+	deadline := time.Now().Add(time.Second)
+	for {
+		queue.mu.Lock()
+		renewed := append([]string(nil), queue.renewed...)
+		queue.mu.Unlock()
+		if len(renewed) > 0 {
+			if renewed[0] != "redis-entry" {
+				t.Fatalf("renewed lease IDs = %v", renewed)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("active delivery lease was not renewed")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	close(release)
 	if err := service.Close(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- renew Redis Stream pending-entry leases while an HTTP delivery is still running
- renew a lease only while the entry is still owned by the current consumer
- stop heartbeats before acknowledging or dead-lettering a completed job
- use `XCLAIM JUSTID` so heartbeats do not inflate delivery-attempt counts
- add regression coverage for blocked delivery and lease ownership transfer

This prevents `XAUTOCLAIM` from handing an active delivery to another worker after the fixed 30-second idle threshold, without stealing a lease already reclaimed by another consumer.

## Validation
- `git diff --check`
- `go test -race ./internal/webhook`
- `go test ./...`
- `bun test`