### PR TITLE
perf(mailserver): paginate before cloning email bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable changes to OwlMail are documented in this file. The format follows
 
 ### Changed
 
+- Mailbox list queries now filter, sort, and paginate under a consistent store
+  snapshot before cloning results; previews avoid cloning message bodies,
+  headers, and attachment metadata.
 - The Web inbox now uses compact email previews for mailbox lists and only
   fetches complete message content after a message is selected.
 - The zero-credential default is now documented as NO AUTH mode. It accepts

--- a/internal/api/api_emails.go
+++ b/internal/api/api_emails.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/soulteary/owlmail/internal/common"
+	"github.com/soulteary/owlmail/internal/mailserver"
 	"github.com/soulteary/owlmail/internal/types"
 )
 
@@ -21,19 +22,8 @@ const (
 	maxExportBytes    = 256 << 20
 )
 
-// EmailPreview represents a lightweight email preview
-type EmailPreview struct {
-	ID            string    `json:"id"`
-	Time          time.Time `json:"time"`
-	Read          bool      `json:"read"`
-	Subject       string    `json:"subject"`
-	From          string    `json:"from"`
-	To            []string  `json:"to"`
-	Size          int64     `json:"size"`
-	SizeHuman     string    `json:"sizeHuman"`
-	HasAttachment bool      `json:"hasAttachment"`
-	Preview       string    `json:"preview"` // First 200 chars of text
-}
+// EmailPreview represents a lightweight email preview.
+type EmailPreview = mailserver.EmailPreview
 
 // getAllEmails handles GET /api/v1/emails
 func (api *API) getAllEmails(c fiber.Ctx) error {
@@ -61,39 +51,16 @@ func (api *API) getAllEmails(c fiber.Ctx) error {
 		offset = 0
 	}
 
-	emails := api.mailServer.GetAllEmail()
-	filtered := applyEmailFilters(emails, query, from, to, dateFrom, dateTo, read)
-
-	if sortBy != "" {
-		applyEmailSorting(filtered, sortBy, sortOrder)
-	} else {
-		sort.Slice(filtered, func(i, j int) bool {
-			return filtered[i].Time.After(filtered[j].Time)
-		})
-	}
-
-	total := len(filtered)
-	start := offset
-	end := offset + limit
-	if start > total {
-		start = total
-	}
-	if end > total {
-		end = total
-	}
-
-	var paginatedEmails []*types.Email
-	if start < end {
-		paginatedEmails = filtered[start:end]
-	} else {
-		paginatedEmails = make([]*types.Email, 0)
-	}
+	emails, total := api.mailServer.QueryEmails(mailserver.EmailQuery{
+		Query: query, From: from, To: to, DateFrom: dateFrom, DateTo: dateTo,
+		Read: read, SortBy: sortBy, SortOrder: sortOrder, Offset: offset, Limit: limit,
+	})
 
 	return c.JSON(fiber.Map{
 		"total":  total,
 		"limit":  limit,
 		"offset": offset,
-		"emails": paginatedEmails,
+		"emails": emails,
 	})
 }
 
@@ -247,74 +214,10 @@ func (api *API) getEmailPreviews(c fiber.Ctx) error {
 		offset = 0
 	}
 
-	emails := api.mailServer.GetAllEmail()
-	filtered := applyEmailFilters(emails, query, from, to, dateFrom, dateTo, read)
-
-	if sortBy != "" {
-		applyEmailSorting(filtered, sortBy, sortOrder)
-	} else {
-		sort.Slice(filtered, func(i, j int) bool {
-			return filtered[i].Time.After(filtered[j].Time)
-		})
-	}
-
-	total := len(filtered)
-	start := offset
-	end := offset + limit
-	if start > total {
-		start = total
-	}
-	if end > total {
-		end = total
-	}
-
-	var paginatedEmails []*types.Email
-	if start < end {
-		paginatedEmails = filtered[start:end]
-	} else {
-		paginatedEmails = make([]*types.Email, 0)
-	}
-
-	previews := make([]*EmailPreview, 0, len(paginatedEmails))
-	for _, email := range paginatedEmails {
-		preview := &EmailPreview{
-			ID:            email.ID,
-			Time:          email.Time,
-			Read:          email.Read,
-			Subject:       email.Subject,
-			Size:          email.Size,
-			SizeHuman:     email.SizeHuman,
-			HasAttachment: len(email.Attachments) > 0,
-		}
-
-		if len(email.From) > 0 {
-			preview.From = email.From[0].Address
-		}
-
-		preview.To = make([]string, 0, len(email.To))
-		for _, addr := range email.To {
-			preview.To = append(preview.To, addr.Address)
-		}
-
-		previewText := email.Text
-		if previewText == "" {
-			previewText = email.HTML
-			previewText = strings.ReplaceAll(previewText, "<", " <")
-			previewText = strings.ReplaceAll(previewText, ">", "> ")
-			previewText = strings.ReplaceAll(previewText, "\n", " ")
-			previewText = strings.ReplaceAll(previewText, "\r", " ")
-			for strings.Contains(previewText, "  ") {
-				previewText = strings.ReplaceAll(previewText, "  ", " ")
-			}
-			previewText = strings.TrimSpace(previewText)
-		}
-		if len(previewText) > 200 {
-			previewText = previewText[:200] + "..."
-		}
-		preview.Preview = previewText
-
-		previews = append(previews, preview)
-	}
+	previews, total := api.mailServer.QueryEmailPreviews(mailserver.EmailQuery{
+		Query: query, From: from, To: to, DateFrom: dateFrom, DateTo: dateTo,
+		Read: read, SortBy: sortBy, SortOrder: sortOrder, Offset: offset, Limit: limit,
+	})
 
 	return c.JSON(fiber.Map{
 		"total":    total,

--- a/internal/mailserver/query.go
+++ b/internal/mailserver/query.go
@@ -8,9 +8,7 @@ import (
 	"github.com/emersion/go-message/mail"
 )
 
-// EmailQuery describes a mailbox snapshot query. Filtering, sorting and
-// pagination are evaluated while the store read lock is held, so Total and the
-// returned page describe one consistent mailbox state.
+// EmailQuery describes a mailbox snapshot query.
 type EmailQuery struct {
 	Query     string
 	From      string
@@ -38,15 +36,43 @@ type EmailPreview struct {
 	Preview       string    `json:"preview"`
 }
 
-// QueryEmails returns deep copies of only the selected page.
+type queryAddress struct {
+	name    string
+	address string
+}
+
+type emailQueryRecord struct {
+	source        *Email
+	id            string
+	time          time.Time
+	read          bool
+	subject       string
+	from          []queryAddress
+	to            []queryAddress
+	cc            []queryAddress
+	calculatedBCC []queryAddress
+	text          string
+	html          string
+	size          int64
+	sizeHuman     string
+	hasAttachment bool
+}
+
+// QueryEmails returns deep copies of only the selected page. The lightweight
+// query snapshot is captured under the store lock; body scans and sorting do
+// not block mailbox writers.
 func (ms *MailServer) QueryEmails(query EmailQuery) ([]*Email, int) {
+	page, total := paginateEmailRecords(ms.queryEmailSnapshot(), query)
+
 	ms.storeMutex.RLock()
 	defer ms.storeMutex.RUnlock()
-
-	page, total := ms.queryEmailPageLocked(query)
 	result := make([]*Email, 0, len(page))
-	for _, email := range page {
-		result = append(result, cloneEmail(email))
+	for _, record := range page {
+		email := cloneEmail(record.source)
+		// Read state can change between the lightweight snapshot and cloning.
+		// Preserve the state that was used to select this page.
+		email.Read = record.read
+		result = append(result, email)
 	}
 	return result, total
 }
@@ -54,40 +80,76 @@ func (ms *MailServer) QueryEmails(query EmailQuery) ([]*Email, int) {
 // QueryEmailPreviews returns detached summaries without cloning message bodies,
 // headers or attachment structures.
 func (ms *MailServer) QueryEmailPreviews(query EmailQuery) ([]EmailPreview, int) {
-	ms.storeMutex.RLock()
-	defer ms.storeMutex.RUnlock()
-
-	page, total := ms.queryEmailPageLocked(query)
+	page, total := paginateEmailRecords(ms.queryEmailSnapshot(), query)
 	result := make([]EmailPreview, 0, len(page))
-	for _, email := range page {
+	for _, record := range page {
 		preview := EmailPreview{
-			ID:            email.ID,
-			Time:          email.Time,
-			Read:          email.Read,
-			Subject:       email.Subject,
-			Size:          email.Size,
-			SizeHuman:     email.SizeHuman,
-			HasAttachment: len(email.Attachments) > 0,
-			To:            make([]string, 0, len(email.To)),
+			ID:            record.id,
+			Time:          record.time,
+			Read:          record.read,
+			Subject:       record.subject,
+			Size:          record.size,
+			SizeHuman:     record.sizeHuman,
+			HasAttachment: record.hasAttachment,
+			To:            make([]string, 0, len(record.to)),
+			Preview:       emailPreviewText(record.text, record.html),
 		}
-		if len(email.From) > 0 {
-			preview.From = email.From[0].Address
+		if len(record.from) > 0 {
+			preview.From = record.from[0].address
 		}
-		for _, address := range email.To {
-			preview.To = append(preview.To, address.Address)
+		for _, address := range record.to {
+			preview.To = append(preview.To, address.address)
 		}
-		preview.Preview = emailPreviewText(email)
 		result = append(result, preview)
 	}
 	return result, total
 }
 
-func (ms *MailServer) queryEmailPageLocked(query EmailQuery) ([]*Email, int) {
-	matched := make([]*Email, 0, len(ms.storeOrder))
+func (ms *MailServer) queryEmailSnapshot() []emailQueryRecord {
+	ms.storeMutex.RLock()
+	defer ms.storeMutex.RUnlock()
+
+	records := make([]emailQueryRecord, 0, len(ms.storeOrder))
 	for _, id := range ms.storeOrder {
 		email, exists := ms.storeByID[id]
-		if exists && emailMatchesQuery(email, query) {
-			matched = append(matched, email)
+		if !exists {
+			continue
+		}
+		records = append(records, emailQueryRecord{
+			source:        email,
+			id:            email.ID,
+			time:          email.Time,
+			read:          email.Read,
+			subject:       email.Subject,
+			from:          snapshotAddresses(email.From),
+			to:            snapshotAddresses(email.To),
+			cc:            snapshotAddresses(email.CC),
+			calculatedBCC: snapshotAddresses(email.CalculatedBCC),
+			text:          email.Text,
+			html:          email.HTML,
+			size:          email.Size,
+			sizeHuman:     email.SizeHuman,
+			hasAttachment: len(email.Attachments) > 0,
+		})
+	}
+	return records
+}
+
+func snapshotAddresses(addresses []*mail.Address) []queryAddress {
+	result := make([]queryAddress, 0, len(addresses))
+	for _, address := range addresses {
+		if address != nil {
+			result = append(result, queryAddress{name: address.Name, address: address.Address})
+		}
+	}
+	return result
+}
+
+func paginateEmailRecords(records []emailQueryRecord, query EmailQuery) ([]emailQueryRecord, int) {
+	matched := records[:0]
+	for _, record := range records {
+		if emailMatchesQuery(record, query) {
+			matched = append(matched, record)
 		}
 	}
 	sortEmailQueryResults(matched, query.SortBy, query.SortOrder)
@@ -110,67 +172,67 @@ func (ms *MailServer) queryEmailPageLocked(query EmailQuery) ([]*Email, int) {
 	return matched[start:end], total
 }
 
-func emailMatchesQuery(email *Email, query EmailQuery) bool {
+func emailMatchesQuery(email emailQueryRecord, query EmailQuery) bool {
 	if query.Query != "" {
 		needle := strings.ToLower(query.Query)
-		if !strings.Contains(strings.ToLower(email.Subject), needle) &&
-			!strings.Contains(strings.ToLower(email.Text), needle) &&
-			!strings.Contains(strings.ToLower(email.HTML), needle) {
+		if !strings.Contains(strings.ToLower(email.subject), needle) &&
+			!strings.Contains(strings.ToLower(email.text), needle) &&
+			!strings.Contains(strings.ToLower(email.html), needle) {
 			return false
 		}
 	}
-	if query.From != "" && !addressListContains(email.From, query.From, true) {
+	if query.From != "" && !addressListContains(email.from, query.From, true) {
 		return false
 	}
-	if query.To != "" && !addressListContains(email.To, query.To, true) &&
-		!addressListContains(email.CC, query.To, true) &&
-		!addressListContains(email.CalculatedBCC, query.To, false) {
+	if query.To != "" && !addressListContains(email.to, query.To, true) &&
+		!addressListContains(email.cc, query.To, true) &&
+		!addressListContains(email.calculatedBCC, query.To, false) {
 		return false
 	}
 	if query.DateFrom != "" {
-		if from, err := time.Parse("2006-01-02", query.DateFrom); err == nil && email.Time.Before(from) {
+		if from, err := time.Parse("2006-01-02", query.DateFrom); err == nil && email.time.Before(from) {
 			return false
 		}
 	}
 	if query.DateTo != "" {
-		if to, err := time.Parse("2006-01-02", query.DateTo); err == nil && email.Time.After(to.Add(24*time.Hour)) {
+		if to, err := time.Parse("2006-01-02", query.DateTo); err == nil && email.time.After(to.Add(24*time.Hour)) {
 			return false
 		}
 	}
-	if query.Read != "" && email.Read != (query.Read == "true") {
+	if query.Read != "" && email.read != (query.Read == "true") {
 		return false
 	}
 	return true
 }
 
-func addressListContains(addresses []*mail.Address, value string, includeName bool) bool {
+func addressListContains(addresses []queryAddress, value string, includeName bool) bool {
 	needle := strings.ToLower(value)
 	for _, address := range addresses {
-		if address != nil && (strings.Contains(strings.ToLower(address.Address), needle) ||
-			(includeName && strings.Contains(strings.ToLower(address.Name), needle))) {
+		if strings.Contains(strings.ToLower(address.address), needle) ||
+			(includeName && strings.Contains(strings.ToLower(address.name), needle)) {
 			return true
 		}
 	}
 	return false
 }
 
-func sortEmailQueryResults(emails []*Email, sortBy, sortOrder string) {
+func sortEmailQueryResults(emails []emailQueryRecord, sortBy, sortOrder string) {
 	ascending := sortOrder == "asc"
 	var less func(i, j int) bool
 	switch sortBy {
 	case "":
-		less = func(i, j int) bool { return emails[i].Time.After(emails[j].Time) }
+		less = func(i, j int) bool { return emails[i].time.After(emails[j].time) }
 	case "time":
 		less = func(i, j int) bool {
 			if ascending {
-				return emails[i].Time.Before(emails[j].Time)
+				return emails[i].time.Before(emails[j].time)
 			}
-			return emails[i].Time.After(emails[j].Time)
+			return emails[i].time.After(emails[j].time)
 		}
 	case "subject":
 		less = func(i, j int) bool {
-			a := strings.ToLower(emails[i].Subject)
-			b := strings.ToLower(emails[j].Subject)
+			a := strings.ToLower(emails[i].subject)
+			b := strings.ToLower(emails[j].subject)
 			if ascending {
 				return a < b
 			}
@@ -179,11 +241,11 @@ func sortEmailQueryResults(emails []*Email, sortBy, sortOrder string) {
 	case "from":
 		less = func(i, j int) bool {
 			a, b := "", ""
-			if len(emails[i].From) > 0 {
-				a = strings.ToLower(emails[i].From[0].Address)
+			if len(emails[i].from) > 0 {
+				a = strings.ToLower(emails[i].from[0].address)
 			}
-			if len(emails[j].From) > 0 {
-				b = strings.ToLower(emails[j].From[0].Address)
+			if len(emails[j].from) > 0 {
+				b = strings.ToLower(emails[j].from[0].address)
 			}
 			if ascending {
 				return a < b
@@ -193,9 +255,9 @@ func sortEmailQueryResults(emails []*Email, sortBy, sortOrder string) {
 	case "size":
 		less = func(i, j int) bool {
 			if ascending {
-				return emails[i].Size < emails[j].Size
+				return emails[i].size < emails[j].size
 			}
-			return emails[i].Size > emails[j].Size
+			return emails[i].size > emails[j].size
 		}
 	}
 	if less != nil {
@@ -203,10 +265,9 @@ func sortEmailQueryResults(emails []*Email, sortBy, sortOrder string) {
 	}
 }
 
-func emailPreviewText(email *Email) string {
-	text := email.Text
+func emailPreviewText(text, html string) string {
 	if text == "" {
-		text = strings.NewReplacer("<", " <", ">", "> ", "\n", " ", "\r", " ").Replace(email.HTML)
+		text = strings.NewReplacer("<", " <", ">", "> ", "\n", " ", "\r", " ").Replace(html)
 		for strings.Contains(text, "  ") {
 			text = strings.ReplaceAll(text, "  ", " ")
 		}

--- a/internal/mailserver/query.go
+++ b/internal/mailserver/query.go
@@ -1,0 +1,219 @@
+package mailserver
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/emersion/go-message/mail"
+)
+
+// EmailQuery describes a mailbox snapshot query. Filtering, sorting and
+// pagination are evaluated while the store read lock is held, so Total and the
+// returned page describe one consistent mailbox state.
+type EmailQuery struct {
+	Query     string
+	From      string
+	To        string
+	DateFrom  string
+	DateTo    string
+	Read      string
+	SortBy    string
+	SortOrder string
+	Offset    int
+	Limit     int
+}
+
+// EmailPreview is a lightweight, detached mailbox-list value.
+type EmailPreview struct {
+	ID            string    `json:"id"`
+	Time          time.Time `json:"time"`
+	Read          bool      `json:"read"`
+	Subject       string    `json:"subject"`
+	From          string    `json:"from"`
+	To            []string  `json:"to"`
+	Size          int64     `json:"size"`
+	SizeHuman     string    `json:"sizeHuman"`
+	HasAttachment bool      `json:"hasAttachment"`
+	Preview       string    `json:"preview"`
+}
+
+// QueryEmails returns deep copies of only the selected page.
+func (ms *MailServer) QueryEmails(query EmailQuery) ([]*Email, int) {
+	ms.storeMutex.RLock()
+	defer ms.storeMutex.RUnlock()
+
+	page, total := ms.queryEmailPageLocked(query)
+	result := make([]*Email, 0, len(page))
+	for _, email := range page {
+		result = append(result, cloneEmail(email))
+	}
+	return result, total
+}
+
+// QueryEmailPreviews returns detached summaries without cloning message bodies,
+// headers or attachment structures.
+func (ms *MailServer) QueryEmailPreviews(query EmailQuery) ([]EmailPreview, int) {
+	ms.storeMutex.RLock()
+	defer ms.storeMutex.RUnlock()
+
+	page, total := ms.queryEmailPageLocked(query)
+	result := make([]EmailPreview, 0, len(page))
+	for _, email := range page {
+		preview := EmailPreview{
+			ID:            email.ID,
+			Time:          email.Time,
+			Read:          email.Read,
+			Subject:       email.Subject,
+			Size:          email.Size,
+			SizeHuman:     email.SizeHuman,
+			HasAttachment: len(email.Attachments) > 0,
+			To:            make([]string, 0, len(email.To)),
+		}
+		if len(email.From) > 0 {
+			preview.From = email.From[0].Address
+		}
+		for _, address := range email.To {
+			preview.To = append(preview.To, address.Address)
+		}
+		preview.Preview = emailPreviewText(email)
+		result = append(result, preview)
+	}
+	return result, total
+}
+
+func (ms *MailServer) queryEmailPageLocked(query EmailQuery) ([]*Email, int) {
+	matched := make([]*Email, 0, len(ms.storeOrder))
+	for _, id := range ms.storeOrder {
+		email, exists := ms.storeByID[id]
+		if exists && emailMatchesQuery(email, query) {
+			matched = append(matched, email)
+		}
+	}
+	sortEmailQueryResults(matched, query.SortBy, query.SortOrder)
+	total := len(matched)
+	start := query.Offset
+	if start < 0 {
+		start = 0
+	}
+	if start > total {
+		start = total
+	}
+	limit := query.Limit
+	if limit < 0 {
+		limit = 0
+	}
+	end := start + limit
+	if end > total {
+		end = total
+	}
+	return matched[start:end], total
+}
+
+func emailMatchesQuery(email *Email, query EmailQuery) bool {
+	if query.Query != "" {
+		needle := strings.ToLower(query.Query)
+		if !strings.Contains(strings.ToLower(email.Subject), needle) &&
+			!strings.Contains(strings.ToLower(email.Text), needle) &&
+			!strings.Contains(strings.ToLower(email.HTML), needle) {
+			return false
+		}
+	}
+	if query.From != "" && !addressListContains(email.From, query.From, true) {
+		return false
+	}
+	if query.To != "" && !addressListContains(email.To, query.To, true) &&
+		!addressListContains(email.CC, query.To, true) &&
+		!addressListContains(email.CalculatedBCC, query.To, false) {
+		return false
+	}
+	if query.DateFrom != "" {
+		if from, err := time.Parse("2006-01-02", query.DateFrom); err == nil && email.Time.Before(from) {
+			return false
+		}
+	}
+	if query.DateTo != "" {
+		if to, err := time.Parse("2006-01-02", query.DateTo); err == nil && email.Time.After(to.Add(24*time.Hour)) {
+			return false
+		}
+	}
+	if query.Read != "" && email.Read != (query.Read == "true") {
+		return false
+	}
+	return true
+}
+
+func addressListContains(addresses []*mail.Address, value string, includeName bool) bool {
+	needle := strings.ToLower(value)
+	for _, address := range addresses {
+		if address != nil && (strings.Contains(strings.ToLower(address.Address), needle) ||
+			(includeName && strings.Contains(strings.ToLower(address.Name), needle))) {
+			return true
+		}
+	}
+	return false
+}
+
+func sortEmailQueryResults(emails []*Email, sortBy, sortOrder string) {
+	ascending := sortOrder == "asc"
+	var less func(i, j int) bool
+	switch sortBy {
+	case "":
+		less = func(i, j int) bool { return emails[i].Time.After(emails[j].Time) }
+	case "time":
+		less = func(i, j int) bool {
+			if ascending {
+				return emails[i].Time.Before(emails[j].Time)
+			}
+			return emails[i].Time.After(emails[j].Time)
+		}
+	case "subject":
+		less = func(i, j int) bool {
+			a := strings.ToLower(emails[i].Subject)
+			b := strings.ToLower(emails[j].Subject)
+			if ascending {
+				return a < b
+			}
+			return a > b
+		}
+	case "from":
+		less = func(i, j int) bool {
+			a, b := "", ""
+			if len(emails[i].From) > 0 {
+				a = strings.ToLower(emails[i].From[0].Address)
+			}
+			if len(emails[j].From) > 0 {
+				b = strings.ToLower(emails[j].From[0].Address)
+			}
+			if ascending {
+				return a < b
+			}
+			return a > b
+		}
+	case "size":
+		less = func(i, j int) bool {
+			if ascending {
+				return emails[i].Size < emails[j].Size
+			}
+			return emails[i].Size > emails[j].Size
+		}
+	}
+	if less != nil {
+		sort.Slice(emails, less)
+	}
+}
+
+func emailPreviewText(email *Email) string {
+	text := email.Text
+	if text == "" {
+		text = strings.NewReplacer("<", " <", ">", "> ", "\n", " ", "\r", " ").Replace(email.HTML)
+		for strings.Contains(text, "  ") {
+			text = strings.ReplaceAll(text, "  ", " ")
+		}
+		text = strings.TrimSpace(text)
+	}
+	if len(text) > 200 {
+		text = text[:200] + "..."
+	}
+	return text
+}

--- a/internal/mailserver/query_test.go
+++ b/internal/mailserver/query_test.go
@@ -1,0 +1,120 @@
+package mailserver
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/emersion/go-message/mail"
+)
+
+func queryTestServer(count int) *MailServer {
+	server := &MailServer{
+		storeByID: make(map[string]*Email, count),
+		storeOrder: make([]string, 0, count),
+		receivedAtByID: make(map[string]time.Time, count),
+	}
+	for i := 0; i < count; i++ {
+		id := fmt.Sprintf("mail-%05d", i)
+		email := &Email{
+			ID: id, Time: time.Date(2026, 1, 1, 0, i, 0, 0, time.UTC),
+			Read: i%2 == 0, Subject: fmt.Sprintf("subject %05d", i),
+			From: []*mail.Address{{Name: "Sender", Address: fmt.Sprintf("sender%d@example.test", i%3)}},
+			To: []*mail.Address{{Address: fmt.Sprintf("recipient%d@example.test", i%4)}},
+			Text: strings.Repeat("message body ", 128), Size: int64(i), SizeHuman: fmt.Sprintf("%d B", i),
+			Headers: map[string]interface{}{"X-Test": []string{"one", "two"}},
+		}
+		server.storeByID[id] = email
+		server.storeOrder = append(server.storeOrder, id)
+	}
+	return server
+}
+
+func TestQueryEmailsFiltersSortsAndPaginates(t *testing.T) {
+	server := queryTestServer(12)
+	page, total := server.QueryEmails(EmailQuery{
+		From: "sender1", To: "recipient1", Read: "false",
+		SortBy: "size", SortOrder: "desc", Offset: 1, Limit: 2,
+	})
+	if total != 1 || len(page) != 0 {
+		t.Fatalf("total, page length = %d, %d; want 1, 0", total, len(page))
+	}
+
+	page, total = server.QueryEmails(EmailQuery{Query: "body", SortBy: "subject", SortOrder: "desc", Offset: 2, Limit: 3})
+	if total != 12 || len(page) != 3 {
+		t.Fatalf("total, page length = %d, %d; want 12, 3", total, len(page))
+	}
+	if page[0].ID != "mail-00009" || page[2].ID != "mail-00007" {
+		t.Fatalf("unexpected page IDs: %s ... %s", page[0].ID, page[2].ID)
+	}
+}
+
+func TestQueryEmailsReturnsDetachedPage(t *testing.T) {
+	server := queryTestServer(4)
+	page, _ := server.QueryEmails(EmailQuery{Limit: 1})
+	page[0].Subject = "mutated"
+	page[0].From[0].Address = "mutated@example.test"
+	page[0].Headers["X-Test"].([]string)[0] = "mutated"
+
+	again, _ := server.QueryEmails(EmailQuery{Limit: 1})
+	if again[0].Subject == "mutated" || again[0].From[0].Address == "mutated@example.test" ||
+		again[0].Headers["X-Test"].([]string)[0] == "mutated" {
+		t.Fatal("query exposed mutable store state")
+	}
+}
+
+func TestQueryEmailPreviewsDuringConcurrentWrites(t *testing.T) {
+	server := queryTestServer(100)
+	var writers sync.WaitGroup
+	writers.Add(1)
+	go func() {
+		defer writers.Done()
+		for i := 100; i < 300; i++ {
+			id := fmt.Sprintf("mail-%05d", i)
+			server.storeMutex.Lock()
+			server.storeByID[id] = &Email{ID: id, Time: time.Now(), Subject: id, Text: "body"}
+			server.storeOrder = append(server.storeOrder, id)
+			server.storeMutex.Unlock()
+		}
+	}()
+	for i := 0; i < 200; i++ {
+		previews, total := server.QueryEmailPreviews(EmailQuery{Offset: i % 10, Limit: 25})
+		if total < len(previews) {
+			t.Fatalf("total %d is smaller than page %d", total, len(previews))
+		}
+	}
+	writers.Wait()
+}
+
+func BenchmarkMailboxQuery10K(b *testing.B) {
+	server := queryTestServer(10_000)
+	query := EmailQuery{Offset: 5_000, Limit: 50}
+	b.Run("before_clone_all", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			server.storeMutex.RLock()
+			all := make([]*Email, 0, len(server.storeOrder))
+			for _, id := range server.storeOrder {
+				all = append(all, cloneEmail(server.storeByID[id]))
+			}
+			server.storeMutex.RUnlock()
+			sort.Slice(all, func(i, j int) bool { return all[i].Time.After(all[j].Time) })
+			_ = all[query.Offset : query.Offset+query.Limit]
+		}
+	})
+	b.Run("after_paginate_then_clone", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_, _ = server.QueryEmails(query)
+		}
+	})
+	b.Run("after_preview_without_body_clone", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_, _ = server.QueryEmailPreviews(query)
+		}
+	})
+}

--- a/internal/mailserver/query_test.go
+++ b/internal/mailserver/query_test.go
@@ -13,8 +13,8 @@ import (
 
 func queryTestServer(count int) *MailServer {
 	server := &MailServer{
-		storeByID: make(map[string]*Email, count),
-		storeOrder: make([]string, 0, count),
+		storeByID:      make(map[string]*Email, count),
+		storeOrder:     make([]string, 0, count),
 		receivedAtByID: make(map[string]time.Time, count),
 	}
 	for i := 0; i < count; i++ {
@@ -23,7 +23,7 @@ func queryTestServer(count int) *MailServer {
 			ID: id, Time: time.Date(2026, 1, 1, 0, i, 0, 0, time.UTC),
 			Read: i%2 == 0, Subject: fmt.Sprintf("subject %05d", i),
 			From: []*mail.Address{{Name: "Sender", Address: fmt.Sprintf("sender%d@example.test", i%3)}},
-			To: []*mail.Address{{Address: fmt.Sprintf("recipient%d@example.test", i%4)}},
+			To:   []*mail.Address{{Address: fmt.Sprintf("recipient%d@example.test", i%4)}},
 			Text: strings.Repeat("message body ", 128), Size: int64(i), SizeHuman: fmt.Sprintf("%d B", i),
 			Headers: map[string]interface{}{"X-Test": []string{"one", "two"}},
 		}


### PR DESCRIPTION
## Summary

- add a thread-safe mailbox query API that filters and sorts against one read-locked snapshot
- paginate before deep-cloning full messages
- build detached preview values without cloning bodies, headers, or attachment metadata
- preserve existing REST routes, query parameters, response keys, filtering, sorting, pagination, and total semantics
- add filtering/sorting/pagination, snapshot-isolation, concurrent-write/race tests, plus a 10,000-message allocation/time benchmark
- update the Unreleased changelog without Web UI changes

## Validation

Requested checks:
- `go test -race ./...`
- `go vet ./...`
- repository Go/Bun/documentation checks

The benchmark intentionally reports `ns/op`, `B/op`, and `allocs/op` without a flaky CI threshold.