### PR TITLE
docs(demo): require network controls for SMTP

### DIFF
--- a/examples/webhooks/soulteary-webhook/README.md
+++ b/examples/webhooks/soulteary-webhook/README.md
@@ -93,10 +93,12 @@ owlmail -webhook-config owlmail.json
 ```
 
 The example binds every host port to `127.0.0.1`; do not remove that boundary on
-a shared host. For production, keep both OwlMail and WebHook private or behind
-an authenticated reverse proxy, configure OwlMail Web Basic Auth, restrict SMTP
-ingress, retain HMAC verification, restrict allowed command paths, bound
-execution and concurrency, and avoid logging full email bodies.
+a shared host. In production, the HTTP UIs may be placed behind an authenticated
+reverse proxy, and OwlMail Web Basic Auth should remain enabled. This does not
+protect SMTP: keep port 1025 bound to a trusted interface or isolate it with
+network policy, a firewall, or a private tunnel. Retain HMAC verification,
+restrict allowed command paths, bound execution and concurrency, and avoid
+logging full email bodies.
 
 [中文说明](./README.zh-CN.md) ·
 [Webhook forwarding reference](../../../docs/en/Webhook-Forwarding.md) ·

--- a/examples/webhooks/soulteary-webhook/README.zh-CN.md
+++ b/examples/webhooks/soulteary-webhook/README.zh-CN.md
@@ -86,9 +86,10 @@ owlmail -webhook-config owlmail.json
 ```
 
 示例将所有宿主机端口绑定到 `127.0.0.1`，在共享主机上不要移除此边界。
-生产环境中，请将 OwlMail 和 WebHook 都保持为私有服务或置于经过身份验证的反向代理之后，
-为 OwlMail 配置 Web Basic Auth 并限制 SMTP 入口；同时保留 HMAC 校验，限制允许执行的
-命令路径、执行时间与并发，并避免记录完整邮件正文。
+生产环境中，HTTP 界面可以置于经过身份验证的反向代理之后，并应继续启用 OwlMail Web
+Basic Auth；但这不能保护 SMTP。请将 1025 端口限制在可信接口，或通过网络策略、防火墙
+或私有隧道进行隔离。同时保留 HMAC 校验，限制允许执行的命令路径、执行时间与并发，
+并避免记录完整邮件正文。
 
 [English](./README.md) ·
 [Webhook 消息转发参考](../../../docs/zh-CN/Webhook-Forwarding.md) ·

--- a/tests/docs/markdown.test.js
+++ b/tests/docs/markdown.test.js
@@ -25,6 +25,23 @@ test("Webhook demo publishes host ports on loopback only", () => {
   assert.doesNotMatch(compose, /^\s*-\s*["']?(?:9000|1025|1080):/m);
 });
 
+test("Webhook demo distinguishes HTTP proxying from SMTP network controls", () => {
+  const english = fs.readFileSync(
+    path.join(root, "examples/webhooks/soulteary-webhook/README.md"),
+    "utf8",
+  );
+  assert.match(english, /This does not\s+protect SMTP/);
+  assert.ok(english.includes("network policy, a firewall, or a private tunnel"));
+
+  const chinese = fs.readFileSync(
+    path.join(root, "examples/webhooks/soulteary-webhook/README.zh-CN.md"),
+    "utf8",
+  );
+  assert.ok(chinese.includes("不能保护 SMTP"));
+  assert.ok(chinese.includes("网络策略、防火墙"));
+  assert.ok(chinese.includes("私有隧道"));
+});
+
 function walkMarkdown(directory) {
   const files = [];
   for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {


### PR DESCRIPTION
## Summary

- distinguish authenticated HTTP reverse proxying from SMTP ingress protection in the OwlMail/WebHook demo
- require port 1025 to remain on a trusted interface or behind network policy, a firewall, or a private tunnel
- keep the English and Chinese guidance aligned and add a documentation regression test

## Context

This resolves the P1 review finding left open when #42 was closed as superseded by #55. The loopback Compose bindings were fixed, but the production wording could still imply that an HTTP reverse proxy protects the directly published SMTP listener.

## Verification

- `git diff --check`
- `node --check tests/docs/markdown.test.js`
- full Bun documentation tests delegated to CI