### PR TITLE
perf(web): use preview API for mailbox lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to OwlMail are documented in this file. The format follows
 
 ### Changed
 
+- The Web inbox now loads mailbox lists from the preview API, avoiding full
+  message bodies, headers, and attachment content until a message is selected.
 - The zero-credential default is now documented as NO AUTH mode. It accepts
   unauthenticated delivery and arbitrary PLAIN/LOGIN credentials for test
   clients that require SMTP credentials. Configuring both inbound credentials

--- a/tests/web/app.test.js
+++ b/tests/web/app.test.js
@@ -20,15 +20,24 @@ function createClassList() {
 function createElement() {
     const listeners = new Map();
     const attributes = new Map();
+    let textContent = '';
+    let innerHTML = '';
     return {
         listeners,
         attributes,
         classList: createClassList(),
         hidden: true,
         disabled: false,
-        textContent: '',
+        get textContent() { return textContent; },
+        set textContent(value) {
+            textContent = value;
+            innerHTML = value;
+        },
+        get innerHTML() { return innerHTML; },
+        set innerHTML(value) { innerHTML = value; },
         title: '',
         addEventListener(name, handler) { listeners.set(name, handler); },
+        querySelectorAll() { return []; },
         setAttribute(name, value) { attributes.set(name, value); }
     };
 }
@@ -41,10 +50,12 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
     const notificationToggle = createElement();
     const notificationStatus = createElement();
     const emailDetail = createElement();
+    const emailList = createElement();
     const elements = new Map([
         ['notificationToggle', notificationToggle],
         ['notificationStatus', notificationStatus],
-        ['emailDetail', emailDetail]
+        ['emailDetail', emailDetail],
+        ['emailList', emailList]
     ]);
     const notifications = [];
     const windowListeners = new Map();
@@ -118,6 +129,7 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
     return {
         documentListeners,
         emailDetail,
+        emailList,
         notificationStatus,
         notificationToggle,
         notifications,
@@ -252,12 +264,23 @@ test('mailbox lists use the preview endpoint and preserve query parameters', asy
             return {
                 ok: true,
                 headers: { get: () => 'application/json' },
-                json: async () => ({ emails: [], total: 0 })
+                json: async () => ({
+                    previews: [{
+                        id: 'mail-42',
+                        subject: 'Release notes',
+                        from: 'sender@example.test',
+                        preview: 'Lightweight body preview',
+                        read: false,
+                        hasAttachment: true,
+                        time: '2026-09-01T12:00:00Z'
+                    }],
+                    total: 1
+                })
             };
         }
     });
 
-    await harness.run("API.getEmails(50, 25, 'release notes')");
+    await harness.run("state.currentPage = 2; state.pageSize = 25; state.searchQuery = 'release notes'; loadEmails()");
 
     assert.equal(requests.length, 1);
     const requestURL = new URL(requests[0]);
@@ -265,6 +288,13 @@ test('mailbox lists use the preview endpoint and preserve query parameters', asy
     assert.equal(requestURL.searchParams.get('offset'), '50');
     assert.equal(requestURL.searchParams.get('limit'), '25');
     assert.equal(requestURL.searchParams.get('q'), 'release notes');
+    assert.equal(harness.run('state.emails.length'), 1);
+    assert.equal(harness.run('state.emails[0].id'), 'mail-42');
+    assert.equal(harness.run('state.total'), 1);
+    assert.match(harness.emailList.innerHTML, /sender@example\.test/);
+    assert.match(harness.emailList.innerHTML, /Lightweight body preview/);
+    assert.match(harness.emailList.innerHTML, /email-item unread/);
+    assert.match(harness.emailList.innerHTML, /📎/);
 });
 
 test('email details continue to use the single-email endpoint', async () => {

--- a/tests/web/app.test.js
+++ b/tests/web/app.test.js
@@ -33,7 +33,7 @@ function createElement() {
     };
 }
 
-function createHarness({ permission = 'default', secure = true, savedPreference = null, serviceWorker = false } = {}) {
+function createHarness({ permission = 'default', secure = true, savedPreference = null, serviceWorker = false, fetchImpl } = {}) {
     const storage = new Map();
     if (savedPreference !== null) {
         storage.set('owlmail.browserNotifications.enabled', savedPreference);
@@ -105,9 +105,10 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
         console,
         setTimeout() { return 1; },
         clearTimeout() {},
-        fetch: async () => { throw new Error('unexpected fetch'); },
+        fetch: fetchImpl || (async () => { throw new Error('unexpected fetch'); }),
         WebSocket: function WebSocket() {},
         URL,
+        URLSearchParams,
         Blob,
         confirm: () => true
     };
@@ -241,4 +242,46 @@ test('initial language setup translates the empty email detail', () => {
     harness.run("setLanguage('fr', false)");
 
     assert.match(harness.emailDetail.innerHTML, /Sélectionnez un email/);
+});
+
+test('mailbox lists use the preview endpoint and preserve query parameters', async () => {
+    const requests = [];
+    const harness = createHarness({
+        fetchImpl: async (url) => {
+            requests.push(url);
+            return {
+                ok: true,
+                headers: { get: () => 'application/json' },
+                json: async () => ({ emails: [], total: 0 })
+            };
+        }
+    });
+
+    await harness.run("API.getEmails(50, 25, 'release notes')");
+
+    assert.equal(requests.length, 1);
+    const requestURL = new URL(requests[0]);
+    assert.equal(requestURL.pathname, '/api/v1/emails/preview');
+    assert.equal(requestURL.searchParams.get('offset'), '50');
+    assert.equal(requestURL.searchParams.get('limit'), '25');
+    assert.equal(requestURL.searchParams.get('q'), 'release notes');
+});
+
+test('email details continue to use the single-email endpoint', async () => {
+    const requests = [];
+    const harness = createHarness({
+        fetchImpl: async (url) => {
+            requests.push(url);
+            return {
+                ok: true,
+                headers: { get: () => 'application/json' },
+                json: async () => ({ id: 'mail-42', html: '<p>full body</p>' })
+            };
+        }
+    });
+
+    await harness.run("API.getEmail('mail-42')");
+
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0], 'http://owlmail.test/api/v1/emails/mail-42');
 });

--- a/web/app.js
+++ b/web/app.js
@@ -1003,7 +1003,7 @@ const API = {
         if (query) {
             params.append('q', query);
         }
-        const response = await fetch(`${API_BASE}/emails?${params}`);
+        const response = await fetch(`${API_BASE}/emails/preview?${params}`);
         return await handleAPIResponse(response);
     },
 

--- a/web/app.js
+++ b/web/app.js
@@ -1193,16 +1193,21 @@ function renderEmailList() {
     }
 
     container.innerHTML = state.emails.map(email => {
-        const from = email.from && email.from.length > 0 
-            ? formatAddress(email.from[0])
-            : t('unknown');
+        const from = typeof email.from === 'string'
+            ? (email.from || t('unknown'))
+            : email.from && email.from.length > 0
+                ? formatAddress(email.from[0])
+                : t('unknown');
         const time = formatTime(email.time);
-        const preview = email.text ? email.text.substring(0, 100) : '';
+        const previewText = email.preview || email.text || '';
+        const preview = previewText.substring(0, 100);
         const unreadClass = email.read ? '' : 'unread';
         const selectedClass = state.currentEmail && state.currentEmail.id === email.id ? 'selected' : '';
         const attachments = email.attachments && email.attachments.length > 0
             ? `<div class="email-item-attachments">📎 ${t('attachments', { count: email.attachments.length })}</div>`
-            : '';
+            : email.hasAttachment
+                ? '<div class="email-item-attachments">📎</div>'
+                : '';
 
         return `
             <div class="email-item ${unreadClass} ${selectedClass}" data-id="${email.id}">
@@ -1322,7 +1327,7 @@ async function loadEmails() {
             state.pageSize,
             state.searchQuery
         );
-        state.emails = data.emails || [];
+        state.emails = data.previews || [];
         state.total = data.total || 0;
         renderEmailList();
         updateEmailCount();


### PR DESCRIPTION
## Summary

- load mailbox lists from `GET /api/v1/emails/preview`
- preserve list pagination and search query parameters
- keep selected-message detail loading on `GET /api/v1/emails/:id`
- add browser contract tests for both request paths
- document the user-visible performance change under Unreleased

This change does not modify WebSocket events, REST response structures, or server-side mailbox data structures.

## Validation

- `bun test ./tests/web ./tests/docs` (59 passed)
- `bun build ./web/*.js --target=browser`
- `go mod verify`
- `go test ./...`
- `go vet ./...`
- `gofmt -s -l .` (clean)
- `git diff --check`