### PR TITLE
fix(webhook): roll back mail when outbox handoff fails

### DIFF
--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -265,6 +265,16 @@ func registerWebhookService(server *mailserver.MailServer, service *webhooknotif
 	}); err != nil {
 		return fmt.Errorf("register webhook queue handoff: %w", err)
 	}
+	server.On("new", func(email *mailserver.Email) {
+		if err := service.Commit(email.ID); err != nil {
+			common.Error("Failed to commit webhook queue handoff: %v", err)
+		}
+	})
+	for _, email := range server.GetAllEmail() {
+		if err := service.Commit(email.ID); err != nil {
+			return fmt.Errorf("recover webhook queue handoff for %s: %w", email.ID, err)
+		}
+	}
 	return nil
 }
 

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -175,7 +175,6 @@ func registerEventHandlers(server *mailserver.MailServer) {
 		common.Log("New email received: %s (from: %s)", subject, fromAddr)
 		common.Verbose("Email details - ID: %s, Size: %s, Attachments: %d", email.ID, email.SizeHuman, len(email.Attachments))
 	})
-
 	server.On("delete", func(email *mailserver.Email) {
 		if email == nil {
 			common.Log("Email deleted: (nil email)")
@@ -268,6 +267,14 @@ func registerWebhookService(server *mailserver.MailServer, service *webhooknotif
 	server.On("new", func(email *mailserver.Email) {
 		if err := service.Commit(email.ID); err != nil {
 			common.Error("Failed to commit webhook queue handoff: %v", err)
+		}
+	})
+	server.On("new-rollback", func(email *mailserver.Email) {
+		if email == nil {
+			return
+		}
+		if err := service.Abort(email.ID); err != nil {
+			common.Error("Failed to discard rejected webhook queue handoff: %v", err)
 		}
 	})
 	if err := service.RecoverAcceptedPending(); err != nil {

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -260,10 +260,8 @@ func registerWebhookService(server *mailserver.MailServer, service *webhooknotif
 	if server == nil || service == nil {
 		return nil
 	}
-	if err := server.OnSynchronous("new", func(email *mailserver.Email) {
-		if err := service.Enqueue(email); err != nil {
-			common.Error("Failed to enqueue webhook delivery: %v", err)
-		}
+	if err := server.OnSynchronous("new", func(email *mailserver.Email) error {
+		return service.Enqueue(email)
 	}); err != nil {
 		return fmt.Errorf("register webhook queue handoff: %w", err)
 	}

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -270,6 +270,9 @@ func registerWebhookService(server *mailserver.MailServer, service *webhooknotif
 			common.Error("Failed to commit webhook queue handoff: %v", err)
 		}
 	})
+	if err := service.RecoverAcceptedPending(); err != nil {
+		return fmt.Errorf("recover accepted webhook queue handoffs: %w", err)
+	}
 	for _, email := range server.GetAllEmail() {
 		if err := service.Commit(email.ID); err != nil {
 			return fmt.Errorf("recover webhook queue handoff for %s: %w", email.ID, err)

--- a/cmd/owlmail/main_test.go
+++ b/cmd/owlmail/main_test.go
@@ -459,6 +459,60 @@ func TestRegisterWebhookHandlerHandlesNil(t *testing.T) {
 	}
 }
 
+func TestRegisterWebhookServicePropagatesOutboxFailure(t *testing.T) {
+	mailDir := t.TempDir()
+	server, err := mailserver.NewMailServer(1025, "localhost", mailDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	dispatcher, err := webhooknotify.NewDispatcher(webhooknotify.Config{Targets: []webhooknotify.Target{{
+		Name: "test",
+		URL:  "https://example.com/hook",
+	}}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service, err := webhooknotify.NewService(dispatcher, webhooknotify.ServiceOptions{
+		MaxConcurrency: 1,
+		SpoolDir:       mailDir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	outboxPath := filepath.Join(mailDir, ".owlmail-webhook-outbox")
+	defer func() {
+		_ = os.Remove(outboxPath)
+		_ = os.MkdirAll(outboxPath, 0750)
+		_ = service.Close()
+	}()
+	if err := registerWebhookService(server, service); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(outboxPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outboxPath, []byte("blocks outbox directory"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	err = server.SaveEmailToStore(
+		"failed-outbox",
+		false,
+		&mailserver.Envelope{From: "sender@example.com", To: []string{"recipient@example.com"}},
+		&mailserver.Email{Subject: "must roll back"},
+	)
+	if err == nil {
+		t.Fatal("email commit succeeded despite the failed webhook outbox")
+	}
+	if _, err := server.GetEmail("failed-outbox"); err == nil {
+		t.Fatal("email became visible after the durable handoff failed")
+	}
+	if _, err := os.Stat(filepath.Join(mailDir, ".owlmail-meta", "failed-outbox.json")); !os.IsNotExist(err) {
+		t.Fatalf("metadata survived failed webhook handoff: %v", err)
+	}
+}
+
 func TestSetupAuthConfig(t *testing.T) {
 	// Test with empty user and password (should return nil)
 	cfg := &config.Config{

--- a/internal/mailserver/events.go
+++ b/internal/mailserver/events.go
@@ -13,12 +13,15 @@ func (ms *MailServer) On(event string, handler func(*types.Email)) {
 
 // OnSynchronous registers a lightweight handoff listener that completes
 // before emit returns. It is intended for durable queue writes, not network
-// delivery or other long-running work. Only one transactional handler is
-// allowed per event because independent durable side effects cannot be rolled
-// back safely when a later handler fails.
+// delivery or other long-running work. Only the "new" event has transactional
+// rollback support, and only one handler is allowed because independent durable
+// side effects cannot be rolled back safely when a later handler fails.
 func (ms *MailServer) OnSynchronous(event string, handler func(*types.Email) error) error {
 	if handler == nil {
 		return fmt.Errorf("event handler cannot be nil")
+	}
+	if event != "new" {
+		return fmt.Errorf("synchronous handlers are only supported for new events")
 	}
 	ms.listenersMutex.Lock()
 	defer ms.listenersMutex.Unlock()

--- a/internal/mailserver/events.go
+++ b/internal/mailserver/events.go
@@ -13,13 +13,20 @@ func (ms *MailServer) On(event string, handler func(*types.Email)) {
 
 // OnSynchronous registers a lightweight handoff listener that completes
 // before emit returns. It is intended for durable queue writes, not network
-// delivery or other long-running work.
+// delivery or other long-running work. Only one transactional handler is
+// allowed per event because independent durable side effects cannot be rolled
+// back safely when a later handler fails.
 func (ms *MailServer) OnSynchronous(event string, handler func(*types.Email) error) error {
 	if handler == nil {
 		return fmt.Errorf("event handler cannot be nil")
 	}
 	ms.listenersMutex.Lock()
 	defer ms.listenersMutex.Unlock()
+	for _, listener := range ms.listeners[event] {
+		if listener.synchronousHandler != nil {
+			return fmt.Errorf("synchronous %s event handler is already registered", event)
+		}
+	}
 	ms.listeners[event] = append(ms.listeners[event], eventListener{synchronousHandler: handler})
 	return nil
 }

--- a/internal/mailserver/events.go
+++ b/internal/mailserver/events.go
@@ -73,6 +73,17 @@ func (ms *MailServer) emitSynchronous(event string, email *types.Email) error {
 	return nil
 }
 
+func (ms *MailServer) hasSynchronousListener(event string) bool {
+	ms.listenersMutex.RLock()
+	defer ms.listenersMutex.RUnlock()
+	for _, listener := range ms.listeners[event] {
+		if listener.synchronousHandler != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // emitAsynchronous starts notification listeners after the state change is
 // committed. These listeners cannot affect the completed transaction.
 func (ms *MailServer) emitAsynchronous(event string, email *types.Email) {

--- a/internal/mailserver/events.go
+++ b/internal/mailserver/events.go
@@ -112,6 +112,27 @@ func (ms *MailServer) emitAsynchronous(event string, email *types.Email) {
 	}
 }
 
+// emitNotificationAndWait invokes ordinary notification handlers inline. It
+// is used for rollback cleanup that must finish before a failed transaction can
+// be retried with the same identifier.
+func (ms *MailServer) emitNotificationAndWait(event string, email *types.Email) {
+	ms.listenersMutex.RLock()
+	listeners := append([]eventListener(nil), ms.listeners[event]...)
+	ms.listenersMutex.RUnlock()
+	for _, listener := range listeners {
+		if listener.handler == nil {
+			continue
+		}
+		if listener.slots != nil {
+			listener.slots <- struct{}{}
+		}
+		listener.handler(cloneEmail(email))
+		if listener.slots != nil {
+			<-listener.slots
+		}
+	}
+}
+
 // emit sends an event to all listeners. Synchronous failures prevent
 // asynchronous notification listeners from observing an uncommitted event.
 func (ms *MailServer) emit(event string, email *types.Email) error {

--- a/internal/mailserver/events.go
+++ b/internal/mailserver/events.go
@@ -14,13 +14,13 @@ func (ms *MailServer) On(event string, handler func(*types.Email)) {
 // OnSynchronous registers a lightweight handoff listener that completes
 // before emit returns. It is intended for durable queue writes, not network
 // delivery or other long-running work.
-func (ms *MailServer) OnSynchronous(event string, handler func(*types.Email)) error {
+func (ms *MailServer) OnSynchronous(event string, handler func(*types.Email) error) error {
 	if handler == nil {
 		return fmt.Errorf("event handler cannot be nil")
 	}
 	ms.listenersMutex.Lock()
 	defer ms.listenersMutex.Unlock()
-	ms.listeners[event] = append(ms.listeners[event], eventListener{handler: handler, synchronous: true})
+	ms.listeners[event] = append(ms.listeners[event], eventListener{synchronousHandler: handler})
 	return nil
 }
 
@@ -46,27 +46,40 @@ func (ms *MailServer) OnWithConcurrency(event string, maxConcurrency int, handle
 	return nil
 }
 
-// emit sends an event to all listeners
-func (ms *MailServer) emit(event string, email *types.Email) {
+// emitSynchronous runs durable handoff listeners before the caller publishes
+// the state change. A failure aborts the caller's transaction.
+func (ms *MailServer) emitSynchronous(event string, email *types.Email) error {
 	ms.listenersMutex.RLock()
 	listeners := append([]eventListener(nil), ms.listeners[event]...)
 	ms.listenersMutex.RUnlock()
 	for _, listener := range listeners {
-		if listener.synchronous {
-			listener.handler(cloneEmail(email))
+		if listener.synchronousHandler == nil {
+			continue
+		}
+		if err := listener.synchronousHandler(cloneEmail(email)); err != nil {
+			return fmt.Errorf("synchronous %s event handoff: %w", event, err)
 		}
 	}
+	return nil
+}
+
+// emitAsynchronous starts notification listeners after the state change is
+// committed. These listeners cannot affect the completed transaction.
+func (ms *MailServer) emitAsynchronous(event string, email *types.Email) {
+	ms.listenersMutex.RLock()
+	listeners := append([]eventListener(nil), ms.listeners[event]...)
+	ms.listenersMutex.RUnlock()
 
 	// Start unlimited listeners first so a saturated bounded listener cannot
 	// delay UI broadcasts or lightweight logging handlers registered after it.
 	for _, listener := range listeners {
-		if !listener.synchronous && listener.slots == nil {
+		if listener.handler != nil && listener.slots == nil {
 			emailSnapshot := cloneEmail(email)
 			go listener.handler(emailSnapshot)
 		}
 	}
 	for _, listener := range listeners {
-		if listener.synchronous || listener.slots == nil {
+		if listener.handler == nil || listener.slots == nil {
 			continue
 		}
 		listener.slots <- struct{}{}
@@ -76,4 +89,14 @@ func (ms *MailServer) emit(event string, email *types.Email) {
 			listener.handler(emailSnapshot)
 		}(listener)
 	}
+}
+
+// emit sends an event to all listeners. Synchronous failures prevent
+// asynchronous notification listeners from observing an uncommitted event.
+func (ms *MailServer) emit(event string, email *types.Email) error {
+	if err := ms.emitSynchronous(event, email); err != nil {
+		return err
+	}
+	ms.emitAsynchronous(event, email)
+	return nil
 }

--- a/internal/mailserver/mailserver_events_test.go
+++ b/internal/mailserver/mailserver_events_test.go
@@ -1,6 +1,7 @@
 package mailserver
 
 import (
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -191,5 +192,30 @@ func TestOnWithConcurrencyRejectsInvalidRegistration(t *testing.T) {
 	}
 	if err := server.OnWithConcurrency("new", 1, nil); err == nil {
 		t.Fatal("nil handler should fail")
+	}
+}
+
+func TestSynchronousFailureStopsUncommittedNotifications(t *testing.T) {
+	server, err := NewMailServer(1025, "localhost", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	handoffErr := errors.New("injected durable handoff failure")
+	if err := server.OnSynchronous("new", func(*Email) error { return handoffErr }); err != nil {
+		t.Fatal(err)
+	}
+	notified := make(chan struct{}, 1)
+	server.On("new", func(*Email) { notified <- struct{}{} })
+
+	err = server.emit("new", &Email{ID: "uncommitted"})
+	if !errors.Is(err, handoffErr) {
+		t.Fatalf("emit error = %v, want %v", err, handoffErr)
+	}
+	select {
+	case <-notified:
+		t.Fatal("asynchronous listener observed an event whose durable handoff failed")
+	case <-time.After(50 * time.Millisecond):
 	}
 }

--- a/internal/mailserver/mailserver_events_test.go
+++ b/internal/mailserver/mailserver_events_test.go
@@ -237,3 +237,16 @@ func TestOnSynchronousRejectsMultipleTransactionalHandlers(t *testing.T) {
 		t.Fatal("multiple transactional handlers would allow a partial durable handoff")
 	}
 }
+
+func TestOnSynchronousRejectsEventsWithoutTransactionalRollback(t *testing.T) {
+	server, err := NewMailServer(1025, "localhost", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	err = server.OnSynchronous("delete", func(*Email) error { return nil })
+	if err == nil {
+		t.Fatal("delete does not support transactional handoff rollback")
+	}
+}

--- a/internal/mailserver/mailserver_events_test.go
+++ b/internal/mailserver/mailserver_events_test.go
@@ -219,3 +219,21 @@ func TestSynchronousFailureStopsUncommittedNotifications(t *testing.T) {
 	case <-time.After(50 * time.Millisecond):
 	}
 }
+
+func TestOnSynchronousRejectsMultipleTransactionalHandlers(t *testing.T) {
+	server, err := NewMailServer(1025, "localhost", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	if err := server.OnSynchronous("new", func(*Email) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	err = server.OnSynchronous("new", func(*Email) error {
+		return errors.New("must never run")
+	})
+	if err == nil {
+		t.Fatal("multiple transactional handlers would allow a partial durable handoff")
+	}
+}

--- a/internal/mailserver/storage_transaction.go
+++ b/internal/mailserver/storage_transaction.go
@@ -159,6 +159,35 @@ func (ms *MailServer) acceptRollbackFence(id string) error {
 	return ms.writeRollbackFenceState(id, acceptedFenceState)
 }
 
+func (ms *MailServer) createAcceptedHandoffFence(id string) error {
+	fencePath := rollbackFencePath(ms.mailDir, id)
+	fence, err := os.OpenFile(fencePath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			state, stateErr := readRollbackFenceState(fencePath)
+			if stateErr == nil && state == acceptedFenceState {
+				return nil
+			}
+		}
+		return fmt.Errorf("create accepted webhook handoff fence: %w", err)
+	}
+	if _, err := fence.WriteString(acceptedFenceState + "\n"); err != nil {
+		_ = fence.Close()
+		return fmt.Errorf("write accepted webhook handoff fence: %w", err)
+	}
+	if err := fence.Sync(); err != nil {
+		_ = fence.Close()
+		return fmt.Errorf("sync accepted webhook handoff fence: %w", err)
+	}
+	if err := fence.Close(); err != nil {
+		return fmt.Errorf("close accepted webhook handoff fence: %w", err)
+	}
+	if err := syncDirectory(ms.mailDir); err != nil {
+		return fmt.Errorf("sync accepted webhook handoff fence: %w", err)
+	}
+	return nil
+}
+
 func (ms *MailServer) completeLocalRollbackFence(id string) error {
 	if err := ms.writeRollbackFenceState(id, localFenceState); err != nil {
 		return err

--- a/internal/mailserver/storage_transaction.go
+++ b/internal/mailserver/storage_transaction.go
@@ -208,22 +208,35 @@ func (ms *MailServer) completeLocalRollbackFence(id string) error {
 
 func (ms *MailServer) writeRollbackFenceState(id, state string) error {
 	fencePath := rollbackFencePath(ms.mailDir, id)
-	fence, err := os.OpenFile(fencePath, os.O_TRUNC|os.O_WRONLY, 0600)
+	fence, err := os.CreateTemp(ms.mailDir, storageTempPrefix+"fence-"+id+"-*.tmp")
 	if err != nil {
 		return err
 	}
-	if _, err := fence.WriteString(state + "\n"); err != nil {
+	temporaryPath := fence.Name()
+	replaced := false
+	defer func() {
 		_ = fence.Close()
+		if !replaced {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if err := fence.Chmod(0600); err != nil {
+		return err
+	}
+	if _, err := fence.WriteString(state + "\n"); err != nil {
 		return err
 	}
 	if err := fence.Sync(); err != nil {
-		_ = fence.Close()
 		return err
 	}
 	if err := fence.Close(); err != nil {
 		return err
 	}
-	return nil
+	if err := os.Rename(temporaryPath, fencePath); err != nil {
+		return err
+	}
+	replaced = true
+	return syncDirectory(ms.mailDir)
 }
 
 // rollbackIncomingEmail cleans final artifacts while retaining the previously
@@ -300,8 +313,14 @@ func (ms *MailServer) recoverStorageArtifacts() error {
 				state = rollbackFenceState
 			}
 			if state != rollbackFenceState {
-				recoveryErrors = append(recoveryErrors, fmt.Errorf("invalid rollback fence state for %s", id))
-				continue
+				// Older interrupted state writes may have left a partial marker.
+				// Treat unknown states conservatively as rejection so the email
+				// cannot remain permanently hidden behind an invalid fence.
+				if err := ms.writeRollbackFenceState(id, rollbackFenceState); err != nil {
+					recoveryErrors = append(recoveryErrors, fmt.Errorf("recover invalid rollback fence for %s: %w", id, err))
+					continue
+				}
+				state = rollbackFenceState
 			}
 			if err := ms.cleanupRollbackFencedEmail(id); err != nil {
 				recoveryErrors = append(recoveryErrors, fmt.Errorf("clean rollback-fenced email %s: %w", id, err))

--- a/internal/mailserver/storage_transaction.go
+++ b/internal/mailserver/storage_transaction.go
@@ -17,6 +17,7 @@ const (
 	storageTempPrefix   = ".owlmail-tmp-"
 	rollbackFencePrefix = storageTempPrefix + "rollback-"
 	rollbackFenceSuffix = ".fence"
+	activeFenceState    = "active"
 	rollbackFenceState  = "rollback"
 	acceptedFenceState  = "accepted"
 	quarantineDirName   = "quarantine"
@@ -132,7 +133,7 @@ func (ms *MailServer) createRollbackFence(id string) error {
 	if err != nil {
 		return fmt.Errorf("create email rollback fence: %w", err)
 	}
-	if _, err := fence.WriteString(rollbackFenceState + "\n"); err != nil {
+	if _, err := fence.WriteString(activeFenceState + "\n"); err != nil {
 		_ = fence.Close()
 		return fmt.Errorf("write email rollback fence: %w", err)
 	}
@@ -150,12 +151,26 @@ func (ms *MailServer) createRollbackFence(id string) error {
 }
 
 func (ms *MailServer) acceptRollbackFence(id string) error {
+	if err := ms.writeRollbackFenceState(id, acceptedFenceState); err != nil {
+		return err
+	}
+	fencePath := rollbackFencePath(ms.mailDir, id)
+	// Acceptance is committed once the existing durable fence contains the
+	// synced accepted state. Removing that marker is only housekeeping.
+	_ = os.Remove(fencePath)
+	// If this sync fails and the directory removal is lost, the durable file
+	// can only reappear with the already-synced accepted state.
+	_ = syncDirectory(ms.mailDir)
+	return nil
+}
+
+func (ms *MailServer) writeRollbackFenceState(id, state string) error {
 	fencePath := rollbackFencePath(ms.mailDir, id)
 	fence, err := os.OpenFile(fencePath, os.O_TRUNC|os.O_WRONLY, 0600)
 	if err != nil {
 		return err
 	}
-	if _, err := fence.WriteString(acceptedFenceState + "\n"); err != nil {
+	if _, err := fence.WriteString(state + "\n"); err != nil {
 		_ = fence.Close()
 		return err
 	}
@@ -166,12 +181,6 @@ func (ms *MailServer) acceptRollbackFence(id string) error {
 	if err := fence.Close(); err != nil {
 		return err
 	}
-	// Acceptance is committed once the existing durable fence contains the
-	// synced accepted state. Removing that marker is only housekeeping.
-	_ = os.Remove(fencePath)
-	// If this sync fails and the directory removal is lost, the durable file
-	// can only reappear with the already-synced accepted state.
-	_ = syncDirectory(ms.mailDir)
 	return nil
 }
 
@@ -179,6 +188,9 @@ func (ms *MailServer) acceptRollbackFence(id string) error {
 // persisted rollback fence. Recovery therefore keeps the ID rejected even if
 // any unlink or directory sync is not durable.
 func (ms *MailServer) rollbackIncomingEmail(id, emlPath, attachmentPath string) error {
+	if err := ms.writeRollbackFenceState(id, rollbackFenceState); err != nil {
+		return fmt.Errorf("persist rejected email rollback fence: %w", err)
+	}
 	var cleanupErrors []error
 	if ms.beforeEmailRollback != nil {
 		if err := ms.beforeEmailRollback(emlPath); err != nil {
@@ -235,6 +247,13 @@ func (ms *MailServer) recoverStorageArtifacts() error {
 					recoveryErrors = append(recoveryErrors, fmt.Errorf("remove accepted fence for %s: %w", id, err))
 				}
 				continue
+			}
+			if state == activeFenceState {
+				if err := ms.writeRollbackFenceState(id, rollbackFenceState); err != nil {
+					recoveryErrors = append(recoveryErrors, fmt.Errorf("finalize interrupted rollback fence for %s: %w", id, err))
+					continue
+				}
+				state = rollbackFenceState
 			}
 			if state != rollbackFenceState {
 				recoveryErrors = append(recoveryErrors, fmt.Errorf("invalid rollback fence state for %s", id))

--- a/internal/mailserver/storage_transaction.go
+++ b/internal/mailserver/storage_transaction.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/soulteary/owlmail/internal/common"
 )
 
 const (
@@ -182,8 +183,16 @@ func (ms *MailServer) createAcceptedHandoffFence(id string) error {
 	if err := fence.Close(); err != nil {
 		return fmt.Errorf("close accepted webhook handoff fence: %w", err)
 	}
-	if err := syncDirectory(ms.mailDir); err != nil {
-		return fmt.Errorf("sync accepted webhook handoff fence: %w", err)
+	syncFenceDirectory := syncDirectory
+	if ms.syncAcceptedFenceDirectory != nil {
+		syncFenceDirectory = ms.syncAcceptedFenceDirectory
+	}
+	if err := syncFenceDirectory(ms.mailDir); err != nil {
+		// The accepted marker is already visible and its contents are durable.
+		// Reporting rollback now would allow a caller retry to duplicate the
+		// staged webhook. Preserve commit semantics and surface the durability
+		// degradation operationally instead.
+		common.Error("Failed to sync accepted webhook handoff directory: %v", err)
 	}
 	return nil
 }

--- a/internal/mailserver/storage_transaction.go
+++ b/internal/mailserver/storage_transaction.go
@@ -166,9 +166,9 @@ func (ms *MailServer) acceptRollbackFence(id string) error {
 	if err := fence.Close(); err != nil {
 		return err
 	}
-	if err := os.Remove(fencePath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return err
-	}
+	// Acceptance is committed once the existing durable fence contains the
+	// synced accepted state. Removing that marker is only housekeeping.
+	_ = os.Remove(fencePath)
 	// If this sync fails and the directory removal is lost, the durable file
 	// can only reappear with the already-synced accepted state.
 	_ = syncDirectory(ms.mailDir)

--- a/internal/mailserver/storage_transaction.go
+++ b/internal/mailserver/storage_transaction.go
@@ -14,8 +14,10 @@ import (
 )
 
 const (
-	storageTempPrefix = ".owlmail-tmp-"
-	quarantineDirName = "quarantine"
+	storageTempPrefix   = ".owlmail-tmp-"
+	rollbackFencePrefix = storageTempPrefix + "rollback-"
+	rollbackFenceSuffix = ".fence"
+	quarantineDirName   = "quarantine"
 )
 
 // storeIncomingEmail commits attachments first and the EML file last. The EML
@@ -95,19 +97,76 @@ func (ms *MailServer) storeIncomingEmail(id string, r io.Reader, session *Sessio
 	}
 	committedEML = true
 	if err := syncDirectory(ms.mailDir); err != nil {
-		_ = os.Remove(finalEML)
-		_ = os.RemoveAll(finalAttachments)
-		return fmt.Errorf("sync mail directory: %w", err)
+		rollbackErr := ms.rollbackIncomingEmail(id, finalEML, finalAttachments)
+		committedEML = false
+		committedAttachments = false
+		return errors.Join(fmt.Errorf("sync mail directory: %w", err), rollbackErr)
 	}
 
 	if err := ms.SaveEmailToStore(id, false, envelope, email); err != nil {
-		_ = os.Remove(finalEML)
-		_ = os.RemoveAll(finalAttachments)
-		_ = syncDirectory(ms.mailDir)
+		rollbackErr := ms.rollbackIncomingEmail(id, finalEML, finalAttachments)
 		committedEML = false
 		committedAttachments = false
-		return fmt.Errorf("commit email to memory: %w", err)
+		return errors.Join(fmt.Errorf("commit email to memory: %w", err), rollbackErr)
 	}
+	return nil
+}
+
+func rollbackFencePath(mailDir, id string) string {
+	return filepath.Join(mailDir, rollbackFencePrefix+id+rollbackFenceSuffix)
+}
+
+// rollbackIncomingEmail durably fences the message before cleanup. If removal
+// later fails, startup recovery will skip and retry cleanup for the fenced ID
+// instead of loading a message that SMTP rejected.
+func (ms *MailServer) rollbackIncomingEmail(id, emlPath, attachmentPath string) error {
+	fencePath := rollbackFencePath(ms.mailDir, id)
+	fence, err := os.OpenFile(fencePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
+	if err != nil {
+		return fmt.Errorf("create email rollback fence: %w", err)
+	}
+	if _, err := fence.WriteString(id + "\n"); err != nil {
+		_ = fence.Close()
+		return fmt.Errorf("write email rollback fence: %w", err)
+	}
+	if err := fence.Sync(); err != nil {
+		_ = fence.Close()
+		return fmt.Errorf("sync email rollback fence: %w", err)
+	}
+	if err := fence.Close(); err != nil {
+		return fmt.Errorf("close email rollback fence: %w", err)
+	}
+	if err := syncDirectory(ms.mailDir); err != nil {
+		return fmt.Errorf("sync email rollback fence: %w", err)
+	}
+
+	var cleanupErrors []error
+	if ms.beforeEmailRollback != nil {
+		if err := ms.beforeEmailRollback(emlPath); err != nil {
+			cleanupErrors = append(cleanupErrors, err)
+		} else if err := os.Remove(emlPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			cleanupErrors = append(cleanupErrors, err)
+		}
+	} else if err := os.Remove(emlPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		cleanupErrors = append(cleanupErrors, err)
+	}
+	if err := os.RemoveAll(attachmentPath); err != nil {
+		cleanupErrors = append(cleanupErrors, err)
+	}
+	if err := syncDirectory(ms.mailDir); err != nil {
+		cleanupErrors = append(cleanupErrors, err)
+	}
+	if len(cleanupErrors) != 0 {
+		// The durable fence is the rollback confirmation. Keep it so recovery
+		// cannot publish any surviving EML after restart.
+		return nil
+	}
+	if err := os.Remove(fencePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	// Failure to persist fence removal is harmless: a stale fence with no EML
+	// is cleaned during recovery and cannot resurrect the rejected message.
+	_ = syncDirectory(ms.mailDir)
 	return nil
 }
 
@@ -132,6 +191,12 @@ func (ms *MailServer) recoverStorageArtifacts() error {
 	}
 	var recoveryErrors []error
 	for _, entry := range entries {
+		if id, ok := rollbackFenceID(entry.Name()); ok {
+			if err := ms.cleanupRollbackFencedEmail(id, filepath.Join(ms.mailDir, entry.Name())); err != nil {
+				recoveryErrors = append(recoveryErrors, fmt.Errorf("clean rollback-fenced email %s: %w", id, err))
+			}
+			continue
+		}
 		if !strings.HasPrefix(entry.Name(), storageTempPrefix) {
 			continue
 		}
@@ -140,6 +205,34 @@ func (ms *MailServer) recoverStorageArtifacts() error {
 		}
 	}
 	return errors.Join(recoveryErrors...)
+}
+
+func rollbackFenceID(name string) (string, bool) {
+	if !strings.HasPrefix(name, rollbackFencePrefix) || !strings.HasSuffix(name, rollbackFenceSuffix) {
+		return "", false
+	}
+	id := strings.TrimSuffix(strings.TrimPrefix(name, rollbackFencePrefix), rollbackFenceSuffix)
+	return id, validateEmailID(id) == nil
+}
+
+func (ms *MailServer) cleanupRollbackFencedEmail(id, fencePath string) error {
+	var cleanupErrors []error
+	if err := os.Remove(filepath.Join(ms.mailDir, id+".eml")); err != nil && !errors.Is(err, os.ErrNotExist) {
+		cleanupErrors = append(cleanupErrors, err)
+	}
+	if err := os.RemoveAll(filepath.Join(ms.mailDir, id)); err != nil {
+		cleanupErrors = append(cleanupErrors, err)
+	}
+	if err := ms.deleteEmailMetadata(id); err != nil {
+		cleanupErrors = append(cleanupErrors, err)
+	}
+	if len(cleanupErrors) != 0 {
+		return errors.Join(cleanupErrors...)
+	}
+	if err := os.Remove(fencePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return syncDirectory(ms.mailDir)
 }
 
 func (ms *MailServer) quarantineEmail(id, emlPath, reason string) error {

--- a/internal/mailserver/storage_transaction.go
+++ b/internal/mailserver/storage_transaction.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/soulteary/owlmail/internal/common"
 )
 
 const (
@@ -114,16 +113,11 @@ func (ms *MailServer) storeIncomingEmail(id string, r io.Reader, session *Sessio
 		return errors.Join(fmt.Errorf("sync mail directory: %w", err), rollbackErr)
 	}
 
-	if err := ms.SaveEmailToStore(id, false, envelope, email); err != nil {
+	if err := ms.saveEmailToStore(id, false, envelope, email, true, true); err != nil {
 		rollbackErr := ms.rollbackIncomingEmail(id, finalEML, finalAttachments)
 		committedEML = false
 		committedAttachments = false
 		return errors.Join(fmt.Errorf("commit email to memory: %w", err), rollbackErr)
-	}
-	if err := ms.acceptRollbackFence(id); err != nil {
-		// The email and durable webhook handoff are already committed. Reporting
-		// rejection would be less safe than retaining an accepted message.
-		common.Error("Failed to mark email rollback fence accepted for %s: %v", id, err)
 	}
 	return nil
 }

--- a/internal/mailserver/storage_transaction.go
+++ b/internal/mailserver/storage_transaction.go
@@ -11,12 +11,15 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/soulteary/owlmail/internal/common"
 )
 
 const (
 	storageTempPrefix   = ".owlmail-tmp-"
 	rollbackFencePrefix = storageTempPrefix + "rollback-"
 	rollbackFenceSuffix = ".fence"
+	rollbackFenceState  = "rollback"
+	acceptedFenceState  = "accepted"
 	quarantineDirName   = "quarantine"
 )
 
@@ -87,6 +90,14 @@ func (ms *MailServer) storeIncomingEmail(id string, r io.Reader, session *Sessio
 		if err := syncDirectory(stagedAttachments); err != nil {
 			return fmt.Errorf("sync staged attachments: %w", err)
 		}
+	}
+	// Persist the rollback decision before any final path becomes visible. If
+	// a later handoff or cleanup fails, recovery can never mistake the EML for
+	// an accepted message.
+	if err := ms.createRollbackFence(id); err != nil {
+		return err
+	}
+	if len(entries) > 0 {
 		if err := os.Rename(stagedAttachments, finalAttachments); err != nil {
 			return fmt.Errorf("commit attachments: %w", err)
 		}
@@ -109,6 +120,11 @@ func (ms *MailServer) storeIncomingEmail(id string, r io.Reader, session *Sessio
 		committedAttachments = false
 		return errors.Join(fmt.Errorf("commit email to memory: %w", err), rollbackErr)
 	}
+	if err := ms.acceptRollbackFence(id); err != nil {
+		// The email and durable webhook handoff are already committed. Reporting
+		// rejection would be less safe than retaining an accepted message.
+		common.Error("Failed to mark email rollback fence accepted for %s: %v", id, err)
+	}
 	return nil
 }
 
@@ -116,16 +132,13 @@ func rollbackFencePath(mailDir, id string) string {
 	return filepath.Join(mailDir, rollbackFencePrefix+id+rollbackFenceSuffix)
 }
 
-// rollbackIncomingEmail durably fences the message before cleanup. If removal
-// later fails, startup recovery will skip and retry cleanup for the fenced ID
-// instead of loading a message that SMTP rejected.
-func (ms *MailServer) rollbackIncomingEmail(id, emlPath, attachmentPath string) error {
+func (ms *MailServer) createRollbackFence(id string) error {
 	fencePath := rollbackFencePath(ms.mailDir, id)
-	fence, err := os.OpenFile(fencePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
+	fence, err := os.OpenFile(fencePath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
 	if err != nil {
 		return fmt.Errorf("create email rollback fence: %w", err)
 	}
-	if _, err := fence.WriteString(id + "\n"); err != nil {
+	if _, err := fence.WriteString(rollbackFenceState + "\n"); err != nil {
 		_ = fence.Close()
 		return fmt.Errorf("write email rollback fence: %w", err)
 	}
@@ -139,7 +152,39 @@ func (ms *MailServer) rollbackIncomingEmail(id, emlPath, attachmentPath string) 
 	if err := syncDirectory(ms.mailDir); err != nil {
 		return fmt.Errorf("sync email rollback fence: %w", err)
 	}
+	return nil
+}
 
+func (ms *MailServer) acceptRollbackFence(id string) error {
+	fencePath := rollbackFencePath(ms.mailDir, id)
+	fence, err := os.OpenFile(fencePath, os.O_TRUNC|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	if _, err := fence.WriteString(acceptedFenceState + "\n"); err != nil {
+		_ = fence.Close()
+		return err
+	}
+	if err := fence.Sync(); err != nil {
+		_ = fence.Close()
+		return err
+	}
+	if err := fence.Close(); err != nil {
+		return err
+	}
+	if err := os.Remove(fencePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	// If this sync fails and the directory removal is lost, the durable file
+	// can only reappear with the already-synced accepted state.
+	_ = syncDirectory(ms.mailDir)
+	return nil
+}
+
+// rollbackIncomingEmail cleans final artifacts while retaining the previously
+// persisted rollback fence. Recovery therefore keeps the ID rejected even if
+// any unlink or directory sync is not durable.
+func (ms *MailServer) rollbackIncomingEmail(id, emlPath, attachmentPath string) error {
 	var cleanupErrors []error
 	if ms.beforeEmailRollback != nil {
 		if err := ms.beforeEmailRollback(emlPath); err != nil {
@@ -157,16 +202,9 @@ func (ms *MailServer) rollbackIncomingEmail(id, emlPath, attachmentPath string) 
 		cleanupErrors = append(cleanupErrors, err)
 	}
 	if len(cleanupErrors) != 0 {
-		// The durable fence is the rollback confirmation. Keep it so recovery
-		// cannot publish any surviving EML after restart.
+		// The durable fence is the rollback confirmation.
 		return nil
 	}
-	if err := os.Remove(fencePath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	// Failure to persist fence removal is harmless: a stale fence with no EML
-	// is cleaned during recovery and cannot resurrect the rejected message.
-	_ = syncDirectory(ms.mailDir)
 	return nil
 }
 
@@ -192,7 +230,23 @@ func (ms *MailServer) recoverStorageArtifacts() error {
 	var recoveryErrors []error
 	for _, entry := range entries {
 		if id, ok := rollbackFenceID(entry.Name()); ok {
-			if err := ms.cleanupRollbackFencedEmail(id, filepath.Join(ms.mailDir, entry.Name())); err != nil {
+			fencePath := filepath.Join(ms.mailDir, entry.Name())
+			state, err := readRollbackFenceState(fencePath)
+			if err != nil {
+				recoveryErrors = append(recoveryErrors, fmt.Errorf("read rollback fence for %s: %w", id, err))
+				continue
+			}
+			if state == acceptedFenceState {
+				if err := os.Remove(fencePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+					recoveryErrors = append(recoveryErrors, fmt.Errorf("remove accepted fence for %s: %w", id, err))
+				}
+				continue
+			}
+			if state != rollbackFenceState {
+				recoveryErrors = append(recoveryErrors, fmt.Errorf("invalid rollback fence state for %s", id))
+				continue
+			}
+			if err := ms.cleanupRollbackFencedEmail(id); err != nil {
 				recoveryErrors = append(recoveryErrors, fmt.Errorf("clean rollback-fenced email %s: %w", id, err))
 			}
 			continue
@@ -207,6 +261,14 @@ func (ms *MailServer) recoverStorageArtifacts() error {
 	return errors.Join(recoveryErrors...)
 }
 
+func readRollbackFenceState(path string) (string, error) {
+	encoded, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(encoded)), nil
+}
+
 func rollbackFenceID(name string) (string, bool) {
 	if !strings.HasPrefix(name, rollbackFencePrefix) || !strings.HasSuffix(name, rollbackFenceSuffix) {
 		return "", false
@@ -215,7 +277,7 @@ func rollbackFenceID(name string) (string, bool) {
 	return id, validateEmailID(id) == nil
 }
 
-func (ms *MailServer) cleanupRollbackFencedEmail(id, fencePath string) error {
+func (ms *MailServer) cleanupRollbackFencedEmail(id string) error {
 	var cleanupErrors []error
 	if err := os.Remove(filepath.Join(ms.mailDir, id+".eml")); err != nil && !errors.Is(err, os.ErrNotExist) {
 		cleanupErrors = append(cleanupErrors, err)
@@ -229,9 +291,8 @@ func (ms *MailServer) cleanupRollbackFencedEmail(id, fencePath string) error {
 	if len(cleanupErrors) != 0 {
 		return errors.Join(cleanupErrors...)
 	}
-	if err := os.Remove(fencePath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return err
-	}
+	// Retain the durable rollback fence after cleanup. This retires the ID and
+	// prevents a crash from exposing an EML unlink whose durability was unknown.
 	return syncDirectory(ms.mailDir)
 }
 

--- a/internal/mailserver/storage_transaction.go
+++ b/internal/mailserver/storage_transaction.go
@@ -20,12 +20,15 @@ const (
 	activeFenceState    = "active"
 	rollbackFenceState  = "rollback"
 	acceptedFenceState  = "accepted"
+	localFenceState     = "accepted-local"
 	quarantineDirName   = "quarantine"
 )
 
 // storeIncomingEmail commits attachments first and the EML file last. The EML
 // rename is the transaction marker observed by startup recovery.
 func (ms *MailServer) storeIncomingEmail(id string, r io.Reader, session *Session) error {
+	ms.storageTransactionMutex.Lock()
+	defer ms.storageTransactionMutex.Unlock()
 	if err := validateEmailID(id); err != nil {
 		return err
 	}
@@ -156,6 +159,15 @@ func (ms *MailServer) acceptRollbackFence(id string) error {
 	return ms.writeRollbackFenceState(id, acceptedFenceState)
 }
 
+func (ms *MailServer) completeLocalRollbackFence(id string) error {
+	if err := ms.writeRollbackFenceState(id, localFenceState); err != nil {
+		return err
+	}
+	_ = os.Remove(rollbackFencePath(ms.mailDir, id))
+	_ = syncDirectory(ms.mailDir)
+	return nil
+}
+
 func (ms *MailServer) writeRollbackFenceState(id, state string) error {
 	fencePath := rollbackFencePath(ms.mailDir, id)
 	fence, err := os.OpenFile(fencePath, os.O_TRUNC|os.O_WRONLY, 0600)
@@ -235,9 +247,11 @@ func (ms *MailServer) recoverStorageArtifacts() error {
 				continue
 			}
 			if state == acceptedFenceState {
-				if err := os.Remove(fencePath); err != nil && !errors.Is(err, os.ErrNotExist) {
-					recoveryErrors = append(recoveryErrors, fmt.Errorf("remove accepted fence for %s: %w", id, err))
-				}
+				// Webhook startup recovery owns accepted-fence cleanup.
+				continue
+			}
+			if state == localFenceState {
+				_ = os.Remove(fencePath)
 				continue
 			}
 			if state == activeFenceState {

--- a/internal/mailserver/storage_transaction.go
+++ b/internal/mailserver/storage_transaction.go
@@ -151,17 +151,9 @@ func (ms *MailServer) createRollbackFence(id string) error {
 }
 
 func (ms *MailServer) acceptRollbackFence(id string) error {
-	if err := ms.writeRollbackFenceState(id, acceptedFenceState); err != nil {
-		return err
-	}
-	fencePath := rollbackFencePath(ms.mailDir, id)
-	// Acceptance is committed once the existing durable fence contains the
-	// synced accepted state. Removing that marker is only housekeeping.
-	_ = os.Remove(fencePath)
-	// If this sync fails and the directory removal is lost, the durable file
-	// can only reappear with the already-synced accepted state.
-	_ = syncDirectory(ms.mailDir)
-	return nil
+	// Keep the accepted fence until the staged webhook job is promoted. It is
+	// the durable recovery key even if the user deletes the email meanwhile.
+	return ms.writeRollbackFenceState(id, acceptedFenceState)
 }
 
 func (ms *MailServer) writeRollbackFenceState(id, state string) error {

--- a/internal/mailserver/storage_transaction_test.go
+++ b/internal/mailserver/storage_transaction_test.go
@@ -364,6 +364,49 @@ func TestReloadWaitsForActiveStorageTransaction(t *testing.T) {
 	}
 }
 
+func TestDeleteAllWaitsForActiveStorageTransaction(t *testing.T) {
+	dir := t.TempDir()
+	server, err := NewMailServer(1025, "localhost", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	server.beforeStoreCommit = func(*Email) error {
+		once.Do(func() { close(started) })
+		<-release
+		return nil
+	}
+	stored := make(chan error, 1)
+	go func() {
+		stored <- server.storeIncomingEmail("delete-all-race", bytes.NewReader(validMessage("delete all")), nil)
+	}()
+	<-started
+
+	deleted := make(chan error, 1)
+	go func() { deleted <- server.DeleteAllEmail() }()
+	select {
+	case err := <-deleted:
+		t.Fatalf("delete-all completed during an active storage transaction: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	close(release)
+	if err := <-stored; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-deleted; err != nil {
+		t.Fatal(err)
+	}
+	if got := len(server.GetAllEmail()); got != 0 {
+		t.Fatalf("delete-all retained %d committed email(s)", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "delete-all-race.eml")); !os.IsNotExist(err) {
+		t.Fatalf("delete-all retained the committed EML: %v", err)
+	}
+}
+
 func TestLoadMailsQuarantinesCorruptIncompleteAndOrphanArtifacts(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "corrupt.eml"), []byte("not a message"), 0644); err != nil {

--- a/internal/mailserver/storage_transaction_test.go
+++ b/internal/mailserver/storage_transaction_test.go
@@ -38,6 +38,9 @@ func assertNoCommittedOrTemporaryArtifacts(t *testing.T, dir string) {
 		if entry.Name() == quarantineDirName {
 			continue
 		}
+		if _, ok := rollbackFenceID(entry.Name()); ok {
+			continue
+		}
 		if strings.HasSuffix(entry.Name(), ".eml") || strings.HasPrefix(entry.Name(), storageTempPrefix) {
 			t.Fatalf("unexpected storage artifact after rollback: %s", entry.Name())
 		}
@@ -126,6 +129,32 @@ func TestFailedHandoffFencesEMLWhenImmediateCleanupFails(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, "fenced-handoff.eml")); !os.IsNotExist(err) {
 		t.Fatalf("recovery retained rollback-fenced EML: %v", err)
+	}
+	if state, err := readRollbackFenceState(rollbackFencePath(dir, "fenced-handoff")); err != nil || state != rollbackFenceState {
+		t.Fatalf("durable rollback fence after recovery = %q, %v", state, err)
+	}
+}
+
+func TestRecoveryLoadsEmailWithStaleAcceptedFence(t *testing.T) {
+	dir := t.TempDir()
+	id := "accepted-fence"
+	if err := os.WriteFile(filepath.Join(dir, id+".eml"), validMessage("accepted"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rollbackFencePath(dir, id), []byte(acceptedFenceState+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	server, err := NewMailServer(1025, "localhost", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	if got := len(server.GetAllEmail()); got != 1 {
+		t.Fatalf("restart loaded %d email(s) with accepted fence, want 1", got)
+	}
+	if _, err := os.Stat(rollbackFencePath(dir, id)); !os.IsNotExist(err) {
+		t.Fatalf("stale accepted fence survived recovery: %v", err)
 	}
 }
 

--- a/internal/mailserver/storage_transaction_test.go
+++ b/internal/mailserver/storage_transaction_test.go
@@ -207,6 +207,36 @@ func TestSaveEmailToStorePersistsAcceptedWebhookHandoff(t *testing.T) {
 	}
 }
 
+func TestSaveEmailToStoreKeepsCommitAfterAcceptedFenceDirectorySyncFailure(t *testing.T) {
+	dir := t.TempDir()
+	server, err := NewMailServer(1025, "localhost", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.OnSynchronous("new", func(*Email) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	server.syncAcceptedFenceDirectory = func(string) error {
+		return errors.New("injected accepted-fence directory sync failure")
+	}
+
+	id := "accepted-sync-error"
+	if err := server.SaveEmailToStore(
+		id,
+		false,
+		&Envelope{From: "sender@example.com", To: []string{"recipient@example.com"}},
+		&Email{Subject: "accepted despite directory sync error"},
+	); err != nil {
+		t.Fatalf("accepted handoff was reported as rolled back: %v", err)
+	}
+	if _, err := server.GetEmail(id); err != nil {
+		t.Fatalf("accepted email was not published: %v", err)
+	}
+	if state, err := readRollbackFenceState(rollbackFencePath(dir, id)); err != nil || state != acceptedFenceState {
+		t.Fatalf("accepted handoff fence after directory sync error = %q, %v", state, err)
+	}
+}
+
 func TestReloadPersistsAcceptedWebhookHandoff(t *testing.T) {
 	dir := t.TempDir()
 	server, err := NewMailServer(1025, "localhost", dir)

--- a/internal/mailserver/storage_transaction_test.go
+++ b/internal/mailserver/storage_transaction_test.go
@@ -158,6 +158,25 @@ func TestRecoveryLoadsEmailWithStaleAcceptedFence(t *testing.T) {
 	}
 }
 
+func TestDeleteAllPreservesTransactionFences(t *testing.T) {
+	dir := t.TempDir()
+	server, err := NewMailServer(1025, "localhost", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	fencePath := rollbackFencePath(dir, "deleted-accepted")
+	if err := os.WriteFile(fencePath, []byte(acceptedFenceState+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.DeleteAllEmail(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(fencePath); err != nil {
+		t.Fatalf("bulk deletion removed transaction fence: %v", err)
+	}
+}
+
 func TestStoreIncomingEmailRollsBackAttachmentFailure(t *testing.T) {
 	dir := t.TempDir()
 	server, err := NewMailServer(1025, "localhost", dir)

--- a/internal/mailserver/storage_transaction_test.go
+++ b/internal/mailserver/storage_transaction_test.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func validMessage(subject string) []byte {
@@ -135,7 +137,7 @@ func TestFailedHandoffFencesEMLWhenImmediateCleanupFails(t *testing.T) {
 	}
 }
 
-func TestRecoveryLoadsEmailWithStaleAcceptedFence(t *testing.T) {
+func TestRecoveryLoadsEmailAndPreservesAcceptedFenceForWebhookRecovery(t *testing.T) {
 	dir := t.TempDir()
 	id := "accepted-fence"
 	if err := os.WriteFile(filepath.Join(dir, id+".eml"), validMessage("accepted"), 0600); err != nil {
@@ -153,8 +155,31 @@ func TestRecoveryLoadsEmailWithStaleAcceptedFence(t *testing.T) {
 	if got := len(server.GetAllEmail()); got != 1 {
 		t.Fatalf("restart loaded %d email(s) with accepted fence, want 1", got)
 	}
+	if state, err := readRollbackFenceState(rollbackFencePath(dir, id)); err != nil || state != acceptedFenceState {
+		t.Fatalf("accepted fence needed by webhook recovery = %q, %v", state, err)
+	}
+}
+
+func TestRecoveryRemovesCompletedLocalFence(t *testing.T) {
+	dir := t.TempDir()
+	id := "local-fence"
+	if err := os.WriteFile(filepath.Join(dir, id+".eml"), validMessage("local"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rollbackFencePath(dir, id), []byte(localFenceState+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	server, err := NewMailServer(1025, "localhost", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	if got := len(server.GetAllEmail()); got != 1 {
+		t.Fatalf("restart loaded %d email(s) with local fence, want 1", got)
+	}
 	if _, err := os.Stat(rollbackFencePath(dir, id)); !os.IsNotExist(err) {
-		t.Fatalf("stale accepted fence survived recovery: %v", err)
+		t.Fatalf("completed local fence survived recovery: %v", err)
 	}
 }
 
@@ -217,6 +242,49 @@ func TestStoreIncomingEmailCommitsCompleteMessage(t *testing.T) {
 	}
 	if got := len(server.GetAllEmail()); got != 1 {
 		t.Fatalf("expected one published email, got %d", got)
+	}
+	if _, err := os.Stat(rollbackFencePath(dir, "complete-message")); !os.IsNotExist(err) {
+		t.Fatalf("local-only delivery retained a transaction fence: %v", err)
+	}
+}
+
+func TestReloadWaitsForActiveStorageTransaction(t *testing.T) {
+	dir := t.TempDir()
+	server, err := NewMailServer(1025, "localhost", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	server.beforeStoreCommit = func(*Email) error {
+		once.Do(func() { close(started) })
+		<-release
+		return nil
+	}
+	stored := make(chan error, 1)
+	go func() {
+		stored <- server.storeIncomingEmail("reload-race", bytes.NewReader(validMessage("reload")), nil)
+	}()
+	<-started
+
+	reloaded := make(chan error, 1)
+	go func() { reloaded <- server.LoadMailsFromDirectory() }()
+	select {
+	case err := <-reloaded:
+		t.Fatalf("reload completed during an active storage transaction: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	close(release)
+	if err := <-stored; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-reloaded; err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.GetEmail("reload-race"); err != nil {
+		t.Fatalf("committed email missing after serialized reload: %v", err)
 	}
 }
 

--- a/internal/mailserver/storage_transaction_test.go
+++ b/internal/mailserver/storage_transaction_test.go
@@ -90,6 +90,45 @@ func TestStoreIncomingEmailRollsBackDurableHandoffFailure(t *testing.T) {
 	assertNoCommittedOrTemporaryArtifacts(t, dir)
 }
 
+func TestFailedHandoffFencesEMLWhenImmediateCleanupFails(t *testing.T) {
+	dir := t.TempDir()
+	server, err := NewMailServer(1025, "localhost", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.OnSynchronous("new", func(*Email) error {
+		return errors.New("injected outbox failure")
+	}); err != nil {
+		t.Fatal(err)
+	}
+	server.beforeEmailRollback = func(string) error {
+		return errors.New("injected EML cleanup failure")
+	}
+
+	err = server.storeIncomingEmail("fenced-handoff", bytes.NewReader(validMessage("fenced")), nil)
+	if err == nil || !strings.Contains(err.Error(), "injected outbox failure") {
+		t.Fatalf("expected durable handoff failure, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "fenced-handoff.eml")); err != nil {
+		t.Fatalf("fault injection did not retain the EML: %v", err)
+	}
+	if _, err := os.Stat(rollbackFencePath(dir, "fenced-handoff")); err != nil {
+		t.Fatalf("rollback fence missing: %v", err)
+	}
+
+	restarted, err := NewMailServer(1025, "localhost", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = restarted.Close() }()
+	if got := len(restarted.GetAllEmail()); got != 0 {
+		t.Fatalf("restart loaded %d rollback-fenced email(s)", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "fenced-handoff.eml")); !os.IsNotExist(err) {
+		t.Fatalf("recovery retained rollback-fenced EML: %v", err)
+	}
+}
+
 func TestStoreIncomingEmailRollsBackAttachmentFailure(t *testing.T) {
 	dir := t.TempDir()
 	server, err := NewMailServer(1025, "localhost", dir)

--- a/internal/mailserver/storage_transaction_test.go
+++ b/internal/mailserver/storage_transaction_test.go
@@ -62,6 +62,34 @@ func TestStoreIncomingEmailRollsBackAfterMemoryCommitFailure(t *testing.T) {
 	assertNoCommittedOrTemporaryArtifacts(t, dir)
 }
 
+func TestStoreIncomingEmailRollsBackDurableHandoffFailure(t *testing.T) {
+	dir := t.TempDir()
+	server, err := NewMailServer(1025, "localhost", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.OnSynchronous("new", func(*Email) error {
+		return errors.New("injected outbox failure")
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	err = server.storeIncomingEmail("handoff-message", bytes.NewReader(multipartMessage()), nil)
+	if err == nil || !strings.Contains(err.Error(), "injected outbox failure") {
+		t.Fatalf("expected durable handoff failure, got %v", err)
+	}
+	if got := len(server.GetAllEmail()); got != 0 {
+		t.Fatalf("memory store contains %d email(s) after handoff rollback", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "handoff-message")); !os.IsNotExist(err) {
+		t.Fatalf("attachment directory survived handoff rollback: %v", err)
+	}
+	if _, err := os.Stat(server.metadataPath("handoff-message")); !os.IsNotExist(err) {
+		t.Fatalf("metadata survived handoff rollback: %v", err)
+	}
+	assertNoCommittedOrTemporaryArtifacts(t, dir)
+}
+
 func TestStoreIncomingEmailRollsBackAttachmentFailure(t *testing.T) {
 	dir := t.TempDir()
 	server, err := NewMailServer(1025, "localhost", dir)

--- a/internal/mailserver/storage_transaction_test.go
+++ b/internal/mailserver/storage_transaction_test.go
@@ -183,6 +183,52 @@ func TestRecoveryRemovesCompletedLocalFence(t *testing.T) {
 	}
 }
 
+func TestSaveEmailToStorePersistsAcceptedWebhookHandoff(t *testing.T) {
+	dir := t.TempDir()
+	server, err := NewMailServer(1025, "localhost", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.OnSynchronous("new", func(*Email) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+
+	id := "non-smtp-handoff"
+	if err := server.SaveEmailToStore(
+		id,
+		false,
+		&Envelope{From: "sender@example.com", To: []string{"recipient@example.com"}},
+		&Email{Subject: "accepted outside SMTP"},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if state, err := readRollbackFenceState(rollbackFencePath(dir, id)); err != nil || state != acceptedFenceState {
+		t.Fatalf("non-SMTP accepted handoff fence = %q, %v", state, err)
+	}
+}
+
+func TestReloadPersistsAcceptedWebhookHandoff(t *testing.T) {
+	dir := t.TempDir()
+	server, err := NewMailServer(1025, "localhost", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.OnSynchronous("new", func(*Email) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+
+	id := "reload-handoff"
+	if err := os.WriteFile(filepath.Join(dir, id+".eml"), validMessage("reload handoff"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.LoadMailsFromDirectory(); err != nil {
+		t.Fatal(err)
+	}
+	if state, err := readRollbackFenceState(rollbackFencePath(dir, id)); err != nil || state != acceptedFenceState {
+		t.Fatalf("reloaded accepted handoff fence = %q, %v", state, err)
+	}
+}
+
 func TestDeleteAllPreservesTransactionFences(t *testing.T) {
 	dir := t.TempDir()
 	server, err := NewMailServer(1025, "localhost", dir)

--- a/internal/mailserver/storage_transaction_test.go
+++ b/internal/mailserver/storage_transaction_test.go
@@ -95,6 +95,70 @@ func TestStoreIncomingEmailRollsBackDurableHandoffFailure(t *testing.T) {
 	assertNoCommittedOrTemporaryArtifacts(t, dir)
 }
 
+func TestFailedHandoffWaitsForRollbackCleanup(t *testing.T) {
+	server, err := NewMailServer(1025, "localhost", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.OnSynchronous("new", func(*Email) error {
+		return errors.New("injected handoff failure")
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cleanupStarted := make(chan struct{})
+	releaseCleanup := make(chan struct{})
+	server.On("new-rollback", func(*Email) {
+		close(cleanupStarted)
+		<-releaseCleanup
+	})
+
+	completed := make(chan error, 1)
+	go func() {
+		completed <- server.SaveEmailToStore(
+			"retry-ordering",
+			false,
+			&Envelope{From: "sender@example.com", To: []string{"recipient@example.com"}},
+			&Email{Subject: "failed handoff"},
+		)
+	}()
+	<-cleanupStarted
+	select {
+	case err := <-completed:
+		t.Fatalf("failed save returned before rollback cleanup finished: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	close(releaseCleanup)
+	if err := <-completed; err == nil || !strings.Contains(err.Error(), "injected handoff failure") {
+		t.Fatalf("failed save error = %v", err)
+	}
+}
+
+func TestRecoveryConvertsMalformedFenceToRollback(t *testing.T) {
+	dir := t.TempDir()
+	id := "malformed-fence"
+	if err := os.WriteFile(filepath.Join(dir, id+".eml"), validMessage("malformed"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rollbackFencePath(dir, id), []byte("acc"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	server, err := NewMailServer(1025, "localhost", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	if got := len(server.GetAllEmail()); got != 0 {
+		t.Fatalf("recovery loaded %d malformed-fenced email(s)", got)
+	}
+	if state, err := readRollbackFenceState(rollbackFencePath(dir, id)); err != nil || state != rollbackFenceState {
+		t.Fatalf("recovered malformed fence = %q, %v", state, err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, id+".eml")); !os.IsNotExist(err) {
+		t.Fatalf("malformed-fenced EML survived conservative recovery: %v", err)
+	}
+}
+
 func TestFailedHandoffFencesEMLWhenImmediateCleanupFails(t *testing.T) {
 	dir := t.TempDir()
 	server, err := NewMailServer(1025, "localhost", dir)

--- a/internal/mailserver/store.go
+++ b/internal/mailserver/store.go
@@ -295,6 +295,8 @@ func (ms *MailServer) DeleteEmail(id string) error {
 
 // DeleteAllEmail deletes all emails
 func (ms *MailServer) DeleteAllEmail() error {
+	ms.storageTransactionMutex.Lock()
+	defer ms.storageTransactionMutex.Unlock()
 	common.Log("Deleting all email")
 
 	ms.storeMutex.Lock()

--- a/internal/mailserver/store.go
+++ b/internal/mailserver/store.go
@@ -625,7 +625,10 @@ func (ms *MailServer) LoadMailsFromDirectory() error {
 	if entries, err := os.ReadDir(ms.mailDir); err == nil {
 		for _, entry := range entries {
 			if id, ok := rollbackFenceID(entry.Name()); ok {
-				fencedIDs[id] = struct{}{}
+				state, stateErr := readRollbackFenceState(filepath.Join(ms.mailDir, entry.Name()))
+				if stateErr != nil || state != acceptedFenceState {
+					fencedIDs[id] = struct{}{}
+				}
 			}
 		}
 	}

--- a/internal/mailserver/store.go
+++ b/internal/mailserver/store.go
@@ -80,9 +80,14 @@ func (ms *MailServer) saveEmailToStore(id string, isRead bool, envelope *Envelop
 			return fmt.Errorf("persist email metadata: %w", err)
 		}
 	}
+	hasTransactionalHandoff := ms.hasSynchronousListener("new")
 	handoffErr := ms.emitSynchronous("new", storedEmail)
 	if handoffErr == nil && finalizeRollbackFence {
-		handoffErr = ms.acceptRollbackFence(id)
+		if hasTransactionalHandoff {
+			handoffErr = ms.acceptRollbackFence(id)
+		} else {
+			handoffErr = ms.completeLocalRollbackFence(id)
+		}
 	}
 	if handoffErr != nil {
 		var rollbackErr error
@@ -97,6 +102,9 @@ func (ms *MailServer) saveEmailToStore(id string, isRead bool, envelope *Envelop
 			}
 		}
 		ms.storeMutex.Unlock()
+		if hasTransactionalHandoff {
+			ms.emitAsynchronous("new-rollback", storedEmail)
+		}
 		if rollbackErr != nil {
 			return errors.Join(handoffErr, fmt.Errorf("roll back email metadata: %w", rollbackErr))
 		}
@@ -627,13 +635,15 @@ func (ms *MailServer) parseEmailMessage(id string, r io.Reader, s *Session, save
 
 // LoadMailsFromDirectory loads emails from the mail directory
 func (ms *MailServer) LoadMailsFromDirectory() error {
+	ms.storageTransactionMutex.Lock()
+	defer ms.storageTransactionMutex.Unlock()
 	var loadErrors []error
 	fencedIDs := make(map[string]struct{})
 	if entries, err := os.ReadDir(ms.mailDir); err == nil {
 		for _, entry := range entries {
 			if id, ok := rollbackFenceID(entry.Name()); ok {
 				state, stateErr := readRollbackFenceState(filepath.Join(ms.mailDir, entry.Name()))
-				if stateErr != nil || state != acceptedFenceState {
+				if stateErr != nil || (state != acceptedFenceState && state != localFenceState) {
 					fencedIDs[id] = struct{}{}
 				}
 			}

--- a/internal/mailserver/store.go
+++ b/internal/mailserver/store.go
@@ -20,6 +20,8 @@ const webhookOutboxDirectoryName = ".owlmail-webhook-outbox"
 
 // SaveEmailToStore saves a parsed email to the store (exported for testing)
 func (ms *MailServer) SaveEmailToStore(id string, isRead bool, envelope *Envelope, parsedEmail *Email) error {
+	ms.storageTransactionMutex.Lock()
+	defer ms.storageTransactionMutex.Unlock()
 	return ms.saveEmailToStore(id, isRead, envelope, parsedEmail, true, false)
 }
 
@@ -105,7 +107,9 @@ func (ms *MailServer) saveEmailToStore(id string, isRead bool, envelope *Envelop
 		}
 		ms.storeMutex.Unlock()
 		if hasTransactionalHandoff {
-			ms.emitAsynchronous("new-rollback", storedEmail)
+			// Complete local outbox cleanup before exposing the failure to a
+			// caller that may immediately retry the same email ID.
+			ms.emitNotificationAndWait("new-rollback", storedEmail)
 		}
 		if rollbackErr != nil {
 			return errors.Join(handoffErr, fmt.Errorf("roll back email metadata: %w", rollbackErr))

--- a/internal/mailserver/store.go
+++ b/internal/mailserver/store.go
@@ -621,6 +621,14 @@ func (ms *MailServer) parseEmailMessage(id string, r io.Reader, s *Session, save
 // LoadMailsFromDirectory loads emails from the mail directory
 func (ms *MailServer) LoadMailsFromDirectory() error {
 	var loadErrors []error
+	fencedIDs := make(map[string]struct{})
+	if entries, err := os.ReadDir(ms.mailDir); err == nil {
+		for _, entry := range entries {
+			if id, ok := rollbackFenceID(entry.Name()); ok {
+				fencedIDs[id] = struct{}{}
+			}
+		}
+	}
 	if err := ms.recoverStorageArtifacts(); err != nil {
 		common.Error("Storage recovery completed with errors: %v", err)
 		loadErrors = append(loadErrors, err)
@@ -642,6 +650,9 @@ func (ms *MailServer) LoadMailsFromDirectory() error {
 
 		// Extract ID from filename
 		id := strings.TrimSuffix(file.Name(), ".eml")
+		if _, fenced := fencedIDs[id]; fenced {
+			continue
+		}
 		emlPath := filepath.Join(ms.mailDir, file.Name())
 
 		// Check if email already loaded

--- a/internal/mailserver/store.go
+++ b/internal/mailserver/store.go
@@ -82,12 +82,14 @@ func (ms *MailServer) saveEmailToStore(id string, isRead bool, envelope *Envelop
 	}
 	hasTransactionalHandoff := ms.hasSynchronousListener("new")
 	handoffErr := ms.emitSynchronous("new", storedEmail)
-	if handoffErr == nil && finalizeRollbackFence {
-		if hasTransactionalHandoff {
+	if handoffErr == nil && hasTransactionalHandoff {
+		if finalizeRollbackFence {
 			handoffErr = ms.acceptRollbackFence(id)
 		} else {
-			handoffErr = ms.completeLocalRollbackFence(id)
+			handoffErr = ms.createAcceptedHandoffFence(id)
 		}
+	} else if handoffErr == nil && finalizeRollbackFence {
+		handoffErr = ms.completeLocalRollbackFence(id)
 	}
 	if handoffErr != nil {
 		var rollbackErr error

--- a/internal/mailserver/store.go
+++ b/internal/mailserver/store.go
@@ -66,8 +66,10 @@ func (ms *MailServer) saveEmailToStore(id string, isRead bool, envelope *Envelop
 
 	storedEmail := cloneEmail(parsedEmail)
 	ms.storeMutex.Lock()
-	_, existed := ms.storeByID[id]
+	previousEmail, existed := ms.storeByID[id]
+	previousEmail = cloneEmail(previousEmail)
 	receivedAt := ms.receivedAtByID[id]
+	previousReceivedAt := receivedAt
 	if receivedAt.IsZero() {
 		receivedAt = time.Now().UTC()
 	}
@@ -78,6 +80,24 @@ func (ms *MailServer) saveEmailToStore(id string, isRead bool, envelope *Envelop
 			return fmt.Errorf("persist email metadata: %w", err)
 		}
 	}
+	if err := ms.emitSynchronous("new", storedEmail); err != nil {
+		var rollbackErr error
+		if persistMetadata {
+			if existed {
+				rollbackErr = ms.persistEmailMetadataAt(previousEmail, previousReceivedAt)
+			} else {
+				rollbackErr = ms.deleteEmailMetadata(id)
+				if rollbackErr == nil {
+					rollbackErr = syncStorageDirectory(filepath.Join(ms.mailDir, metadataDirectoryName))
+				}
+			}
+		}
+		ms.storeMutex.Unlock()
+		if rollbackErr != nil {
+			return errors.Join(err, fmt.Errorf("roll back email metadata: %w", rollbackErr))
+		}
+		return err
+	}
 	if !existed {
 		ms.storeOrder = append(ms.storeOrder, id)
 	}
@@ -87,8 +107,9 @@ func (ms *MailServer) saveEmailToStore(id string, isRead bool, envelope *Envelop
 
 	common.Log("Saving email: %s, id: %s", parsedEmail.Subject, id)
 
-	// Emit new email event
-	ms.emit("new", storedEmail)
+	// Notify asynchronous listeners only after the durable handoff and in-memory
+	// commit both succeed.
+	ms.emitAsynchronous("new", storedEmail)
 
 	// Auto relay if enabled
 	if ms.outgoing != nil && ms.outgoing.IsAutoRelayEnabled() {
@@ -251,7 +272,9 @@ func (ms *MailServer) DeleteEmail(id string) error {
 	common.Log("Deleting email - %s, id: %s", email.Subject, email.ID)
 
 	// Emit delete event
-	ms.emit("delete", email)
+	if err := ms.emit("delete", email); err != nil {
+		common.Error("Failed to emit delete event: %v", err)
+	}
 
 	return nil
 }

--- a/internal/mailserver/store.go
+++ b/internal/mailserver/store.go
@@ -300,6 +300,9 @@ func (ms *MailServer) DeleteAllEmail() error {
 			if file.IsDir() && (file.Name() == quarantineDirName || file.Name() == webhookOutboxDirectoryName) {
 				continue
 			}
+			if _, fenced := rollbackFenceID(file.Name()); fenced {
+				continue
+			}
 			if err := os.RemoveAll(filepath.Join(ms.mailDir, file.Name())); err != nil {
 				common.Verbose("Failed to remove file: %v", err)
 			}

--- a/internal/mailserver/store.go
+++ b/internal/mailserver/store.go
@@ -20,10 +20,10 @@ const webhookOutboxDirectoryName = ".owlmail-webhook-outbox"
 
 // SaveEmailToStore saves a parsed email to the store (exported for testing)
 func (ms *MailServer) SaveEmailToStore(id string, isRead bool, envelope *Envelope, parsedEmail *Email) error {
-	return ms.saveEmailToStore(id, isRead, envelope, parsedEmail, true)
+	return ms.saveEmailToStore(id, isRead, envelope, parsedEmail, true, false)
 }
 
-func (ms *MailServer) saveEmailToStore(id string, isRead bool, envelope *Envelope, parsedEmail *Email, persistMetadata bool) error {
+func (ms *MailServer) saveEmailToStore(id string, isRead bool, envelope *Envelope, parsedEmail *Email, persistMetadata, finalizeRollbackFence bool) error {
 	emlPath := filepath.Join(ms.mailDir, id+".eml")
 
 	parsedEmail.ID = id
@@ -80,7 +80,11 @@ func (ms *MailServer) saveEmailToStore(id string, isRead bool, envelope *Envelop
 			return fmt.Errorf("persist email metadata: %w", err)
 		}
 	}
-	if err := ms.emitSynchronous("new", storedEmail); err != nil {
+	handoffErr := ms.emitSynchronous("new", storedEmail)
+	if handoffErr == nil && finalizeRollbackFence {
+		handoffErr = ms.acceptRollbackFence(id)
+	}
+	if handoffErr != nil {
 		var rollbackErr error
 		if persistMetadata {
 			if existed {
@@ -94,9 +98,9 @@ func (ms *MailServer) saveEmailToStore(id string, isRead bool, envelope *Envelop
 		}
 		ms.storeMutex.Unlock()
 		if rollbackErr != nil {
-			return errors.Join(err, fmt.Errorf("roll back email metadata: %w", rollbackErr))
+			return errors.Join(handoffErr, fmt.Errorf("roll back email metadata: %w", rollbackErr))
 		}
-		return err
+		return handoffErr
 	}
 	if !existed {
 		ms.storeOrder = append(ms.storeOrder, id)
@@ -696,7 +700,7 @@ func (ms *MailServer) LoadMailsFromDirectory() error {
 		email, envelope, parseErr := ms.parseEmailMessage(id, emailFile, nil, false, filepath.Join(ms.mailDir, id))
 		closeErr := emailFile.Close()
 		if parseErr == nil && closeErr == nil {
-			if storeErr := ms.saveEmailToStore(id, markAsRead, envelope, email, false); storeErr != nil {
+			if storeErr := ms.saveEmailToStore(id, markAsRead, envelope, email, false, false); storeErr != nil {
 				loadErrors = append(loadErrors, fmt.Errorf("restore email %s: %w", id, storeErr))
 				continue
 			}

--- a/internal/mailserver/types.go
+++ b/internal/mailserver/types.go
@@ -40,9 +40,9 @@ type TLSConfig struct {
 }
 
 type eventListener struct {
-	handler     func(*types.Email)
-	slots       chan struct{}
-	synchronous bool
+	handler            func(*types.Email)
+	synchronousHandler func(*types.Email) error
+	slots              chan struct{}
 }
 
 // MailServer represents the SMTP mail server

--- a/internal/mailserver/types.go
+++ b/internal/mailserver/types.go
@@ -80,11 +80,12 @@ type MailServer struct {
 
 	// Storage hooks are intentionally unexported and nil in production. They
 	// provide deterministic fault injection for transaction boundary tests.
-	beforeStoreCommit     func(*types.Email) error
-	beforeAttachmentWrite func(string) error
-	beforeQuarantineMove  func(string) error
-	beforeEmailRollback   func(string) error
-	beforeEmailDelete     func(string) error
+	beforeStoreCommit          func(*types.Email) error
+	beforeAttachmentWrite      func(string) error
+	beforeQuarantineMove       func(string) error
+	beforeEmailRollback        func(string) error
+	beforeEmailDelete          func(string) error
+	syncAcceptedFenceDirectory func(string) error
 }
 
 // GetHost returns the SMTP server host

--- a/internal/mailserver/types.go
+++ b/internal/mailserver/types.go
@@ -82,6 +82,7 @@ type MailServer struct {
 	beforeStoreCommit     func(*types.Email) error
 	beforeAttachmentWrite func(string) error
 	beforeQuarantineMove  func(string) error
+	beforeEmailRollback   func(string) error
 	beforeEmailDelete     func(string) error
 }
 

--- a/internal/mailserver/types.go
+++ b/internal/mailserver/types.go
@@ -47,21 +47,22 @@ type eventListener struct {
 
 // MailServer represents the SMTP mail server
 type MailServer struct {
-	storeByID      map[string]*types.Email
-	storeOrder     []string
-	receivedAtByID map[string]time.Time
-	storeMutex     sync.RWMutex
-	mailDir        string
-	port           int
-	host           string
-	smtpServer     *smtp.Server
-	smtpsServer    *smtp.Server // SMTPS server (direct TLS on 465)
-	eventChan      chan Event
-	listeners      map[string][]eventListener
-	listenersMutex sync.RWMutex
-	closers        []io.Closer
-	closersMutex   sync.Mutex
-	outgoing       interface {
+	storeByID               map[string]*types.Email
+	storeOrder              []string
+	receivedAtByID          map[string]time.Time
+	storeMutex              sync.RWMutex
+	storageTransactionMutex sync.Mutex
+	mailDir                 string
+	port                    int
+	host                    string
+	smtpServer              *smtp.Server
+	smtpsServer             *smtp.Server // SMTPS server (direct TLS on 465)
+	eventChan               chan Event
+	listeners               map[string][]eventListener
+	listenersMutex          sync.RWMutex
+	closers                 []io.Closer
+	closersMutex            sync.Mutex
+	outgoing                interface {
 		RelayMail(email *types.Email, emlPath, relayTo string, isAutoRelay bool, callback func(error))
 		UpdateConfig(config interface{})
 		GetConfig() interface{}

--- a/internal/webhook/outbox.go
+++ b/internal/webhook/outbox.go
@@ -2,7 +2,6 @@ package webhook
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,7 +16,6 @@ const outboxDirectoryName = ".owlmail-webhook-outbox"
 type deliveryOutbox struct {
 	dir           string
 	mutex         sync.Mutex
-	removeFile    func(string) error
 	syncDirectory func(string) error
 }
 
@@ -30,7 +28,6 @@ func newDeliveryOutbox(spoolDir string) (*deliveryOutbox, error) {
 	dir := filepath.Join(spoolDir, outboxDirectoryName)
 	outbox := &deliveryOutbox{
 		dir:           dir,
-		removeFile:    os.Remove,
 		syncDirectory: syncOutboxDirectory,
 	}
 	if err := outbox.ensureDirectory(); err != nil {
@@ -82,29 +79,14 @@ func (outbox *deliveryOutbox) Store(job deliveryJob) error {
 		return fmt.Errorf("commit webhook outbox job: %w", err)
 	}
 	if err := outbox.syncDirectory(outbox.dir); err != nil {
-		removeErr := outbox.removeFile(finalPath)
-		if removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-			// The entry is still visible to the worker, so resolve the handoff as
-			// committed. Returning an error here would roll back the email while
-			// allowing its webhook to be delivered.
-			committed = true
-			return nil
-		}
-		resyncErr := outbox.syncDirectory(outbox.dir)
-		return errors.Join(
-			fmt.Errorf("sync webhook outbox: %w", err),
-			wrapOutboxCleanupError("sync webhook outbox cleanup", resyncErr),
-		)
+		// The rename is visible but its durability is indeterminate. Resolve the
+		// handoff as committed instead of unlinking it and rejecting an email
+		// whose webhook could reappear after a crash.
+		committed = true
+		return nil
 	}
 	committed = true
 	return nil
-}
-
-func wrapOutboxCleanupError(message string, err error) error {
-	if err == nil || errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	return fmt.Errorf("%s: %w", message, err)
 }
 
 func (outbox *deliveryOutbox) List() ([]outboxEntry, error) {
@@ -145,7 +127,7 @@ func (outbox *deliveryOutbox) Remove(path string) error {
 	if filepath.Dir(path) != outbox.dir {
 		return fmt.Errorf("remove webhook outbox job outside spool")
 	}
-	if err := outbox.removeFile(path); err != nil {
+	if err := os.Remove(path); err != nil {
 		return fmt.Errorf("remove webhook outbox job: %w", err)
 	}
 	return outbox.syncDirectory(outbox.dir)

--- a/internal/webhook/outbox.go
+++ b/internal/webhook/outbox.go
@@ -2,18 +2,21 @@ package webhook
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 )
 
 const outboxDirectoryName = ".owlmail-webhook-outbox"
 
 type deliveryOutbox struct {
-	dir string
+	dir   string
+	mutex sync.Mutex
 }
 
 type outboxEntry struct {
@@ -35,6 +38,8 @@ func (outbox *deliveryOutbox) ensureDirectory() error {
 }
 
 func (outbox *deliveryOutbox) Store(job deliveryJob) error {
+	outbox.mutex.Lock()
+	defer outbox.mutex.Unlock()
 	if err := outbox.ensureDirectory(); err != nil {
 		return fmt.Errorf("create webhook outbox: %w", err)
 	}
@@ -70,14 +75,29 @@ func (outbox *deliveryOutbox) Store(job deliveryJob) error {
 	if err := os.Rename(temporaryPath, finalPath); err != nil {
 		return fmt.Errorf("commit webhook outbox job: %w", err)
 	}
-	committed = true
 	if err := syncOutboxDirectory(outbox.dir); err != nil {
-		return fmt.Errorf("sync webhook outbox: %w", err)
+		removeErr := os.Remove(finalPath)
+		resyncErr := syncOutboxDirectory(outbox.dir)
+		return errors.Join(
+			fmt.Errorf("sync webhook outbox: %w", err),
+			wrapOutboxCleanupError("remove unsynced webhook outbox job", removeErr),
+			wrapOutboxCleanupError("sync webhook outbox cleanup", resyncErr),
+		)
 	}
+	committed = true
 	return nil
 }
 
+func wrapOutboxCleanupError(message string, err error) error {
+	if err == nil || errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", message, err)
+}
+
 func (outbox *deliveryOutbox) List() ([]outboxEntry, error) {
+	outbox.mutex.Lock()
+	defer outbox.mutex.Unlock()
 	if err := outbox.ensureDirectory(); err != nil {
 		return nil, fmt.Errorf("create webhook outbox: %w", err)
 	}
@@ -108,6 +128,8 @@ func (outbox *deliveryOutbox) List() ([]outboxEntry, error) {
 }
 
 func (outbox *deliveryOutbox) Remove(path string) error {
+	outbox.mutex.Lock()
+	defer outbox.mutex.Unlock()
 	if filepath.Dir(path) != outbox.dir {
 		return fmt.Errorf("remove webhook outbox job outside spool")
 	}

--- a/internal/webhook/outbox.go
+++ b/internal/webhook/outbox.go
@@ -13,6 +13,13 @@ import (
 
 const outboxDirectoryName = ".owlmail-webhook-outbox"
 
+const (
+	mailRollbackFencePrefix = ".owlmail-tmp-rollback-"
+	mailRollbackFenceSuffix = ".fence"
+	mailRollbackState       = "rollback"
+	mailMetadataDirectory   = ".owlmail-meta"
+)
+
 type deliveryOutbox struct {
 	dir           string
 	mutex         sync.Mutex
@@ -128,6 +135,80 @@ func (outbox *deliveryOutbox) Commit(emailID string) error {
 		return nil
 	}
 	return nil
+}
+
+// PruneRejectedPending removes staged jobs that can never be promoted because
+// the matching mail transaction is durably rollback-fenced or has no durable
+// EML/metadata state.
+func (outbox *deliveryOutbox) PruneRejectedPending() error {
+	outbox.mutex.Lock()
+	defer outbox.mutex.Unlock()
+	files, err := os.ReadDir(outbox.dir)
+	if err != nil {
+		return fmt.Errorf("read pending webhook outbox: %w", err)
+	}
+	removed := false
+	spoolDir := filepath.Dir(outbox.dir)
+	for _, file := range files {
+		if file.IsDir() || !strings.HasSuffix(file.Name(), ".pending") {
+			continue
+		}
+		pendingPath := filepath.Join(outbox.dir, file.Name())
+		encoded, err := os.ReadFile(pendingPath)
+		if err != nil {
+			return fmt.Errorf("read pending webhook outbox job %s: %w", file.Name(), err)
+		}
+		var job deliveryJob
+		if err := json.Unmarshal(encoded, &job); err != nil {
+			return fmt.Errorf("decode pending webhook outbox job %s: %w", file.Name(), err)
+		}
+		if job.Email == nil || job.Email.ID == "" || filepath.Base(job.Email.ID) != job.Email.ID {
+			return fmt.Errorf("invalid email ID in pending webhook outbox job %s", file.Name())
+		}
+		rejected, err := pendingMailRejected(spoolDir, job.Email.ID)
+		if err != nil {
+			return err
+		}
+		if !rejected {
+			continue
+		}
+		if err := os.Remove(pendingPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove rejected pending webhook outbox job: %w", err)
+		}
+		removed = true
+	}
+	if removed {
+		return outbox.syncDirectory(outbox.dir)
+	}
+	return nil
+}
+
+func pendingMailRejected(spoolDir, emailID string) (bool, error) {
+	fencePath := filepath.Join(spoolDir, mailRollbackFencePrefix+emailID+mailRollbackFenceSuffix)
+	if encoded, err := os.ReadFile(fencePath); err == nil {
+		return strings.TrimSpace(string(encoded)) == mailRollbackState, nil
+	} else if !os.IsNotExist(err) {
+		return false, fmt.Errorf("read mail rollback fence for pending webhook job: %w", err)
+	}
+	emlMissing, err := storagePathMissing(filepath.Join(spoolDir, emailID+".eml"))
+	if err != nil {
+		return false, err
+	}
+	metadataMissing, err := storagePathMissing(filepath.Join(spoolDir, mailMetadataDirectory, emailID+".json"))
+	if err != nil {
+		return false, err
+	}
+	return emlMissing && metadataMissing, nil
+}
+
+func storagePathMissing(path string) (bool, error) {
+	if _, err := os.Stat(path); err == nil {
+		return false, nil
+	} else if os.IsNotExist(err) {
+		return true, nil
+	} else {
+		return false, err
+	}
 }
 
 func (outbox *deliveryOutbox) List() ([]outboxEntry, error) {

--- a/internal/webhook/outbox.go
+++ b/internal/webhook/outbox.go
@@ -128,7 +128,11 @@ func (outbox *deliveryOutbox) Commit(emailID string) error {
 		}
 		promoted = true
 	}
-	if promoted {
+	fenceState, err := mailFenceState(filepath.Dir(outbox.dir), emailID)
+	if err != nil {
+		return err
+	}
+	if promoted || fenceState == mailAcceptedState {
 		if err := outbox.syncDirectory(outbox.dir); err != nil {
 			return fmt.Errorf("sync committed webhook outbox job: %w", err)
 		}

--- a/internal/webhook/outbox.go
+++ b/internal/webhook/outbox.go
@@ -136,6 +136,42 @@ func (outbox *deliveryOutbox) Commit(emailID string) error {
 	return cleanupAcceptedMailFence(filepath.Dir(outbox.dir), emailID)
 }
 
+// Discard removes staged jobs for a mail transaction that did not commit.
+func (outbox *deliveryOutbox) Discard(emailID string) error {
+	outbox.mutex.Lock()
+	defer outbox.mutex.Unlock()
+	files, err := os.ReadDir(outbox.dir)
+	if err != nil {
+		return err
+	}
+	removed := false
+	for _, file := range files {
+		if file.IsDir() || !strings.HasSuffix(file.Name(), ".pending") {
+			continue
+		}
+		path := filepath.Join(outbox.dir, file.Name())
+		encoded, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		var job deliveryJob
+		if err := json.Unmarshal(encoded, &job); err != nil {
+			return err
+		}
+		if job.Email == nil || job.Email.ID != emailID {
+			continue
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		removed = true
+	}
+	if removed {
+		return outbox.syncDirectory(outbox.dir)
+	}
+	return nil
+}
+
 // AcceptedPendingEmailIDs returns durable recovery keys whose mail may already
 // have been deleted. Only an accepted fence authorizes promotion.
 func (outbox *deliveryOutbox) AcceptedPendingEmailIDs() ([]string, error) {

--- a/internal/webhook/outbox.go
+++ b/internal/webhook/outbox.go
@@ -15,8 +15,10 @@ import (
 const outboxDirectoryName = ".owlmail-webhook-outbox"
 
 type deliveryOutbox struct {
-	dir   string
-	mutex sync.Mutex
+	dir           string
+	mutex         sync.Mutex
+	removeFile    func(string) error
+	syncDirectory func(string) error
 }
 
 type outboxEntry struct {
@@ -26,7 +28,11 @@ type outboxEntry struct {
 
 func newDeliveryOutbox(spoolDir string) (*deliveryOutbox, error) {
 	dir := filepath.Join(spoolDir, outboxDirectoryName)
-	outbox := &deliveryOutbox{dir: dir}
+	outbox := &deliveryOutbox{
+		dir:           dir,
+		removeFile:    os.Remove,
+		syncDirectory: syncOutboxDirectory,
+	}
 	if err := outbox.ensureDirectory(); err != nil {
 		return nil, fmt.Errorf("create webhook outbox: %w", err)
 	}
@@ -75,12 +81,18 @@ func (outbox *deliveryOutbox) Store(job deliveryJob) error {
 	if err := os.Rename(temporaryPath, finalPath); err != nil {
 		return fmt.Errorf("commit webhook outbox job: %w", err)
 	}
-	if err := syncOutboxDirectory(outbox.dir); err != nil {
-		removeErr := os.Remove(finalPath)
-		resyncErr := syncOutboxDirectory(outbox.dir)
+	if err := outbox.syncDirectory(outbox.dir); err != nil {
+		removeErr := outbox.removeFile(finalPath)
+		if removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			// The entry is still visible to the worker, so resolve the handoff as
+			// committed. Returning an error here would roll back the email while
+			// allowing its webhook to be delivered.
+			committed = true
+			return nil
+		}
+		resyncErr := outbox.syncDirectory(outbox.dir)
 		return errors.Join(
 			fmt.Errorf("sync webhook outbox: %w", err),
-			wrapOutboxCleanupError("remove unsynced webhook outbox job", removeErr),
 			wrapOutboxCleanupError("sync webhook outbox cleanup", resyncErr),
 		)
 	}
@@ -133,10 +145,10 @@ func (outbox *deliveryOutbox) Remove(path string) error {
 	if filepath.Dir(path) != outbox.dir {
 		return fmt.Errorf("remove webhook outbox job outside spool")
 	}
-	if err := os.Remove(path); err != nil {
+	if err := outbox.removeFile(path); err != nil {
 		return fmt.Errorf("remove webhook outbox job: %w", err)
 	}
-	return syncOutboxDirectory(outbox.dir)
+	return outbox.syncDirectory(outbox.dir)
 }
 
 func syncOutboxDirectory(path string) error {

--- a/internal/webhook/outbox.go
+++ b/internal/webhook/outbox.go
@@ -16,6 +16,7 @@ const outboxDirectoryName = ".owlmail-webhook-outbox"
 const (
 	mailRollbackFencePrefix = ".owlmail-tmp-rollback-"
 	mailRollbackFenceSuffix = ".fence"
+	mailActiveState         = "active"
 	mailRollbackState       = "rollback"
 	mailMetadataDirectory   = ".owlmail-meta"
 )

--- a/internal/webhook/outbox.go
+++ b/internal/webhook/outbox.go
@@ -74,18 +74,59 @@ func (outbox *deliveryOutbox) Store(job deliveryJob) error {
 	if err := temporary.Close(); err != nil {
 		return fmt.Errorf("close webhook outbox job: %w", err)
 	}
-	finalPath := filepath.Join(outbox.dir, job.ID+".json")
+	finalPath := filepath.Join(outbox.dir, job.ID+".pending")
 	if err := os.Rename(temporaryPath, finalPath); err != nil {
 		return fmt.Errorf("commit webhook outbox job: %w", err)
 	}
 	if err := outbox.syncDirectory(outbox.dir); err != nil {
-		// The rename is visible but its durability is indeterminate. Resolve the
-		// handoff as committed instead of unlinking it and rejecting an email
-		// whose webhook could reappear after a crash.
+		// Keep the non-consumable pending entry. The caller can reject safely:
+		// recovery promotes pending jobs only for durably accepted emails.
 		committed = true
-		return nil
+		return fmt.Errorf("sync pending webhook outbox job: %w", err)
 	}
 	committed = true
+	return nil
+}
+
+// Commit promotes staged jobs for an accepted email into the consumable
+// outbox namespace. The caller persists mail acceptance before calling this.
+func (outbox *deliveryOutbox) Commit(emailID string) error {
+	outbox.mutex.Lock()
+	defer outbox.mutex.Unlock()
+	files, err := os.ReadDir(outbox.dir)
+	if err != nil {
+		return fmt.Errorf("read pending webhook outbox: %w", err)
+	}
+	promoted := false
+	for _, file := range files {
+		if file.IsDir() || !strings.HasSuffix(file.Name(), ".pending") {
+			continue
+		}
+		pendingPath := filepath.Join(outbox.dir, file.Name())
+		encoded, err := os.ReadFile(pendingPath)
+		if err != nil {
+			return fmt.Errorf("read pending webhook outbox job %s: %w", file.Name(), err)
+		}
+		var job deliveryJob
+		if err := json.Unmarshal(encoded, &job); err != nil {
+			return fmt.Errorf("decode pending webhook outbox job %s: %w", file.Name(), err)
+		}
+		if job.Email == nil || job.Email.ID != emailID {
+			continue
+		}
+		committedPath := strings.TrimSuffix(pendingPath, ".pending") + ".json"
+		if err := os.Rename(pendingPath, committedPath); err != nil {
+			return fmt.Errorf("commit pending webhook outbox job: %w", err)
+		}
+		promoted = true
+	}
+	if !promoted {
+		return nil
+	}
+	if err := outbox.syncDirectory(outbox.dir); err != nil {
+		// Promoted entries are already visible after durable mail acceptance.
+		return nil
+	}
 	return nil
 }
 

--- a/internal/webhook/outbox.go
+++ b/internal/webhook/outbox.go
@@ -18,7 +18,6 @@ const (
 	mailRollbackFenceSuffix = ".fence"
 	mailActiveState         = "active"
 	mailRollbackState       = "rollback"
-	mailMetadataDirectory   = ".owlmail-meta"
 )
 
 type deliveryOutbox struct {
@@ -139,8 +138,7 @@ func (outbox *deliveryOutbox) Commit(emailID string) error {
 }
 
 // PruneRejectedPending removes staged jobs that can never be promoted because
-// the matching mail transaction is durably rollback-fenced or has no durable
-// EML/metadata state.
+// the matching mail transaction is explicitly and durably rollback-fenced.
 func (outbox *deliveryOutbox) PruneRejectedPending() error {
 	outbox.mutex.Lock()
 	defer outbox.mutex.Unlock()
@@ -191,25 +189,7 @@ func pendingMailRejected(spoolDir, emailID string) (bool, error) {
 	} else if !os.IsNotExist(err) {
 		return false, fmt.Errorf("read mail rollback fence for pending webhook job: %w", err)
 	}
-	emlMissing, err := storagePathMissing(filepath.Join(spoolDir, emailID+".eml"))
-	if err != nil {
-		return false, err
-	}
-	metadataMissing, err := storagePathMissing(filepath.Join(spoolDir, mailMetadataDirectory, emailID+".json"))
-	if err != nil {
-		return false, err
-	}
-	return emlMissing && metadataMissing, nil
-}
-
-func storagePathMissing(path string) (bool, error) {
-	if _, err := os.Stat(path); err == nil {
-		return false, nil
-	} else if os.IsNotExist(err) {
-		return true, nil
-	} else {
-		return false, err
-	}
+	return false, nil
 }
 
 func (outbox *deliveryOutbox) List() ([]outboxEntry, error) {

--- a/internal/webhook/outbox.go
+++ b/internal/webhook/outbox.go
@@ -18,6 +18,7 @@ const (
 	mailRollbackFenceSuffix = ".fence"
 	mailActiveState         = "active"
 	mailRollbackState       = "rollback"
+	mailAcceptedState       = "accepted"
 )
 
 type deliveryOutbox struct {
@@ -127,14 +128,81 @@ func (outbox *deliveryOutbox) Commit(emailID string) error {
 		}
 		promoted = true
 	}
-	if !promoted {
+	if promoted {
+		if err := outbox.syncDirectory(outbox.dir); err != nil {
+			return fmt.Errorf("sync committed webhook outbox job: %w", err)
+		}
+	}
+	return cleanupAcceptedMailFence(filepath.Dir(outbox.dir), emailID)
+}
+
+// AcceptedPendingEmailIDs returns durable recovery keys whose mail may already
+// have been deleted. Only an accepted fence authorizes promotion.
+func (outbox *deliveryOutbox) AcceptedPendingEmailIDs() ([]string, error) {
+	outbox.mutex.Lock()
+	defer outbox.mutex.Unlock()
+	files, err := os.ReadDir(outbox.dir)
+	if err != nil {
+		return nil, err
+	}
+	spoolDir := filepath.Dir(outbox.dir)
+	accepted := make(map[string]struct{})
+	for _, file := range files {
+		if file.IsDir() || !strings.HasSuffix(file.Name(), ".pending") {
+			continue
+		}
+		encoded, err := os.ReadFile(filepath.Join(outbox.dir, file.Name()))
+		if err != nil {
+			return nil, err
+		}
+		var job deliveryJob
+		if err := json.Unmarshal(encoded, &job); err != nil {
+			return nil, err
+		}
+		if job.Email == nil || job.Email.ID == "" || filepath.Base(job.Email.ID) != job.Email.ID {
+			return nil, fmt.Errorf("invalid email ID in pending webhook outbox job %s", file.Name())
+		}
+		state, err := mailFenceState(spoolDir, job.Email.ID)
+		if err != nil {
+			return nil, err
+		}
+		if state == mailAcceptedState {
+			accepted[job.Email.ID] = struct{}{}
+		}
+	}
+	ids := make([]string, 0, len(accepted))
+	for id := range accepted {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids, nil
+}
+
+func cleanupAcceptedMailFence(spoolDir, emailID string) error {
+	fencePath := filepath.Join(spoolDir, mailRollbackFencePrefix+emailID+mailRollbackFenceSuffix)
+	state, err := mailFenceState(spoolDir, emailID)
+	if err != nil {
+		return err
+	}
+	if state != mailAcceptedState {
 		return nil
 	}
-	if err := outbox.syncDirectory(outbox.dir); err != nil {
-		// Promoted entries are already visible after durable mail acceptance.
-		return nil
+	if err := os.Remove(fencePath); err != nil && !os.IsNotExist(err) {
+		return err
 	}
-	return nil
+	return syncOutboxDirectory(spoolDir)
+}
+
+func mailFenceState(spoolDir, emailID string) (string, error) {
+	fencePath := filepath.Join(spoolDir, mailRollbackFencePrefix+emailID+mailRollbackFenceSuffix)
+	encoded, err := os.ReadFile(fencePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(encoded)), nil
 }
 
 // PruneRejectedPending removes staged jobs that can never be promoted because

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -251,11 +251,9 @@ func stopOutboxRetry(retry *time.Timer) {
 }
 
 func (service *Service) flushOutbox() (bool, error) {
-	if err := service.retryPromotions(); err != nil {
-		return false, err
-	}
+	service.retryPromotions()
 	if err := service.outbox.PruneRejectedPending(); err != nil {
-		return false, err
+		service.report("", []Result{{Err: err}})
 	}
 	entries, err := service.outbox.List()
 	if err != nil {
@@ -282,7 +280,7 @@ func (service *Service) flushOutbox() (bool, error) {
 	return true, nil
 }
 
-func (service *Service) retryPromotions() error {
+func (service *Service) retryPromotions() {
 	var promotionErrors []error
 	service.promotions.Range(func(key, _ any) bool {
 		emailID, ok := key.(string)
@@ -297,7 +295,9 @@ func (service *Service) retryPromotions() error {
 		service.promotions.Delete(emailID)
 		return true
 	})
-	return errors.Join(promotionErrors...)
+	if err := errors.Join(promotionErrors...); err != nil {
+		service.report("", []Result{{Err: err}})
+	}
 }
 
 func cloneDeliveryEmail(email *types.Email) (*types.Email, error) {

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -131,17 +131,26 @@ func (service *Service) Enqueue(email *types.Email) error {
 	if service == nil || email == nil {
 		return fmt.Errorf("webhook email is nil")
 	}
+	reservationID := ""
 	service.handoffMutex.Lock()
 	if !service.accepting {
 		service.handoffMutex.Unlock()
 		return fmt.Errorf("webhook service is shutting down")
 	}
 	service.handoffs.Add(1)
+	if service.outbox != nil {
+		reservationID = uuid.NewString()
+		service.stagedHandoffs.Store(reservationID, email.ID)
+	}
 	service.handoffMutex.Unlock()
 	releaseHandoff := true
 	defer func() {
 		if releaseHandoff {
-			service.handoffs.Done()
+			if reservationID != "" {
+				service.releaseStagedReservation(reservationID)
+			} else {
+				service.handoffs.Done()
+			}
 		}
 	}()
 	emailSnapshot, err := cloneDeliveryEmail(email)
@@ -154,7 +163,6 @@ func (service *Service) Enqueue(email *types.Email) error {
 			service.wakeOutbox()
 			return err
 		}
-		service.stagedHandoffs.Store(email.ID, struct{}{})
 		releaseHandoff = false
 		return nil
 	}
@@ -183,11 +191,9 @@ func (service *Service) Commit(emailID string) error {
 		service.promotions.Store(emailID, struct{}{})
 	} else {
 		service.promotions.Delete(emailID)
+		service.releaseStagedHandoffs(emailID)
 	}
 	service.wakeOutbox()
-	if _, tracked := service.stagedHandoffs.LoadAndDelete(emailID); tracked {
-		service.handoffs.Done()
-	}
 	return err
 }
 
@@ -197,11 +203,37 @@ func (service *Service) Abort(emailID string) error {
 		return nil
 	}
 	err := service.outbox.Discard(emailID)
-	if _, tracked := service.stagedHandoffs.LoadAndDelete(emailID); tracked {
-		service.handoffs.Done()
-	}
+	service.releaseStagedHandoffs(emailID)
 	service.wakeOutbox()
 	return err
+}
+
+func (service *Service) releaseStagedReservation(reservationID string) {
+	if _, tracked := service.stagedHandoffs.LoadAndDelete(reservationID); tracked {
+		service.handoffs.Done()
+	}
+}
+
+func (service *Service) releaseStagedHandoffs(emailID string) {
+	service.stagedHandoffs.Range(func(key, value any) bool {
+		trackedEmailID, ok := value.(string)
+		if !ok || trackedEmailID != emailID {
+			return true
+		}
+		if _, tracked := service.stagedHandoffs.LoadAndDelete(key); tracked {
+			service.handoffs.Done()
+		}
+		return true
+	})
+}
+
+func (service *Service) releaseAllStagedHandoffs() {
+	service.stagedHandoffs.Range(func(key, _ any) bool {
+		if _, tracked := service.stagedHandoffs.LoadAndDelete(key); tracked {
+			service.handoffs.Done()
+		}
+		return true
+	})
 }
 
 // RecoverAcceptedPending promotes accepted jobs using durable fence state,
@@ -336,6 +368,7 @@ func (service *Service) retryPromotions() {
 			return true
 		}
 		service.promotions.Delete(emailID)
+		service.releaseStagedHandoffs(emailID)
 		return true
 	})
 	if err := errors.Join(promotionErrors...); err != nil {
@@ -507,6 +540,7 @@ func (service *Service) Close() error {
 		case <-timer.C:
 			service.closeErr = fmt.Errorf("webhook drain exceeded %s", service.shutdownTimeout)
 			service.cancel()
+			service.releaseAllStagedHandoffs()
 			<-drained
 		}
 		service.cancel()

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -59,6 +59,7 @@ type Service struct {
 	outboxWorkers   sync.WaitGroup
 	deliveries      sync.WaitGroup
 	promotions      sync.Map
+	stagedHandoffs  sync.Map
 	closeErr        error
 }
 
@@ -137,7 +138,12 @@ func (service *Service) Enqueue(email *types.Email) error {
 	}
 	service.handoffs.Add(1)
 	service.handoffMutex.Unlock()
-	defer service.handoffs.Done()
+	releaseHandoff := true
+	defer func() {
+		if releaseHandoff {
+			service.handoffs.Done()
+		}
+	}()
 	emailSnapshot, err := cloneDeliveryEmail(email)
 	if err != nil {
 		return err
@@ -148,6 +154,8 @@ func (service *Service) Enqueue(email *types.Email) error {
 			service.wakeOutbox()
 			return err
 		}
+		service.stagedHandoffs.Store(email.ID, struct{}{})
+		releaseHandoff = false
 		return nil
 	}
 	if service.queue != nil {
@@ -175,6 +183,22 @@ func (service *Service) Commit(emailID string) error {
 		service.promotions.Store(emailID, struct{}{})
 	} else {
 		service.promotions.Delete(emailID)
+	}
+	service.wakeOutbox()
+	if _, tracked := service.stagedHandoffs.LoadAndDelete(emailID); tracked {
+		service.handoffs.Done()
+	}
+	return err
+}
+
+// Abort releases a staged handoff for a mail transaction that was rejected.
+func (service *Service) Abort(emailID string) error {
+	if service == nil || service.outbox == nil || emailID == "" {
+		return nil
+	}
+	err := service.outbox.Discard(emailID)
+	if _, tracked := service.stagedHandoffs.LoadAndDelete(emailID); tracked {
+		service.handoffs.Done()
 	}
 	service.wakeOutbox()
 	return err

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -180,6 +180,25 @@ func (service *Service) Commit(emailID string) error {
 	return err
 }
 
+// RecoverAcceptedPending promotes accepted jobs using durable fence state,
+// independent of whether the email is still present in the mailbox.
+func (service *Service) RecoverAcceptedPending() error {
+	if service == nil || service.outbox == nil {
+		return nil
+	}
+	ids, err := service.outbox.AcceptedPendingEmailIDs()
+	if err != nil {
+		return err
+	}
+	var recoveryErrors []error
+	for _, emailID := range ids {
+		if err := service.Commit(emailID); err != nil {
+			recoveryErrors = append(recoveryErrors, fmt.Errorf("recover accepted webhook job for %s: %w", emailID, err))
+		}
+	}
+	return errors.Join(recoveryErrors...)
+}
+
 func (service *Service) wakeOutbox() {
 	select {
 	case service.outboxWake <- struct{}{}:

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -146,7 +146,6 @@ func (service *Service) Enqueue(email *types.Email) error {
 		if err := service.outbox.Store(job); err != nil {
 			return err
 		}
-		service.wakeOutbox()
 		return nil
 	}
 	if service.queue != nil {
@@ -161,6 +160,17 @@ func (service *Service) Enqueue(email *types.Email) error {
 	case <-service.ctx.Done():
 		return service.ctx.Err()
 	}
+}
+
+// Commit makes staged outbox jobs consumable after the mail server has durably
+// recorded acceptance. Calling it again is safe and supports startup recovery.
+func (service *Service) Commit(emailID string) error {
+	if service == nil || service.outbox == nil || emailID == "" {
+		return nil
+	}
+	err := service.outbox.Commit(emailID)
+	service.wakeOutbox()
+	return err
 }
 
 func (service *Service) wakeOutbox() {

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -58,6 +58,7 @@ type Service struct {
 	workers         sync.WaitGroup
 	outboxWorkers   sync.WaitGroup
 	deliveries      sync.WaitGroup
+	promotions      sync.Map
 	closeErr        error
 }
 
@@ -144,6 +145,7 @@ func (service *Service) Enqueue(email *types.Email) error {
 	job := deliveryJob{ID: uuid.NewString(), EnqueuedAt: time.Now().UTC(), Email: emailSnapshot}
 	if service.outbox != nil {
 		if err := service.outbox.Store(job); err != nil {
+			service.wakeOutbox()
 			return err
 		}
 		return nil
@@ -169,6 +171,11 @@ func (service *Service) Commit(emailID string) error {
 		return nil
 	}
 	err := service.outbox.Commit(emailID)
+	if err != nil {
+		service.promotions.Store(emailID, struct{}{})
+	} else {
+		service.promotions.Delete(emailID)
+	}
 	service.wakeOutbox()
 	return err
 }
@@ -220,10 +227,14 @@ func (service *Service) runOutbox() {
 		if closing {
 			return
 		}
+		retry.Reset(defaultOutboxRetry)
 		select {
+		case <-retry.C:
 		case <-service.outboxWake:
+			stopOutboxRetry(retry)
 		case <-service.outboxClosing:
 			closing = true
+			stopOutboxRetry(retry)
 		case <-service.ctx.Done():
 			return
 		}
@@ -240,6 +251,12 @@ func stopOutboxRetry(retry *time.Timer) {
 }
 
 func (service *Service) flushOutbox() (bool, error) {
+	if err := service.retryPromotions(); err != nil {
+		return false, err
+	}
+	if err := service.outbox.PruneRejectedPending(); err != nil {
+		return false, err
+	}
 	entries, err := service.outbox.List()
 	if err != nil {
 		return false, err
@@ -263,6 +280,24 @@ func (service *Service) flushOutbox() (bool, error) {
 		return true, err
 	}
 	return true, nil
+}
+
+func (service *Service) retryPromotions() error {
+	var promotionErrors []error
+	service.promotions.Range(func(key, _ any) bool {
+		emailID, ok := key.(string)
+		if !ok {
+			service.promotions.Delete(key)
+			return true
+		}
+		if err := service.outbox.Commit(emailID); err != nil {
+			promotionErrors = append(promotionErrors, fmt.Errorf("promote accepted webhook job for %s: %w", emailID, err))
+			return true
+		}
+		service.promotions.Delete(emailID)
+		return true
+	})
+	return errors.Join(promotionErrors...)
 }
 
 func cloneDeliveryEmail(email *types.Email) (*types.Email, error) {

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -143,11 +143,10 @@ func (service *Service) Enqueue(email *types.Email) error {
 	}
 	job := deliveryJob{ID: uuid.NewString(), EnqueuedAt: time.Now().UTC(), Email: emailSnapshot}
 	if service.outbox != nil {
-		err := service.outbox.Store(job)
-		service.wakeOutbox()
-		if err != nil {
+		if err := service.outbox.Store(job); err != nil {
 			return err
 		}
+		service.wakeOutbox()
 		return nil
 	}
 	if service.queue != nil {

--- a/internal/webhook/service_test.go
+++ b/internal/webhook/service_test.go
@@ -200,6 +200,73 @@ func TestOutboxRecreatesMissingDirectory(t *testing.T) {
 	}
 }
 
+func TestOutboxEnqueueCommitsVisibleEntryWhenRollbackRemovalFails(t *testing.T) {
+	outbox, err := newDeliveryOutbox(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	syncCalls := 0
+	outbox.syncDirectory = func(string) error {
+		syncCalls++
+		if syncCalls == 1 {
+			return errors.New("injected directory sync failure")
+		}
+		return nil
+	}
+	outbox.removeFile = func(string) error {
+		return errors.New("injected rollback removal failure")
+	}
+	service := &Service{
+		outbox: outbox, outboxWake: make(chan struct{}, 1),
+		ctx: context.Background(), accepting: true,
+	}
+
+	if err := service.Enqueue(testEmail()); err != nil {
+		t.Fatalf("visible outbox entry must resolve as committed: %v", err)
+	}
+	select {
+	case <-service.outboxWake:
+	default:
+		t.Fatal("committed visible outbox entry did not wake the worker")
+	}
+	entries, err := outbox.List()
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("visible committed outbox entry = %#v, %v", entries, err)
+	}
+}
+
+func TestOutboxReportsSyncFailureAfterConfirmedRollback(t *testing.T) {
+	outbox, err := newDeliveryOutbox(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	syncCalls := 0
+	outbox.syncDirectory = func(string) error {
+		syncCalls++
+		if syncCalls == 1 {
+			return errors.New("injected directory sync failure")
+		}
+		return nil
+	}
+	service := &Service{
+		outbox: outbox, outboxWake: make(chan struct{}, 1),
+		ctx: context.Background(), accepting: true,
+	}
+
+	if err := service.Enqueue(testEmail()); err == nil {
+		t.Fatal("confirmed outbox rollback must report the original sync failure")
+	}
+	select {
+	case <-service.outboxWake:
+		t.Fatal("failed outbox handoff woke the worker")
+	default:
+	}
+	entries, err := outbox.List()
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("outbox after confirmed rollback = %#v, %v", entries, err)
+	}
+}
+
 func TestOutboxCloseSignalFlushesAcceptedEntries(t *testing.T) {
 	outbox, err := newDeliveryOutbox(t.TempDir())
 	if err != nil {

--- a/internal/webhook/service_test.go
+++ b/internal/webhook/service_test.go
@@ -343,6 +343,28 @@ func TestOutboxKeepsPendingJobForActiveMailTransaction(t *testing.T) {
 	}
 }
 
+func TestOutboxKeepsPendingJobWithoutExplicitRollbackFence(t *testing.T) {
+	spoolDir := t.TempDir()
+	outbox, err := newDeliveryOutbox(spoolDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	job := deliveryJob{ID: "accepted-then-deleted", EnqueuedAt: time.Now().UTC(), Email: testEmail()}
+	if err := outbox.Store(job); err != nil {
+		t.Fatal(err)
+	}
+	if err := outbox.PruneRejectedPending(); err != nil {
+		t.Fatal(err)
+	}
+	if err := outbox.Commit(job.Email.ID); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := outbox.List()
+	if err != nil || len(entries) != 1 || entries[0].job.ID != job.ID {
+		t.Fatalf("accepted deleted-mail handoff = %#v, %v", entries, err)
+	}
+}
+
 func TestOutboxCloseSignalFlushesAcceptedEntries(t *testing.T) {
 	outbox, err := newDeliveryOutbox(t.TempDir())
 	if err != nil {

--- a/internal/webhook/service_test.go
+++ b/internal/webhook/service_test.go
@@ -320,6 +320,29 @@ func TestOutboxPrunesPendingJobForRollbackFencedMail(t *testing.T) {
 	}
 }
 
+func TestOutboxKeepsPendingJobForActiveMailTransaction(t *testing.T) {
+	spoolDir := t.TempDir()
+	outbox, err := newDeliveryOutbox(spoolDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	job := deliveryJob{ID: "active-pending", EnqueuedAt: time.Now().UTC(), Email: testEmail()}
+	if err := outbox.Store(job); err != nil {
+		t.Fatal(err)
+	}
+	fencePath := filepath.Join(spoolDir, mailRollbackFencePrefix+job.Email.ID+mailRollbackFenceSuffix)
+	if err := os.WriteFile(fencePath, []byte(mailActiveState+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := outbox.PruneRejectedPending(); err != nil {
+		t.Fatal(err)
+	}
+	files, err := os.ReadDir(outbox.dir)
+	if err != nil || len(files) != 1 || !strings.HasSuffix(files[0].Name(), ".pending") {
+		t.Fatalf("active transaction pending job = %#v, %v", files, err)
+	}
+}
+
 func TestOutboxCloseSignalFlushesAcceptedEntries(t *testing.T) {
 	outbox, err := newDeliveryOutbox(t.TempDir())
 	if err != nil {

--- a/internal/webhook/service_test.go
+++ b/internal/webhook/service_test.go
@@ -200,21 +200,13 @@ func TestOutboxRecreatesMissingDirectory(t *testing.T) {
 	}
 }
 
-func TestOutboxEnqueueCommitsVisibleEntryWhenRollbackRemovalFails(t *testing.T) {
+func TestOutboxEnqueueCommitsIndeterminateVisibleEntry(t *testing.T) {
 	outbox, err := newDeliveryOutbox(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
-	syncCalls := 0
 	outbox.syncDirectory = func(string) error {
-		syncCalls++
-		if syncCalls == 1 {
-			return errors.New("injected directory sync failure")
-		}
-		return nil
-	}
-	outbox.removeFile = func(string) error {
-		return errors.New("injected rollback removal failure")
+		return errors.New("injected directory sync failure")
 	}
 	service := &Service{
 		outbox: outbox, outboxWake: make(chan struct{}, 1),
@@ -222,7 +214,7 @@ func TestOutboxEnqueueCommitsVisibleEntryWhenRollbackRemovalFails(t *testing.T) 
 	}
 
 	if err := service.Enqueue(testEmail()); err != nil {
-		t.Fatalf("visible outbox entry must resolve as committed: %v", err)
+		t.Fatalf("indeterminate visible outbox entry must resolve as committed: %v", err)
 	}
 	select {
 	case <-service.outboxWake:
@@ -232,38 +224,6 @@ func TestOutboxEnqueueCommitsVisibleEntryWhenRollbackRemovalFails(t *testing.T) 
 	entries, err := outbox.List()
 	if err != nil || len(entries) != 1 {
 		t.Fatalf("visible committed outbox entry = %#v, %v", entries, err)
-	}
-}
-
-func TestOutboxReportsSyncFailureAfterConfirmedRollback(t *testing.T) {
-	outbox, err := newDeliveryOutbox(t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
-	syncCalls := 0
-	outbox.syncDirectory = func(string) error {
-		syncCalls++
-		if syncCalls == 1 {
-			return errors.New("injected directory sync failure")
-		}
-		return nil
-	}
-	service := &Service{
-		outbox: outbox, outboxWake: make(chan struct{}, 1),
-		ctx: context.Background(), accepting: true,
-	}
-
-	if err := service.Enqueue(testEmail()); err == nil {
-		t.Fatal("confirmed outbox rollback must report the original sync failure")
-	}
-	select {
-	case <-service.outboxWake:
-		t.Fatal("failed outbox handoff woke the worker")
-	default:
-	}
-	entries, err := outbox.List()
-	if err != nil || len(entries) != 0 {
-		t.Fatalf("outbox after confirmed rollback = %#v, %v", entries, err)
 	}
 }
 

--- a/internal/webhook/service_test.go
+++ b/internal/webhook/service_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -237,8 +238,10 @@ func TestOutboxStageSyncFailureRemainsNonConsumable(t *testing.T) {
 	}
 	select {
 	case <-service.outboxWake:
-		t.Fatal("failed staged handoff woke the worker")
+		// The worker is woken to reclaim the rejected pending entry after the
+		// mail rollback decision becomes visible.
 	default:
+		t.Fatal("failed staged handoff did not schedule pending cleanup")
 	}
 	entries, err := outbox.List()
 	if err != nil || len(entries) != 0 {
@@ -247,6 +250,73 @@ func TestOutboxStageSyncFailureRemainsNonConsumable(t *testing.T) {
 	files, err := os.ReadDir(outbox.dir)
 	if err != nil || len(files) != 1 || !strings.HasSuffix(files[0].Name(), ".pending") {
 		t.Fatalf("non-consumable pending handoff = %#v, %v", files, err)
+	}
+}
+
+func TestOutboxRetriesAcceptedPendingPromotion(t *testing.T) {
+	spoolDir := t.TempDir()
+	outbox, err := newDeliveryOutbox(spoolDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	job := deliveryJob{ID: "retry-promotion", EnqueuedAt: time.Now().UTC(), Email: testEmail()}
+	if err := outbox.Store(job); err != nil {
+		t.Fatal(err)
+	}
+	backupDir := outbox.dir + "-backup"
+	if err := os.Rename(outbox.dir, backupDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outbox.dir, []byte("blocks outbox directory"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	service := &Service{
+		outbox: outbox, outboxWake: make(chan struct{}, 1),
+		memoryQueue: make(chan deliveryJob, 1), ctx: context.Background(),
+	}
+	if err := service.Commit(job.Email.ID); err == nil {
+		t.Fatal("blocked outbox promotion unexpectedly succeeded")
+	}
+	if err := os.Remove(outbox.dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(backupDir, outbox.dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if pending, err := service.flushOutbox(); err != nil || !pending {
+		t.Fatalf("promotion retry flush = %v, %v", pending, err)
+	}
+	select {
+	case delivered := <-service.memoryQueue:
+		if delivered.ID != job.ID {
+			t.Fatalf("promoted job = %q, want %q", delivered.ID, job.ID)
+		}
+	default:
+		t.Fatal("accepted pending job was not delivered after promotion retry")
+	}
+}
+
+func TestOutboxPrunesPendingJobForRollbackFencedMail(t *testing.T) {
+	spoolDir := t.TempDir()
+	outbox, err := newDeliveryOutbox(spoolDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	job := deliveryJob{ID: "rejected-pending", EnqueuedAt: time.Now().UTC(), Email: testEmail()}
+	if err := outbox.Store(job); err != nil {
+		t.Fatal(err)
+	}
+	fencePath := filepath.Join(spoolDir, mailRollbackFencePrefix+job.Email.ID+mailRollbackFenceSuffix)
+	if err := os.WriteFile(fencePath, []byte(mailRollbackState+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := outbox.PruneRejectedPending(); err != nil {
+		t.Fatal(err)
+	}
+	files, err := os.ReadDir(outbox.dir)
+	if err != nil || len(files) != 0 {
+		t.Fatalf("outbox after rejected pending cleanup = %#v, %v", files, err)
 	}
 }
 

--- a/internal/webhook/service_test.go
+++ b/internal/webhook/service_test.go
@@ -431,6 +431,50 @@ func TestOutboxRetriesAcceptedPendingPromotion(t *testing.T) {
 	}
 }
 
+func TestOutboxRetryResyncsRenamedPromotionBeforeFenceCleanup(t *testing.T) {
+	spoolDir := t.TempDir()
+	outbox, err := newDeliveryOutbox(spoolDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	job := deliveryJob{ID: "resync-promotion", EnqueuedAt: time.Now().UTC(), Email: testEmail()}
+	if err := outbox.Store(job); err != nil {
+		t.Fatal(err)
+	}
+	fencePath := filepath.Join(spoolDir, mailRollbackFencePrefix+job.Email.ID+mailRollbackFenceSuffix)
+	if err := os.WriteFile(fencePath, []byte(mailAcceptedState+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	outbox.syncDirectory = func(string) error {
+		return errors.New("injected committed outbox sync failure")
+	}
+	if err := outbox.Commit(job.Email.ID); err == nil {
+		t.Fatal("promotion with failed directory sync unexpectedly succeeded")
+	}
+	if _, err := os.Stat(fencePath); err != nil {
+		t.Fatalf("accepted fence removed before durable promotion: %v", err)
+	}
+	files, err := os.ReadDir(outbox.dir)
+	if err != nil || len(files) != 1 || !strings.HasSuffix(files[0].Name(), ".json") {
+		t.Fatalf("renamed promotion after sync failure = %#v, %v", files, err)
+	}
+
+	syncCalls := 0
+	outbox.syncDirectory = func(string) error {
+		syncCalls++
+		return nil
+	}
+	if err := outbox.Commit(job.Email.ID); err != nil {
+		t.Fatal(err)
+	}
+	if syncCalls != 1 {
+		t.Fatalf("promotion retry directory sync calls = %d, want 1", syncCalls)
+	}
+	if _, err := os.Stat(fencePath); !os.IsNotExist(err) {
+		t.Fatalf("accepted fence survived durable promotion retry: %v", err)
+	}
+}
+
 func TestOutboxPrunesPendingJobForRollbackFencedMail(t *testing.T) {
 	spoolDir := t.TempDir()
 	outbox, err := newDeliveryOutbox(spoolDir)

--- a/internal/webhook/service_test.go
+++ b/internal/webhook/service_test.go
@@ -365,6 +365,33 @@ func TestOutboxKeepsPendingJobWithoutExplicitRollbackFence(t *testing.T) {
 	}
 }
 
+func TestRecoverAcceptedPendingAfterEmailDeletion(t *testing.T) {
+	spoolDir := t.TempDir()
+	outbox, err := newDeliveryOutbox(spoolDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	job := deliveryJob{ID: "recover-deleted-accepted", EnqueuedAt: time.Now().UTC(), Email: testEmail()}
+	if err := outbox.Store(job); err != nil {
+		t.Fatal(err)
+	}
+	fencePath := filepath.Join(spoolDir, mailRollbackFencePrefix+job.Email.ID+mailRollbackFenceSuffix)
+	if err := os.WriteFile(fencePath, []byte(mailAcceptedState+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	service := &Service{outbox: outbox, outboxWake: make(chan struct{}, 1)}
+	if err := service.RecoverAcceptedPending(); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := outbox.List()
+	if err != nil || len(entries) != 1 || entries[0].job.ID != job.ID {
+		t.Fatalf("recovered accepted deleted-mail handoff = %#v, %v", entries, err)
+	}
+	if _, err := os.Stat(fencePath); !os.IsNotExist(err) {
+		t.Fatalf("accepted recovery fence survived promotion: %v", err)
+	}
+}
+
 func TestOutboxCloseSignalFlushesAcceptedEntries(t *testing.T) {
 	outbox, err := newDeliveryOutbox(t.TempDir())
 	if err != nil {

--- a/internal/webhook/service_test.go
+++ b/internal/webhook/service_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -134,6 +135,9 @@ func TestOutboxRetainsJobUntilQueueAcceptsIt(t *testing.T) {
 	if err := outbox.Store(job); err != nil {
 		t.Fatal(err)
 	}
+	if err := outbox.Commit(job.Email.ID); err != nil {
+		t.Fatal(err)
+	}
 	queue := &fakeDeliveryQueue{claims: make(chan *queueReceipt, 1), enqueueErr: errors.New("redis unavailable")}
 	service := &Service{queue: queue, outbox: outbox, ctx: context.Background()}
 
@@ -177,6 +181,18 @@ func TestOutboxDecouplesEnqueueFromMemoryQueueCapacity(t *testing.T) {
 		t.Fatal("enqueue blocked on the unavailable in-memory queue")
 	}
 	entries, err := outbox.List()
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("staged outbox entries became consumable before acceptance = %#v, %v", entries, err)
+	}
+	select {
+	case <-service.outboxWake:
+		t.Fatal("staged outbox entry woke the worker before acceptance")
+	default:
+	}
+	if err := service.Commit(testEmail().ID); err != nil {
+		t.Fatal(err)
+	}
+	entries, err = outbox.List()
 	if err != nil || len(entries) != 1 {
 		t.Fatalf("durable outbox entries = %#v, %v", entries, err)
 	}
@@ -194,13 +210,16 @@ func TestOutboxRecreatesMissingDirectory(t *testing.T) {
 	if err := outbox.Store(job); err != nil {
 		t.Fatalf("Store() after directory removal: %v", err)
 	}
+	if err := outbox.Commit(job.Email.ID); err != nil {
+		t.Fatal(err)
+	}
 	entries, err := outbox.List()
 	if err != nil || len(entries) != 1 {
 		t.Fatalf("List() after directory recreation = %#v, %v", entries, err)
 	}
 }
 
-func TestOutboxEnqueueCommitsIndeterminateVisibleEntry(t *testing.T) {
+func TestOutboxStageSyncFailureRemainsNonConsumable(t *testing.T) {
 	outbox, err := newDeliveryOutbox(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
@@ -213,17 +232,21 @@ func TestOutboxEnqueueCommitsIndeterminateVisibleEntry(t *testing.T) {
 		ctx: context.Background(), accepting: true,
 	}
 
-	if err := service.Enqueue(testEmail()); err != nil {
-		t.Fatalf("indeterminate visible outbox entry must resolve as committed: %v", err)
+	if err := service.Enqueue(testEmail()); err == nil {
+		t.Fatal("unsynced pending outbox handoff must fail")
 	}
 	select {
 	case <-service.outboxWake:
+		t.Fatal("failed staged handoff woke the worker")
 	default:
-		t.Fatal("committed visible outbox entry did not wake the worker")
 	}
 	entries, err := outbox.List()
-	if err != nil || len(entries) != 1 {
-		t.Fatalf("visible committed outbox entry = %#v, %v", entries, err)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("failed staged handoff became consumable = %#v, %v", entries, err)
+	}
+	files, err := os.ReadDir(outbox.dir)
+	if err != nil || len(files) != 1 || !strings.HasSuffix(files[0].Name(), ".pending") {
+		t.Fatalf("non-consumable pending handoff = %#v, %v", files, err)
 	}
 }
 
@@ -244,6 +267,9 @@ func TestOutboxCloseSignalFlushesAcceptedEntries(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	job := deliveryJob{ID: "accepted-before-close", EnqueuedAt: time.Now().UTC(), Email: testEmail()}
 	if err := outbox.Store(job); err != nil {
+		t.Fatal(err)
+	}
+	if err := outbox.Commit(job.Email.ID); err != nil {
 		t.Fatal(err)
 	}
 	close(service.outboxClosing)

--- a/internal/webhook/service_test.go
+++ b/internal/webhook/service_test.go
@@ -199,6 +199,46 @@ func TestOutboxDecouplesEnqueueFromMemoryQueueCapacity(t *testing.T) {
 	}
 }
 
+func TestServiceCloseWaitsForStagedHandoffDecision(t *testing.T) {
+	receiver := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer receiver.Close()
+	dispatcher, err := NewDispatcher(Config{Targets: []Target{{Name: "staged", URL: receiver.URL}}}, receiver.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service, err := NewService(dispatcher, ServiceOptions{
+		MaxConcurrency: 1, ShutdownTimeout: time.Second, SpoolDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	email := testEmail()
+	if err := service.Enqueue(email); err != nil {
+		t.Fatal(err)
+	}
+
+	closed := make(chan error, 1)
+	go func() { closed <- service.Close() }()
+	select {
+	case err := <-closed:
+		t.Fatalf("Close returned before staged handoff was committed: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	if err := service.Commit(email.ID); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Close did not finish after staged handoff was committed")
+	}
+}
+
 func TestOutboxRecreatesMissingDirectory(t *testing.T) {
 	outbox, err := newDeliveryOutbox(t.TempDir())
 	if err != nil {

--- a/internal/webhook/service_test.go
+++ b/internal/webhook/service_test.go
@@ -239,6 +239,100 @@ func TestServiceCloseWaitsForStagedHandoffDecision(t *testing.T) {
 	}
 }
 
+func TestServiceCloseRetainsFailedPromotionUntilRetrySucceeds(t *testing.T) {
+	receiver := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer receiver.Close()
+	dispatcher, err := NewDispatcher(Config{Targets: []Target{{Name: "retry", URL: receiver.URL}}}, receiver.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service, err := NewService(dispatcher, ServiceOptions{
+		MaxConcurrency: 1, ShutdownTimeout: time.Second, SpoolDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	email := testEmail()
+	if err := service.Enqueue(email); err != nil {
+		t.Fatal(err)
+	}
+	backupDir := service.outbox.dir + "-backup"
+	if err := os.Rename(service.outbox.dir, backupDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(service.outbox.dir, []byte("blocks outbox directory"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := service.Commit(email.ID); err == nil {
+		t.Fatal("blocked outbox promotion unexpectedly succeeded")
+	}
+
+	closed := make(chan error, 1)
+	go func() { closed <- service.Close() }()
+	select {
+	case err := <-closed:
+		t.Fatalf("Close returned while accepted promotion was still failing: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	if err := os.Remove(service.outbox.dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(backupDir, service.outbox.dir); err != nil {
+		t.Fatal(err)
+	}
+	service.wakeOutbox()
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Close did not finish after the promotion retry succeeded")
+	}
+}
+
+func TestServiceCloseTimeoutCancelsPersistentlyFailedPromotion(t *testing.T) {
+	receiver := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer receiver.Close()
+	dispatcher, err := NewDispatcher(Config{Targets: []Target{{Name: "timeout", URL: receiver.URL}}}, receiver.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service, err := NewService(dispatcher, ServiceOptions{
+		MaxConcurrency: 1, ShutdownTimeout: 50 * time.Millisecond, SpoolDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	email := testEmail()
+	if err := service.Enqueue(email); err != nil {
+		t.Fatal(err)
+	}
+	backupDir := service.outbox.dir + "-backup"
+	if err := os.Rename(service.outbox.dir, backupDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(service.outbox.dir, []byte("blocks outbox directory"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := service.Commit(email.ID); err == nil {
+		t.Fatal("blocked outbox promotion unexpectedly succeeded")
+	}
+	if err := service.Close(); err == nil || !strings.Contains(err.Error(), "webhook drain exceeded") {
+		t.Fatalf("Close error = %v, want bounded drain timeout", err)
+	}
+	if err := os.Remove(service.outbox.dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(backupDir, service.outbox.dir); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestOutboxRecreatesMissingDirectory(t *testing.T) {
 	outbox, err := newDeliveryOutbox(t.TempDir())
 	if err != nil {


### PR DESCRIPTION
## Summary

- make synchronous mail event handoffs return errors to the storage transaction
- reject SMTP `DATA` when the Webhook outbox cannot be durably committed
- roll back metadata, in-memory state, EML, and attachments after a failed handoff
- serialize outbox publication with readers and remove a renamed entry when directory `fsync` fails
- keep asynchronous listeners from observing an event whose durable handoff failed

## Review finding

Fixes the P1 finding on #66:
https://github.com/soulteary/owlmail/pull/66#discussion_r3891080353

Previously, `registerWebhookService` logged `Service.Enqueue` errors and returned success. SMTP therefore acknowledged the message even when no durable outbox entry existed.

## Verification

- added transaction rollback coverage for a synchronous handoff failure
- added wiring coverage proving an actual Webhook outbox failure rejects the mail-store commit
- added event coverage proving asynchronous notifications do not observe failed transactions
- all 57 browser/documentation contract tests pass under the Node compatibility runner
- `git diff --check` passes
- Go formatting, race tests, vet, and full Go tests are delegated to GitHub Actions because Go is not installed in the current workspace

## Dependency

This PR targets `release/0.6.0-readiness` so merging it directly updates #66.