### PR TITLE
fix(webhook): spool queue handoffs before delivery

### DIFF
--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -191,6 +191,7 @@ func registerWebhookHandler(server *mailserver.MailServer, dispatcher *webhookno
 	}
 	service, err := webhooknotify.NewService(dispatcher, webhooknotify.ServiceOptions{
 		MaxConcurrency: maxConcurrency,
+		SpoolDir:       server.GetMailDir(),
 		OnResults:      logWebhookResults,
 	})
 	if err != nil {
@@ -212,7 +213,7 @@ func registerWebhookHandler(server *mailserver.MailServer, dispatcher *webhookno
 	return nil
 }
 
-func setupWebhookService(cfg *config.Config, dispatcher *webhooknotify.Dispatcher) (*webhooknotify.Service, error) {
+func setupWebhookService(cfg *config.Config, dispatcher *webhooknotify.Dispatcher, spoolDir string) (*webhooknotify.Service, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("config is nil")
 	}
@@ -226,6 +227,7 @@ func setupWebhookService(cfg *config.Config, dispatcher *webhooknotify.Dispatche
 	service, err := webhooknotify.NewService(dispatcher, webhooknotify.ServiceOptions{
 		RedisURL: cfg.WebhookRedisURL, RedisPrefix: cfg.WebhookRedisPrefix,
 		MaxConcurrency: cfg.WebhookMaxConcurrency, ShutdownTimeout: shutdownTimeout,
+		SpoolDir:  spoolDir,
 		OnResults: logWebhookResults,
 	})
 	if err != nil {
@@ -361,7 +363,7 @@ func createMailServer(cfg *config.Config) (*mailserver.MailServer, error) {
 
 	// Register event handlers
 	registerEventHandlers(server)
-	webhookService, err := setupWebhookService(cfg, webhookDispatcher)
+	webhookService, err := setupWebhookService(cfg, webhookDispatcher, server.GetMailDir())
 	if err != nil {
 		_ = server.Close()
 		return nil, err

--- a/internal/mailserver/mailserver_store_test.go
+++ b/internal/mailserver/mailserver_store_test.go
@@ -333,6 +333,36 @@ func TestMailServerDeleteAllEmailWithEmptyDir(t *testing.T) {
 	}
 }
 
+func TestMailServerDeleteAllEmailPreservesWebhookOutbox(t *testing.T) {
+	tmpDir := t.TempDir()
+	server, err := NewMailServer(1025, "localhost", tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	outboxJob := filepath.Join(tmpDir, webhookOutboxDirectoryName, "pending.json")
+	if err := os.MkdirAll(filepath.Dir(outboxJob), 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outboxJob, []byte(`{"id":"pending"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "mail.eml"), []byte("mail"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := server.DeleteAllEmail(); err != nil {
+		t.Fatal(err)
+	}
+	if content, err := os.ReadFile(outboxJob); err != nil || string(content) != `{"id":"pending"}` {
+		t.Fatalf("outbox job after delete-all = %q, %v", content, err)
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, "mail.eml")); !os.IsNotExist(err) {
+		t.Fatalf("mail file survived delete-all: %v", err)
+	}
+}
+
 func TestMailServerReadEmail(t *testing.T) {
 	tmpDir := t.TempDir()
 	server, err := NewMailServer(1025, "localhost", tmpDir)

--- a/internal/mailserver/store.go
+++ b/internal/mailserver/store.go
@@ -15,6 +15,8 @@ import (
 	"github.com/soulteary/owlmail/internal/common"
 )
 
+const webhookOutboxDirectoryName = ".owlmail-webhook-outbox"
+
 // SaveEmailToStore saves a parsed email to the store (exported for testing)
 func (ms *MailServer) SaveEmailToStore(id string, isRead bool, envelope *Envelope, parsedEmail *Email) error {
 	emlPath := filepath.Join(ms.mailDir, id+".eml")
@@ -233,7 +235,7 @@ func (ms *MailServer) DeleteAllEmail() error {
 	files, err := os.ReadDir(ms.mailDir)
 	if err == nil {
 		for _, file := range files {
-			if file.IsDir() && file.Name() == quarantineDirName {
+			if file.IsDir() && (file.Name() == quarantineDirName || file.Name() == webhookOutboxDirectoryName) {
 				continue
 			}
 			if err := os.RemoveAll(filepath.Join(ms.mailDir, file.Name())); err != nil {

--- a/internal/webhook/outbox.go
+++ b/internal/webhook/outbox.go
@@ -1,0 +1,130 @@
+package webhook
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+const outboxDirectoryName = ".owlmail-webhook-outbox"
+
+type deliveryOutbox struct {
+	dir string
+}
+
+type outboxEntry struct {
+	path string
+	job  deliveryJob
+}
+
+func newDeliveryOutbox(spoolDir string) (*deliveryOutbox, error) {
+	dir := filepath.Join(spoolDir, outboxDirectoryName)
+	outbox := &deliveryOutbox{dir: dir}
+	if err := outbox.ensureDirectory(); err != nil {
+		return nil, fmt.Errorf("create webhook outbox: %w", err)
+	}
+	return outbox, nil
+}
+
+func (outbox *deliveryOutbox) ensureDirectory() error {
+	return os.MkdirAll(outbox.dir, 0750)
+}
+
+func (outbox *deliveryOutbox) Store(job deliveryJob) error {
+	if err := outbox.ensureDirectory(); err != nil {
+		return fmt.Errorf("create webhook outbox: %w", err)
+	}
+	encoded, err := json.Marshal(job)
+	if err != nil {
+		return fmt.Errorf("encode webhook outbox job: %w", err)
+	}
+	temporary, err := os.CreateTemp(outbox.dir, ".pending-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create webhook outbox job: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	committed := false
+	defer func() {
+		_ = temporary.Close()
+		if !committed {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if err := temporary.Chmod(0600); err != nil {
+		return fmt.Errorf("secure webhook outbox job: %w", err)
+	}
+	if _, err := temporary.Write(encoded); err != nil {
+		return fmt.Errorf("write webhook outbox job: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		return fmt.Errorf("sync webhook outbox job: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close webhook outbox job: %w", err)
+	}
+	finalPath := filepath.Join(outbox.dir, job.ID+".json")
+	if err := os.Rename(temporaryPath, finalPath); err != nil {
+		return fmt.Errorf("commit webhook outbox job: %w", err)
+	}
+	committed = true
+	if err := syncOutboxDirectory(outbox.dir); err != nil {
+		return fmt.Errorf("sync webhook outbox: %w", err)
+	}
+	return nil
+}
+
+func (outbox *deliveryOutbox) List() ([]outboxEntry, error) {
+	if err := outbox.ensureDirectory(); err != nil {
+		return nil, fmt.Errorf("create webhook outbox: %w", err)
+	}
+	files, err := os.ReadDir(outbox.dir)
+	if err != nil {
+		return nil, fmt.Errorf("read webhook outbox: %w", err)
+	}
+	entries := make([]outboxEntry, 0, len(files))
+	for _, file := range files {
+		if file.IsDir() || !strings.HasSuffix(file.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(outbox.dir, file.Name())
+		encoded, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read webhook outbox job %s: %w", file.Name(), err)
+		}
+		var job deliveryJob
+		if err := json.Unmarshal(encoded, &job); err != nil {
+			return nil, fmt.Errorf("decode webhook outbox job %s: %w", file.Name(), err)
+		}
+		entries = append(entries, outboxEntry{path: path, job: job})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].job.EnqueuedAt.Before(entries[j].job.EnqueuedAt)
+	})
+	return entries, nil
+}
+
+func (outbox *deliveryOutbox) Remove(path string) error {
+	if filepath.Dir(path) != outbox.dir {
+		return fmt.Errorf("remove webhook outbox job outside spool")
+	}
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("remove webhook outbox job: %w", err)
+	}
+	return syncOutboxDirectory(outbox.dir)
+}
+
+func syncOutboxDirectory(path string) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = directory.Close() }()
+	return directory.Sync()
+}

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -17,6 +17,7 @@ const (
 	defaultMemoryQueueSize = 1024
 	defaultShutdownTimeout = 15 * time.Second
 	defaultLeaseRefresh    = redisClaimIdle / 3
+	defaultOutboxRetry     = 250 * time.Millisecond
 )
 
 // ServiceOptions configures queued webhook delivery.
@@ -25,6 +26,7 @@ type ServiceOptions struct {
 	RedisPrefix     string
 	MaxConcurrency  int
 	ShutdownTimeout time.Duration
+	SpoolDir        string
 	OnResults       func(string, []Result)
 }
 
@@ -39,6 +41,9 @@ type Service struct {
 	dispatcher      *Dispatcher
 	queue           deliveryQueue
 	memoryQueue     chan deliveryJob
+	outbox          *deliveryOutbox
+	outboxWake      chan struct{}
+	outboxClosing   chan struct{}
 	ctx             context.Context
 	cancel          context.CancelFunc
 	shutdownTimeout time.Duration
@@ -51,6 +56,7 @@ type Service struct {
 	closeOnce       sync.Once
 	handoffs        sync.WaitGroup
 	workers         sync.WaitGroup
+	outboxWorkers   sync.WaitGroup
 	deliveries      sync.WaitGroup
 	closeErr        error
 }
@@ -75,6 +81,16 @@ func NewService(dispatcher *Dispatcher, options ServiceOptions) (*Service, error
 		workerCount: options.MaxConcurrency, unlimited: options.MaxConcurrency == 0,
 		leaseRefresh: defaultLeaseRefresh,
 	}
+	if options.SpoolDir != "" {
+		outbox, err := newDeliveryOutbox(options.SpoolDir)
+		if err != nil {
+			cancel()
+			return nil, err
+		}
+		service.outbox = outbox
+		service.outboxWake = make(chan struct{}, 1)
+		service.outboxClosing = make(chan struct{})
+	}
 	if options.RedisURL != "" {
 		consumer := fmt.Sprintf("%s-%s", runtime.GOOS, uuid.NewString())
 		queue, err := newRedisDeliveryQueue(ctx, options.RedisURL, options.RedisPrefix, consumer)
@@ -92,6 +108,10 @@ func NewService(dispatcher *Dispatcher, options ServiceOptions) (*Service, error
 }
 
 func (service *Service) start() {
+	if service.outbox != nil {
+		service.outboxWorkers.Add(1)
+		go service.runOutbox()
+	}
 	if service.unlimited {
 		service.workers.Add(1)
 		go service.runPump()
@@ -103,8 +123,8 @@ func (service *Service) start() {
 	}
 }
 
-// Enqueue durably hands an email to Redis when configured. Delivery remains
-// at-least-once: receivers should deduplicate X-OwlMail-Delivery-ID.
+// Enqueue durably hands an email to the local outbox when configured. Delivery
+// remains at-least-once: receivers should deduplicate X-OwlMail-Delivery-ID.
 func (service *Service) Enqueue(email *types.Email) error {
 	if service == nil || email == nil {
 		return fmt.Errorf("webhook email is nil")
@@ -122,6 +142,14 @@ func (service *Service) Enqueue(email *types.Email) error {
 		return err
 	}
 	job := deliveryJob{ID: uuid.NewString(), EnqueuedAt: time.Now().UTC(), Email: emailSnapshot}
+	if service.outbox != nil {
+		err := service.outbox.Store(job)
+		service.wakeOutbox()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 	if service.queue != nil {
 		if err := service.queue.Enqueue(service.ctx, job); err != nil {
 			return err
@@ -134,6 +162,98 @@ func (service *Service) Enqueue(email *types.Email) error {
 	case <-service.ctx.Done():
 		return service.ctx.Err()
 	}
+}
+
+func (service *Service) wakeOutbox() {
+	select {
+	case service.outboxWake <- struct{}{}:
+	default:
+	}
+}
+
+func (service *Service) runOutbox() {
+	defer service.outboxWorkers.Done()
+	closing := false
+	retry := time.NewTimer(0)
+	if !retry.Stop() {
+		<-retry.C
+	}
+	for {
+		pending, err := service.flushOutbox()
+		if err != nil {
+			service.report("", []Result{{Err: err}})
+			retry.Reset(defaultOutboxRetry)
+			if closing {
+				select {
+				case <-retry.C:
+				case <-service.outboxWake:
+					stopOutboxRetry(retry)
+				case <-service.ctx.Done():
+					return
+				}
+			} else {
+				select {
+				case <-retry.C:
+				case <-service.outboxWake:
+					stopOutboxRetry(retry)
+				case <-service.outboxClosing:
+					closing = true
+					stopOutboxRetry(retry)
+				case <-service.ctx.Done():
+					return
+				}
+			}
+			continue
+		}
+		if pending {
+			continue
+		}
+		if closing {
+			return
+		}
+		select {
+		case <-service.outboxWake:
+		case <-service.outboxClosing:
+			closing = true
+		case <-service.ctx.Done():
+			return
+		}
+	}
+}
+
+func stopOutboxRetry(retry *time.Timer) {
+	if !retry.Stop() {
+		select {
+		case <-retry.C:
+		default:
+		}
+	}
+}
+
+func (service *Service) flushOutbox() (bool, error) {
+	entries, err := service.outbox.List()
+	if err != nil {
+		return false, err
+	}
+	if len(entries) == 0 {
+		return false, nil
+	}
+	entry := entries[0]
+	if service.queue != nil {
+		if err := service.queue.Enqueue(service.ctx, entry.job); err != nil {
+			return true, err
+		}
+	} else {
+		select {
+		case service.memoryQueue <- entry.job:
+		case <-service.ctx.Done():
+			return true, service.ctx.Err()
+		}
+	}
+	if err := service.outbox.Remove(entry.path); err != nil {
+		return true, err
+	}
+	return true, nil
 }
 
 func cloneDeliveryEmail(email *types.Email) (*types.Email, error) {
@@ -281,6 +401,11 @@ func (service *Service) Close() error {
 		drained := make(chan struct{})
 		go func() {
 			service.handoffs.Wait()
+			if service.outbox != nil {
+				close(service.outboxClosing)
+				service.wakeOutbox()
+				service.outboxWorkers.Wait()
+			}
 			if service.memoryQueue != nil {
 				close(service.memoryQueue)
 			}

--- a/internal/webhook/service_test.go
+++ b/internal/webhook/service_test.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -102,20 +103,136 @@ func TestServiceCloseDrainsInFlightDelivery(t *testing.T) {
 }
 
 type fakeDeliveryQueue struct {
-	claims  chan *queueReceipt
-	mu      sync.Mutex
-	acked   []string
-	dead    []string
-	renewed []string
-	count   int64
+	claims     chan *queueReceipt
+	mu         sync.Mutex
+	acked      []string
+	dead       []string
+	renewed    []string
+	count      int64
+	enqueueErr error
 }
 
 func (queue *fakeDeliveryQueue) Enqueue(_ context.Context, job deliveryJob) error {
 	queue.mu.Lock()
+	if queue.enqueueErr != nil {
+		err := queue.enqueueErr
+		queue.mu.Unlock()
+		return err
+	}
 	queue.count++
 	queue.mu.Unlock()
 	queue.claims <- &queueReceipt{id: job.ID, job: job}
 	return nil
+}
+
+func TestOutboxRetainsJobUntilQueueAcceptsIt(t *testing.T) {
+	outbox, err := newDeliveryOutbox(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	job := deliveryJob{ID: "durable-job", EnqueuedAt: time.Now().UTC(), Email: testEmail()}
+	if err := outbox.Store(job); err != nil {
+		t.Fatal(err)
+	}
+	queue := &fakeDeliveryQueue{claims: make(chan *queueReceipt, 1), enqueueErr: errors.New("redis unavailable")}
+	service := &Service{queue: queue, outbox: outbox, ctx: context.Background()}
+
+	if pending, err := service.flushOutbox(); err == nil || !pending {
+		t.Fatalf("flushOutbox() = %v, %v; expected retained failure", pending, err)
+	}
+	entries, err := outbox.List()
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("outbox after queue failure = %#v, %v", entries, err)
+	}
+
+	queue.mu.Lock()
+	queue.enqueueErr = nil
+	queue.mu.Unlock()
+	if pending, err := service.flushOutbox(); err != nil || !pending {
+		t.Fatalf("flushOutbox() retry = %v, %v", pending, err)
+	}
+	entries, err = outbox.List()
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("outbox after successful handoff = %#v, %v", entries, err)
+	}
+}
+
+func TestOutboxDecouplesEnqueueFromMemoryQueueCapacity(t *testing.T) {
+	outbox, err := newDeliveryOutbox(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := &Service{
+		outbox: outbox, outboxWake: make(chan struct{}, 1),
+		memoryQueue: make(chan deliveryJob), ctx: context.Background(), accepting: true,
+	}
+	completed := make(chan error, 1)
+	go func() { completed <- service.Enqueue(testEmail()) }()
+	select {
+	case err := <-completed:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("enqueue blocked on the unavailable in-memory queue")
+	}
+	entries, err := outbox.List()
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("durable outbox entries = %#v, %v", entries, err)
+	}
+}
+
+func TestOutboxRecreatesMissingDirectory(t *testing.T) {
+	outbox, err := newDeliveryOutbox(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(outbox.dir); err != nil {
+		t.Fatal(err)
+	}
+	job := deliveryJob{ID: "recreated", EnqueuedAt: time.Now().UTC(), Email: testEmail()}
+	if err := outbox.Store(job); err != nil {
+		t.Fatalf("Store() after directory removal: %v", err)
+	}
+	entries, err := outbox.List()
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("List() after directory recreation = %#v, %v", entries, err)
+	}
+}
+
+func TestOutboxCloseSignalFlushesAcceptedEntries(t *testing.T) {
+	outbox, err := newDeliveryOutbox(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	service := &Service{
+		outbox: outbox, outboxWake: make(chan struct{}, 1), outboxClosing: make(chan struct{}),
+		memoryQueue: make(chan deliveryJob, 1), ctx: ctx,
+	}
+	service.outboxWorkers.Add(1)
+	go service.runOutbox()
+	// Let the worker observe an empty outbox and wait for work.
+	time.Sleep(10 * time.Millisecond)
+	job := deliveryJob{ID: "accepted-before-close", EnqueuedAt: time.Now().UTC(), Email: testEmail()}
+	if err := outbox.Store(job); err != nil {
+		t.Fatal(err)
+	}
+	close(service.outboxClosing)
+	service.outboxWorkers.Wait()
+	select {
+	case delivered := <-service.memoryQueue:
+		if delivered.ID != job.ID {
+			t.Fatalf("delivered job = %q, want %q", delivered.ID, job.ID)
+		}
+	default:
+		t.Fatal("accepted outbox job was not flushed during close")
+	}
+	entries, err := outbox.List()
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("outbox after close = %#v, %v", entries, err)
+	}
 }
 
 func (queue *fakeDeliveryQueue) Claim(ctx context.Context) (*queueReceipt, error) {


### PR DESCRIPTION
## Summary
- atomically persist webhook jobs in a mail-directory outbox before returning from the SMTP event handoff
- preserve the outbox across delete-all and recreate its directory if it is removed externally
- drain the outbox asynchronously into either the in-memory queue or Redis
- retain and retry jobs when Redis enqueue fails instead of only logging and losing them
- keep SMTP receipt independent of a full in-memory channel
- recover pending outbox jobs after restart and complete a final flush during graceful shutdown

Delivery remains at-least-once, so receivers should continue deduplicating `X-OwlMail-Delivery-ID`.

## Validation
- `git diff --check`
- `go test -race ./internal/webhook ./internal/mailserver ./cmd/owlmail`
- `go test ./...`
- `bun test`