### PR TITLE
perf(web): use preview API for mailbox lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to OwlMail are documented in this file. The format follows
 
 ### Changed
 
+- The Web inbox now uses compact email previews for mailbox lists and only
+  fetches complete message content after a message is selected.
 - The zero-credential default is now documented as NO AUTH mode. It accepts
   unauthenticated delivery and arbitrary PLAIN/LOGIN credentials for test
   clients that require SMTP credentials. Configuring both inbound credentials

--- a/tests/web/app.test.js
+++ b/tests/web/app.test.js
@@ -20,20 +20,49 @@ function createClassList() {
 function createElement() {
     const listeners = new Map();
     const attributes = new Map();
-    return {
+    let innerHTML = '';
+    let textContent = '';
+    const element = {
         listeners,
         attributes,
         classList: createClassList(),
         hidden: true,
         disabled: false,
-        textContent: '',
         title: '',
         addEventListener(name, handler) { listeners.set(name, handler); },
-        setAttribute(name, value) { attributes.set(name, value); }
+        setAttribute(name, value) { attributes.set(name, value); },
+        querySelectorAll() { return []; }
+    };
+    Object.defineProperties(element, {
+        innerHTML: {
+            get() { return innerHTML; },
+            set(value) { innerHTML = String(value); }
+        },
+        textContent: {
+            get() { return textContent; },
+            set(value) {
+                textContent = String(value);
+                innerHTML = textContent
+                    .replaceAll('&', '&amp;')
+                    .replaceAll('<', '&lt;')
+                    .replaceAll('>', '&gt;');
+            }
+        }
+    });
+    return element;
+}
+
+function jsonResponse(data) {
+    return {
+        ok: true,
+        status: 200,
+        headers: { get: (name) => name.toLowerCase() === 'content-type' ? 'application/json' : null },
+        async json() { return data; },
+        async text() { return JSON.stringify(data); }
     };
 }
 
-function createHarness({ permission = 'default', secure = true, savedPreference = null, serviceWorker = false } = {}) {
+function createHarness({ permission = 'default', secure = true, savedPreference = null, serviceWorker = false, fetchImpl = null } = {}) {
     const storage = new Map();
     if (savedPreference !== null) {
         storage.set('owlmail.browserNotifications.enabled', savedPreference);
@@ -41,12 +70,15 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
     const notificationToggle = createElement();
     const notificationStatus = createElement();
     const emailDetail = createElement();
+    const emailList = createElement();
     const elements = new Map([
         ['notificationToggle', notificationToggle],
         ['notificationStatus', notificationStatus],
-        ['emailDetail', emailDetail]
+        ['emailDetail', emailDetail],
+        ['emailList', emailList]
     ]);
     const notifications = [];
+    const fetchRequests = [];
     const windowListeners = new Map();
     const documentListeners = new Map();
     const serviceNotifications = [];
@@ -105,9 +137,14 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
         console,
         setTimeout() { return 1; },
         clearTimeout() {},
-        fetch: async () => { throw new Error('unexpected fetch'); },
+        fetch: async (url, options) => {
+            fetchRequests.push({ url: String(url), options });
+            if (!fetchImpl) throw new Error('unexpected fetch');
+            return fetchImpl(url, options);
+        },
         WebSocket: function WebSocket() {},
         URL,
+        URLSearchParams,
         Blob,
         confirm: () => true
     };
@@ -117,6 +154,8 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
     return {
         documentListeners,
         emailDetail,
+        emailList,
+        fetchRequests,
         notificationStatus,
         notificationToggle,
         notifications,
@@ -127,6 +166,65 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
         run(source) { return vm.runInContext(source, sandbox); }
     };
 }
+
+test('mailbox lists use the preview endpoint and consume preview results', async () => {
+    const harness = createHarness({
+        fetchImpl: async () => jsonResponse({
+            total: 1,
+            limit: 25,
+            offset: 50,
+            previews: [{
+                id: 'mail-42',
+                time: '2026-09-01T00:00:00Z',
+                read: false,
+                subject: 'Quarterly report',
+                from: 'sender@example.test',
+                preview: 'Compact body preview',
+                hasAttachment: true
+            }]
+        })
+    });
+
+    await harness.run(`
+        state.currentPage = 2;
+        state.pageSize = 25;
+        state.searchQuery = 'quarterly report';
+        loadEmails();
+    `);
+
+    assert.equal(harness.fetchRequests.length, 1);
+    const requestURL = new URL(harness.fetchRequests[0].url);
+    assert.equal(requestURL.pathname, '/api/v1/emails/preview');
+    assert.equal(requestURL.searchParams.get('offset'), '50');
+    assert.equal(requestURL.searchParams.get('limit'), '25');
+    assert.equal(requestURL.searchParams.get('q'), 'quarterly report');
+    assert.equal(harness.run('state.emails[0].id'), 'mail-42');
+    assert.equal(harness.run('state.emails[0].read'), false);
+    assert.equal(harness.run('state.emails[0].time'), '2026-09-01T00:00:00Z');
+    assert.equal(harness.run('state.emails[0].preview'), 'Compact body preview');
+    assert.equal(harness.run('state.total'), 1);
+    assert.match(harness.emailList.innerHTML, /email-item unread/);
+    assert.match(harness.emailList.innerHTML, /sender@example\.test/);
+    assert.match(harness.emailList.innerHTML, /Compact body preview/);
+    assert.match(harness.emailList.innerHTML, /📎/);
+});
+
+test('selected messages still use the single-email detail endpoint', async () => {
+    const harness = createHarness({
+        fetchImpl: async () => jsonResponse({
+            id: 'mail-42',
+            subject: 'Quarterly report',
+            html: '<p>Full message body</p>'
+        })
+    });
+
+    await harness.run("loadEmailDetail('mail-42')");
+
+    assert.equal(harness.fetchRequests.length, 1);
+    const requestURL = new URL(harness.fetchRequests[0].url);
+    assert.equal(requestURL.pathname, '/api/v1/emails/mail-42');
+    assert.equal(harness.run('state.currentEmail.html'), '<p>Full message body</p>');
+});
 
 test('initialization never prompts and keeps notifications disabled by default', () => {
     const harness = createHarness();

--- a/web/app.js
+++ b/web/app.js
@@ -995,7 +995,7 @@ async function handleAPIResponse(response) {
 
 // API Functions - 使用新的 RESTful API 设计
 const API = {
-    async getEmails(offset = 0, limit = 50, query = '') {
+    async getEmailPreviews(offset = 0, limit = 50, query = '') {
         const params = new URLSearchParams({
             offset: offset.toString(),
             limit: limit.toString()
@@ -1003,7 +1003,7 @@ const API = {
         if (query) {
             params.append('q', query);
         }
-        const response = await fetch(`${API_BASE}/emails?${params}`);
+        const response = await fetch(`${API_BASE}/emails/preview?${params}`);
         return await handleAPIResponse(response);
     },
 
@@ -1193,16 +1193,17 @@ function renderEmailList() {
     }
 
     container.innerHTML = state.emails.map(email => {
-        const from = email.from && email.from.length > 0 
-            ? formatAddress(email.from[0])
-            : t('unknown');
+        const from = Array.isArray(email.from)
+            ? (email.from.length > 0 ? formatAddress(email.from[0]) : t('unknown'))
+            : (email.from ? formatAddress(email.from) : t('unknown'));
         const time = formatTime(email.time);
-        const preview = email.text ? email.text.substring(0, 100) : '';
+        const previewText = typeof email.preview === 'string' ? email.preview : email.text;
+        const preview = previewText ? previewText.substring(0, 100) : '';
         const unreadClass = email.read ? '' : 'unread';
         const selectedClass = state.currentEmail && state.currentEmail.id === email.id ? 'selected' : '';
-        const attachments = email.attachments && email.attachments.length > 0
+        const attachments = Array.isArray(email.attachments) && email.attachments.length > 0
             ? `<div class="email-item-attachments">📎 ${t('attachments', { count: email.attachments.length })}</div>`
-            : '';
+            : (email.hasAttachment ? '<div class="email-item-attachments">📎</div>' : '');
 
         return `
             <div class="email-item ${unreadClass} ${selectedClass}" data-id="${email.id}">
@@ -1317,12 +1318,12 @@ function renderAttachments(attachments, emailId) {
 async function loadEmails() {
     try {
         showLoading();
-        const data = await API.getEmails(
+        const data = await API.getEmailPreviews(
             state.currentPage * state.pageSize,
             state.pageSize,
             state.searchQuery
         );
-        state.emails = data.emails || [];
+        state.emails = data.previews || [];
         state.total = data.total || 0;
         renderEmailList();
         updateEmailCount();


### PR DESCRIPTION
## Summary

- load mailbox pages from `GET /api/v1/emails/preview` instead of the full collection endpoint
- render the compact preview fields while remaining compatible with unchanged full-email WebSocket events
- keep selected-message details on `GET /api/v1/emails/:id`
- add browser contract coverage for list/search/pagination parameters, preview rendering, unread state, and the detail endpoint
- document the change under CHANGELOG Unreleased

## Contract and scope

- preserves the existing search, pagination, unread-state, and server-side newest-first behavior
- does not change any REST response structure or public WebSocket event format
- does not modify server mailbox data structures

## Testing

- `bun build ./web/*.js --target=browser --outdir=...`
- `bun test ./tests/web ./tests/docs` (59 passed)
- `go mod verify`
- `go test -race ./...`
- `go vet ./...`
- `gofmt -s -l .`
- `golangci-lint run --timeout=5m` (0 issues)
