### PR TITLE
perf(mailserver): paginate before cloning email bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,10 @@ All notable changes to OwlMail are documented in this file. The format follows
   attachments no longer require an additional attachment-sized byte slice;
   body read, staging write, S3 upload, and rollback failures reject the message
   before it becomes visible.
-- Mailbox list queries now filter, sort, and paginate under a consistent store
-  snapshot before cloning results; previews avoid cloning message bodies,
-  headers, and attachment metadata.
+- Mailbox list and preview queries now filter, sort, and paginate under a
+  thread-safe store snapshot before cloning results. Full list responses clone
+  only the selected page, while preview responses build lightweight summaries
+  without cloning complete message bodies, headers, or attachments.
 - The Web inbox now uses compact email previews for mailbox lists and only
   fetches complete message content after a message is selected.
 - The zero-credential default is now documented as NO AUTH mode. It accepts

--- a/internal/api/api_emails.go
+++ b/internal/api/api_emails.go
@@ -27,39 +27,13 @@ type EmailPreview = mailserver.EmailPreview
 
 // getAllEmails handles GET /api/v1/emails
 func (api *API) getAllEmails(c fiber.Ctx) error {
-	limitStr := c.Query("limit", "50")
-	offsetStr := c.Query("offset", "0")
-	query := c.Query("q")
-	from := c.Query("from")
-	to := c.Query("to")
-	dateFrom := c.Query("dateFrom")
-	dateTo := c.Query("dateTo")
-	read := c.Query("read")
-	sortBy := c.Query("sortBy", "")
-	sortOrder := c.Query("sortOrder", "desc")
-
-	limit, err := strconv.Atoi(limitStr)
-	if err != nil || limit < 1 {
-		limit = 50
-	}
-	if limit > 1000 {
-		limit = 1000
-	}
-
-	offset, err := strconv.Atoi(offsetStr)
-	if err != nil || offset < 0 {
-		offset = 0
-	}
-
-	emails, total := api.mailServer.QueryEmails(mailserver.EmailQuery{
-		Query: query, From: from, To: to, DateFrom: dateFrom, DateTo: dateTo,
-		Read: read, SortBy: sortBy, SortOrder: sortOrder, Offset: offset, Limit: limit,
-	})
+	query := parseEmailQuery(c)
+	emails, total := api.mailServer.QueryEmails(query)
 
 	return c.JSON(fiber.Map{
 		"total":  total,
-		"limit":  limit,
-		"offset": offset,
+		"limit":  query.Limit,
+		"offset": query.Offset,
 		"emails": emails,
 	})
 }
@@ -190,17 +164,20 @@ func (api *API) reloadMailsFromDirectory(c fiber.Ctx) error {
 
 // getEmailPreviews handles GET /api/v1/emails/preview
 func (api *API) getEmailPreviews(c fiber.Ctx) error {
+	query := parseEmailQuery(c)
+	previews, total := api.mailServer.QueryEmailPreviews(query)
+
+	return c.JSON(fiber.Map{
+		"total":    total,
+		"limit":    query.Limit,
+		"offset":   query.Offset,
+		"previews": previews,
+	})
+}
+
+func parseEmailQuery(c fiber.Ctx) mailserver.EmailQuery {
 	limitStr := c.Query("limit", "50")
 	offsetStr := c.Query("offset", "0")
-	query := c.Query("q")
-	from := c.Query("from")
-	to := c.Query("to")
-	dateFrom := c.Query("dateFrom")
-	dateTo := c.Query("dateTo")
-	read := c.Query("read")
-	sortBy := c.Query("sortBy", "")
-	sortOrder := c.Query("sortOrder", "desc")
-
 	limit, err := strconv.Atoi(limitStr)
 	if err != nil || limit < 1 {
 		limit = 50
@@ -214,17 +191,27 @@ func (api *API) getEmailPreviews(c fiber.Ctx) error {
 		offset = 0
 	}
 
-	previews, total := api.mailServer.QueryEmailPreviews(mailserver.EmailQuery{
-		Query: query, From: from, To: to, DateFrom: dateFrom, DateTo: dateTo,
-		Read: read, SortBy: sortBy, SortOrder: sortOrder, Offset: offset, Limit: limit,
-	})
-
-	return c.JSON(fiber.Map{
-		"total":    total,
-		"limit":    limit,
-		"offset":   offset,
-		"previews": previews,
-	})
+	query := mailserver.EmailQuery{
+		Text:      c.Query("q"),
+		From:      c.Query("from"),
+		To:        c.Query("to"),
+		SortBy:    c.Query("sortBy", ""),
+		SortOrder: c.Query("sortOrder", "desc"),
+		Offset:    offset,
+		Limit:     limit,
+	}
+	if dateFrom, err := time.Parse("2006-01-02", c.Query("dateFrom")); err == nil {
+		query.DateFrom = &dateFrom
+	}
+	if dateTo, err := time.Parse("2006-01-02", c.Query("dateTo")); err == nil {
+		dateTo = dateTo.Add(24 * time.Hour)
+		query.DateTo = &dateTo
+	}
+	if read := c.Query("read"); read != "" {
+		readValue := read == "true"
+		query.Read = &readValue
+	}
+	return query
 }
 
 // batchDeleteEmails handles DELETE /api/v1/emails/batch

--- a/internal/mailserver/query.go
+++ b/internal/mailserver/query.go
@@ -6,23 +6,27 @@ import (
 	"time"
 
 	"github.com/emersion/go-message/mail"
+	"github.com/soulteary/owlmail/internal/types"
 )
 
-// EmailQuery describes a mailbox snapshot query.
+// EmailQuery describes a mailbox snapshot query. DateTo is the inclusive
+// upper boundary used by the existing HTTP API, and Limit is applied after
+// filtering and sorting.
 type EmailQuery struct {
-	Query     string
+	Text      string
 	From      string
 	To        string
-	DateFrom  string
-	DateTo    string
-	Read      string
+	DateFrom  *time.Time
+	DateTo    *time.Time
+	Read      *bool
 	SortBy    string
 	SortOrder string
 	Offset    int
 	Limit     int
 }
 
-// EmailPreview is a lightweight, detached mailbox-list value.
+// EmailPreview is the detached, lightweight representation returned for a
+// mailbox preview query.
 type EmailPreview struct {
 	ID            string    `json:"id"`
 	Time          time.Time `json:"time"`
@@ -36,177 +40,191 @@ type EmailPreview struct {
 	Preview       string    `json:"preview"`
 }
 
-type queryAddress struct {
+// QueryEmails returns detached full-email snapshots for one page and the
+// total number of matches before pagination. The store lock is released while
+// filtering and sorting potentially large bodies, then reacquired only to
+// deep-clone the selected page.
+func (ms *MailServer) QueryEmails(query EmailQuery) ([]*Email, int) {
+	page, total := ms.queryEmailPage(query)
+
+	ms.storeMutex.RLock()
+	defer ms.storeMutex.RUnlock()
+	emails := make([]*Email, 0, len(page))
+	for _, entry := range page {
+		// source is an internal identity handle captured under storeMutex. It is
+		// never dereferenced without the lock and never leaves this package.
+		email := cloneEmail(entry.source)
+		// Keep the response consistent with the read state used by filtering if
+		// a concurrent mark-as-read completed between the two lock sections.
+		email.Read = entry.read
+		emails = append(emails, email)
+	}
+	return emails, total
+}
+
+// QueryEmailPreviews returns detached summaries for one page and the total
+// number of matches before pagination. No full Email snapshot is created.
+func (ms *MailServer) QueryEmailPreviews(query EmailQuery) ([]EmailPreview, int) {
+	page, total := ms.queryEmailPage(query)
+	ms.snapshotPreviewQueryAddresses(page)
+	previews := make([]EmailPreview, 0, len(page))
+	for _, entry := range page {
+		previews = append(previews, makeEmailPreview(entry))
+	}
+	return previews, total
+}
+
+type emailQueryAddress struct {
 	name    string
 	address string
 }
 
-type emailQueryRecord struct {
-	source        *Email
+// emailQueryEntry carries a lightweight, detached view of the fields needed by
+// mailbox filtering, sorting, and previews. Strings are immutable, so copying
+// their headers avoids copying message bodies while address values and slices
+// are detached from the store object graph. source is an opaque internal handle
+// that is dereferenced only while storeMutex is held.
+type emailQueryEntry struct {
+	source        *types.Email
 	id            string
 	time          time.Time
 	read          bool
 	subject       string
-	from          []queryAddress
-	to            []queryAddress
-	cc            []queryAddress
-	calculatedBCC []queryAddress
+	from          []emailQueryAddress
+	to            []emailQueryAddress
+	cc            []emailQueryAddress
+	calculatedBCC []emailQueryAddress
 	text          string
 	html          string
 	size          int64
 	sizeHuman     string
 	hasAttachment bool
+	sortKey       string
 }
 
-// QueryEmails returns deep copies of only the selected page. The lightweight
-// query snapshot is captured under the store lock; body scans and sorting do
-// not block mailbox writers.
-func (ms *MailServer) QueryEmails(query EmailQuery) ([]*Email, int) {
-	page, total := paginateEmailRecords(ms.queryEmailSnapshot(), query)
-
-	ms.storeMutex.RLock()
-	defer ms.storeMutex.RUnlock()
-	result := make([]*Email, 0, len(page))
-	for _, record := range page {
-		email := cloneEmail(record.source)
-		// Read state can change between the lightweight snapshot and cloning.
-		// Preserve the state that was used to select this page.
-		email.Read = record.read
-		result = append(result, email)
+func (ms *MailServer) queryEmailPage(query EmailQuery) ([]emailQueryEntry, int) {
+	entries := ms.snapshotEmailQueryEntries(query)
+	compiled := compileEmailQuery(query)
+	matches := entries[:0]
+	for _, entry := range entries {
+		if compiled.matches(entry) {
+			matches = append(matches, entry)
+		}
 	}
-	return result, total
+
+	sortEmailMatches(matches, query.SortBy, query.SortOrder)
+	total := len(matches)
+	start, end := pageBounds(total, query.Offset, query.Limit)
+	return matches[start:end], total
 }
 
-// QueryEmailPreviews returns detached summaries without cloning message bodies,
-// headers or attachment structures.
-func (ms *MailServer) QueryEmailPreviews(query EmailQuery) ([]EmailPreview, int) {
-	page, total := paginateEmailRecords(ms.queryEmailSnapshot(), query)
-	result := make([]EmailPreview, 0, len(page))
-	for _, record := range page {
-		preview := EmailPreview{
-			ID:            record.id,
-			Time:          record.time,
-			Read:          record.read,
-			Subject:       record.subject,
-			Size:          record.size,
-			SizeHuman:     record.sizeHuman,
-			HasAttachment: record.hasAttachment,
-			To:            make([]string, 0, len(record.to)),
-			Preview:       emailPreviewText(record.text, record.html),
-		}
-		if len(record.from) > 0 {
-			preview.From = record.from[0].address
-		}
-		for _, address := range record.to {
-			preview.To = append(preview.To, address.address)
-		}
-		result = append(result, preview)
-	}
-	return result, total
-}
-
-func (ms *MailServer) queryEmailSnapshot() []emailQueryRecord {
+func (ms *MailServer) snapshotEmailQueryEntries(query EmailQuery) []emailQueryEntry {
 	ms.storeMutex.RLock()
 	defer ms.storeMutex.RUnlock()
 
-	records := make([]emailQueryRecord, 0, len(ms.storeOrder))
+	needFrom := query.From != "" || query.SortBy == "from"
+	needTo := query.To != ""
+	entries := make([]emailQueryEntry, 0, len(ms.storeOrder))
 	for _, id := range ms.storeOrder {
-		email, exists := ms.storeByID[id]
-		if !exists {
-			continue
+		if email, exists := ms.storeByID[id]; exists {
+			entries = append(entries, snapshotEmailQueryEntry(email, needFrom, needTo))
 		}
-		records = append(records, emailQueryRecord{
-			source:        email,
-			id:            email.ID,
-			time:          email.Time,
-			read:          email.Read,
-			subject:       email.Subject,
-			from:          snapshotAddresses(email.From),
-			to:            snapshotAddresses(email.To),
-			cc:            snapshotAddresses(email.CC),
-			calculatedBCC: snapshotAddresses(email.CalculatedBCC),
-			text:          email.Text,
-			html:          email.HTML,
-			size:          email.Size,
-			sizeHuman:     email.SizeHuman,
-			hasAttachment: len(email.Attachments) > 0,
-		})
 	}
-	return records
+	return entries
 }
 
-func snapshotAddresses(addresses []*mail.Address) []queryAddress {
-	result := make([]queryAddress, 0, len(addresses))
+func snapshotEmailQueryEntry(email *types.Email, needFrom, needTo bool) emailQueryEntry {
+	entry := emailQueryEntry{
+		source:        email,
+		id:            email.ID,
+		time:          email.Time,
+		read:          email.Read,
+		subject:       email.Subject,
+		text:          email.Text,
+		html:          email.HTML,
+		size:          email.Size,
+		sizeHuman:     email.SizeHuman,
+		hasAttachment: len(email.Attachments) > 0,
+	}
+	if needFrom {
+		entry.from = snapshotQueryAddresses(email.From)
+	}
+	if needTo {
+		entry.to = snapshotQueryAddresses(email.To)
+		entry.cc = snapshotQueryAddresses(email.CC)
+		entry.calculatedBCC = snapshotQueryAddresses(email.CalculatedBCC)
+	}
+	return entry
+}
+
+func (ms *MailServer) snapshotPreviewQueryAddresses(entries []emailQueryEntry) {
+	ms.storeMutex.RLock()
+	defer ms.storeMutex.RUnlock()
+	for i := range entries {
+		entries[i].from = snapshotQueryAddresses(entries[i].source.From)
+		entries[i].to = snapshotQueryAddresses(entries[i].source.To)
+	}
+}
+
+func snapshotQueryAddresses(addresses []*mail.Address) []emailQueryAddress {
+	if len(addresses) == 0 {
+		return nil
+	}
+	snapshot := make([]emailQueryAddress, 0, len(addresses))
 	for _, address := range addresses {
 		if address != nil {
-			result = append(result, queryAddress{name: address.Name, address: address.Address})
+			snapshot = append(snapshot, emailQueryAddress{name: address.Name, address: address.Address})
 		}
 	}
-	return result
+	return snapshot
 }
 
-func paginateEmailRecords(records []emailQueryRecord, query EmailQuery) ([]emailQueryRecord, int) {
-	matched := records[:0]
-	for _, record := range records {
-		if emailMatchesQuery(record, query) {
-			matched = append(matched, record)
-		}
-	}
-	sortEmailQueryResults(matched, query.SortBy, query.SortOrder)
-	total := len(matched)
-	start := query.Offset
-	if start < 0 {
-		start = 0
-	}
-	if start > total {
-		start = total
-	}
-	limit := query.Limit
-	if limit < 0 {
-		limit = 0
-	}
-	end := start + limit
-	if end > total {
-		end = total
-	}
-	return matched[start:end], total
+type compiledEmailQuery struct {
+	text     string
+	from     string
+	to       string
+	dateFrom *time.Time
+	dateTo   *time.Time
+	read     *bool
 }
 
-func emailMatchesQuery(email emailQueryRecord, query EmailQuery) bool {
-	if query.Query != "" {
-		needle := strings.ToLower(query.Query)
-		if !strings.Contains(strings.ToLower(email.subject), needle) &&
-			!strings.Contains(strings.ToLower(email.text), needle) &&
-			!strings.Contains(strings.ToLower(email.html), needle) {
-			return false
-		}
+func compileEmailQuery(query EmailQuery) compiledEmailQuery {
+	return compiledEmailQuery{
+		text:     strings.ToLower(query.Text),
+		from:     strings.ToLower(query.From),
+		to:       strings.ToLower(query.To),
+		dateFrom: query.DateFrom,
+		dateTo:   query.DateTo,
+		read:     query.Read,
 	}
-	if query.From != "" && !addressListContains(email.from, query.From, true) {
-		return false
-	}
-	if query.To != "" && !addressListContains(email.to, query.To, true) &&
-		!addressListContains(email.cc, query.To, true) &&
-		!addressListContains(email.calculatedBCC, query.To, false) {
-		return false
-	}
-	if query.DateFrom != "" {
-		if from, err := time.Parse("2006-01-02", query.DateFrom); err == nil && email.time.Before(from) {
-			return false
-		}
-	}
-	if query.DateTo != "" {
-		if to, err := time.Parse("2006-01-02", query.DateTo); err == nil && email.time.After(to.Add(24*time.Hour)) {
-			return false
-		}
-	}
-	if query.Read != "" && email.read != (query.Read == "true") {
-		return false
-	}
-	return true
 }
 
-func addressListContains(addresses []queryAddress, value string, includeName bool) bool {
-	needle := strings.ToLower(value)
+func (query compiledEmailQuery) matches(email emailQueryEntry) bool {
+	if query.text != "" &&
+		!strings.Contains(strings.ToLower(email.subject), query.text) &&
+		!strings.Contains(strings.ToLower(email.text), query.text) &&
+		!strings.Contains(strings.ToLower(email.html), query.text) {
+		return false
+	}
+	if query.from != "" && !queryAddressesContain(email.from, query.from, true) {
+		return false
+	}
+	if query.to != "" &&
+		!queryAddressesContain(email.to, query.to, true) &&
+		!queryAddressesContain(email.cc, query.to, true) &&
+		!queryAddressesContain(email.calculatedBCC, query.to, false) {
+		return false
+	}
+	if query.dateFrom != nil && email.time.Before(*query.dateFrom) {
+		return false
+	}
+	if query.dateTo != nil && email.time.After(*query.dateTo) {
+		return false
+	}
+	return query.read == nil || email.read == *query.read
+}
+
+func queryAddressesContain(addresses []emailQueryAddress, needle string, includeName bool) bool {
 	for _, address := range addresses {
 		if strings.Contains(strings.ToLower(address.address), needle) ||
 			(includeName && strings.Contains(strings.ToLower(address.name), needle)) {
@@ -216,65 +234,106 @@ func addressListContains(addresses []queryAddress, value string, includeName boo
 	return false
 }
 
-func sortEmailQueryResults(emails []emailQueryRecord, sortBy, sortOrder string) {
+func sortEmailMatches(emails []emailQueryEntry, sortBy, sortOrder string) {
 	ascending := sortOrder == "asc"
-	var less func(i, j int) bool
 	switch sortBy {
 	case "":
-		less = func(i, j int) bool { return emails[i].time.After(emails[j].time) }
+		sort.Slice(emails, func(i, j int) bool {
+			return emails[i].time.After(emails[j].time)
+		})
 	case "time":
-		less = func(i, j int) bool {
+		sort.Slice(emails, func(i, j int) bool {
 			if ascending {
 				return emails[i].time.Before(emails[j].time)
 			}
 			return emails[i].time.After(emails[j].time)
-		}
+		})
 	case "subject":
-		less = func(i, j int) bool {
-			a := strings.ToLower(emails[i].subject)
-			b := strings.ToLower(emails[j].subject)
-			if ascending {
-				return a < b
-			}
-			return a > b
+		for i := range emails {
+			emails[i].sortKey = strings.ToLower(emails[i].subject)
 		}
+		sort.Slice(emails, func(i, j int) bool {
+			if ascending {
+				return emails[i].sortKey < emails[j].sortKey
+			}
+			return emails[i].sortKey > emails[j].sortKey
+		})
 	case "from":
-		less = func(i, j int) bool {
-			a, b := "", ""
-			if len(emails[i].from) > 0 {
-				a = strings.ToLower(emails[i].from[0].address)
-			}
-			if len(emails[j].from) > 0 {
-				b = strings.ToLower(emails[j].from[0].address)
-			}
-			if ascending {
-				return a < b
-			}
-			return a > b
+		for i := range emails {
+			emails[i].sortKey = firstQueryAddress(emails[i].from)
 		}
+		sort.Slice(emails, func(i, j int) bool {
+			if ascending {
+				return emails[i].sortKey < emails[j].sortKey
+			}
+			return emails[i].sortKey > emails[j].sortKey
+		})
 	case "size":
-		less = func(i, j int) bool {
+		sort.Slice(emails, func(i, j int) bool {
 			if ascending {
 				return emails[i].size < emails[j].size
 			}
 			return emails[i].size > emails[j].size
-		}
-	}
-	if less != nil {
-		sort.Slice(emails, less)
+		})
 	}
 }
 
-func emailPreviewText(text, html string) string {
-	if text == "" {
-		text = strings.NewReplacer("<", " <", ">", "> ", "\n", " ", "\r", " ").Replace(html)
-		for strings.Contains(text, "  ") {
-			text = strings.ReplaceAll(text, "  ", " ")
+func firstQueryAddress(addresses []emailQueryAddress) string {
+	if len(addresses) == 0 {
+		return ""
+	}
+	return strings.ToLower(addresses[0].address)
+}
+
+func pageBounds(total, offset, limit int) (int, int) {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > total {
+		offset = total
+	}
+	if limit <= 0 {
+		return offset, offset
+	}
+	if limit > total-offset {
+		return offset, total
+	}
+	return offset, offset + limit
+}
+
+func makeEmailPreview(email emailQueryEntry) EmailPreview {
+	preview := EmailPreview{
+		ID:            email.id,
+		Time:          email.time,
+		Read:          email.read,
+		Subject:       email.subject,
+		To:            make([]string, 0, len(email.to)),
+		Size:          email.size,
+		SizeHuman:     email.sizeHuman,
+		HasAttachment: email.hasAttachment,
+	}
+	if len(email.from) > 0 {
+		preview.From = email.from[0].address
+	}
+	for _, address := range email.to {
+		preview.To = append(preview.To, address.address)
+	}
+
+	previewText := email.text
+	if previewText == "" {
+		previewText = email.html
+		previewText = strings.ReplaceAll(previewText, "<", " <")
+		previewText = strings.ReplaceAll(previewText, ">", "> ")
+		previewText = strings.ReplaceAll(previewText, "\n", " ")
+		previewText = strings.ReplaceAll(previewText, "\r", " ")
+		for strings.Contains(previewText, "  ") {
+			previewText = strings.ReplaceAll(previewText, "  ", " ")
 		}
-		text = strings.TrimSpace(text)
+		previewText = strings.TrimSpace(previewText)
 	}
-	if len(text) > 200 {
-		text = text[:200] + "..."
+	if len(previewText) > 200 {
+		previewText = previewText[:200] + "..."
 	}
-	return text
+	preview.Preview = previewText
+	return preview
 }

--- a/internal/mailserver/query_test.go
+++ b/internal/mailserver/query_test.go
@@ -2,6 +2,9 @@ package mailserver
 
 import (
 	"fmt"
+	"math"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -11,21 +14,318 @@ import (
 	"github.com/emersion/go-message/mail"
 )
 
-func queryTestServer(count int) *MailServer {
+func TestMailboxQueryFiltersSortsAndPaginates(t *testing.T) {
+	server, base := newMailboxQueryTestServer(t)
+	defer func() { _ = server.Close() }()
+
+	read := false
+	dateFrom := base.Add(24 * time.Hour)
+	dateTo := base.Add(36 * time.Hour)
+	tests := []struct {
+		name  string
+		query EmailQuery
+		want  []string
+	}{
+		{name: "text and HTML", query: EmailQuery{Text: "html needle", Limit: 10}, want: []string{"id-2"}},
+		{name: "from name", query: EmailQuery{From: "alice sender", Limit: 10}, want: []string{"id-1"}},
+		{name: "to address", query: EmailQuery{To: "team@example.test", Limit: 10}, want: []string{"id-1"}},
+		{name: "cc name", query: EmailQuery{To: "copy recipient", Limit: 10}, want: []string{"id-1"}},
+		{name: "calculated bcc address", query: EmailQuery{To: "hidden@example.test", Limit: 10}, want: []string{"id-1"}},
+		{name: "date from", query: EmailQuery{DateFrom: &dateFrom, Limit: 10}, want: []string{"id-3", "id-2"}},
+		{name: "date to", query: EmailQuery{DateTo: &dateTo, Limit: 10}, want: []string{"id-2", "id-1"}},
+		{name: "read state", query: EmailQuery{Read: &read, Limit: 10}, want: []string{"id-3", "id-1"}},
+		{name: "time ascending", query: EmailQuery{SortBy: "time", SortOrder: "asc", Limit: 10}, want: []string{"id-1", "id-2", "id-3"}},
+		{name: "subject descending", query: EmailQuery{SortBy: "subject", SortOrder: "desc", Limit: 10}, want: []string{"id-3", "id-2", "id-1"}},
+		{name: "from ascending", query: EmailQuery{SortBy: "from", SortOrder: "asc", Limit: 10}, want: []string{"id-1", "id-2", "id-3"}},
+		{name: "size ascending", query: EmailQuery{SortBy: "size", SortOrder: "asc", Limit: 10}, want: []string{"id-2", "id-3", "id-1"}},
+		{name: "unknown sort preserves store order", query: EmailQuery{SortBy: "unknown", SortOrder: "asc", Limit: 10}, want: []string{"id-1", "id-2", "id-3"}},
+		{name: "pagination after filtering", query: EmailQuery{Text: "needle", SortBy: "subject", SortOrder: "asc", Offset: 1, Limit: 1}, want: []string{"id-2"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			emails, _ := server.QueryEmails(test.query)
+			if got := emailIDs(emails); fmt.Sprint(got) != fmt.Sprint(test.want) {
+				t.Fatalf("IDs = %v, want %v", got, test.want)
+			}
+		})
+	}
+
+	emails, total := server.QueryEmails(EmailQuery{Text: "needle", SortBy: "subject", SortOrder: "asc", Offset: 1, Limit: 1})
+	if total != 2 || len(emails) != 1 || emails[0].ID != "id-2" {
+		t.Fatalf("paginated result = total %d, emails %v", total, emailIDs(emails))
+	}
+	emails, total = server.QueryEmails(EmailQuery{Offset: math.MaxInt, Limit: math.MaxInt})
+	if total != 3 || emails == nil || len(emails) != 0 {
+		t.Fatalf("out-of-range result = total %d, emails %#v", total, emails)
+	}
+}
+
+func TestMailboxQueryReturnsDetachedResults(t *testing.T) {
+	server, _ := newMailboxQueryTestServer(t)
+	defer func() { _ = server.Close() }()
+
+	query := EmailQuery{SortBy: "unknown", Limit: 1}
+	emails, total := server.QueryEmails(query)
+	if total != 3 || len(emails) != 1 {
+		t.Fatalf("unexpected query result: total %d, emails %d", total, len(emails))
+	}
+	emails[0].Subject = "caller mutation"
+	emails[0].From[0].Address = "mutated@example.test"
+	emails[0].Attachments[0].FileName = "mutated.txt"
+	emails[0].Envelope.To[0] = "mutated@example.test"
+	emails[0].Headers["X-Trace"].([]string)[0] = "mutated"
+
+	again, _ := server.QueryEmails(query)
+	if again[0].Subject != "Alpha" || again[0].From[0].Address != "alice@example.test" {
+		t.Fatalf("full query exposed mutable store state: %#v", again[0])
+	}
+	if again[0].Attachments[0].FileName != "alpha.txt" || again[0].Envelope.To[0] != "team@example.test" {
+		t.Fatalf("nested full-query state was not detached: %#v", again[0])
+	}
+	if again[0].Headers["X-Trace"].([]string)[0] != "alpha" {
+		t.Fatalf("header state was not detached: %#v", again[0].Headers)
+	}
+
+	previews, total := server.QueryEmailPreviews(query)
+	if total != 3 || len(previews) != 1 || len(previews[0].To) != 1 {
+		t.Fatalf("unexpected preview result: total %d, previews %#v", total, previews)
+	}
+	previews[0].To[0] = "mutated@example.test"
+	previewsAgain, _ := server.QueryEmailPreviews(query)
+	if previewsAgain[0].To[0] != "team@example.test" {
+		t.Fatalf("preview query exposed mutable store state: %#v", previewsAgain[0])
+	}
+}
+
+func TestMailboxQueryPreviewBuildsOnlySummaryFields(t *testing.T) {
+	server, _ := newMailboxQueryTestServer(t)
+	defer func() { _ = server.Close() }()
+
+	previews, total := server.QueryEmailPreviews(EmailQuery{SortBy: "unknown", Offset: 1, Limit: 1})
+	if total != 3 || len(previews) != 1 {
+		t.Fatalf("preview result = total %d, previews %#v", total, previews)
+	}
+	preview := previews[0]
+	if preview.ID != "id-2" || preview.From != "bob@example.test" || fmt.Sprint(preview.To) != "[other@example.test]" {
+		t.Fatalf("preview addressing = %#v", preview)
+	}
+	if !preview.HasAttachment || preview.Size != 10 || preview.SizeHuman != "10 bytes" {
+		t.Fatalf("preview metadata = %#v", preview)
+	}
+	if preview.Preview == "" || strings.Contains(preview.Preview, "\n") {
+		t.Fatalf("preview text = %q", preview.Preview)
+	}
+}
+
+func TestMailboxQueryConcurrentWrites(t *testing.T) {
+	server, _ := newMailboxQueryTestServer(t)
+	defer func() { _ = server.Close() }()
+
+	const iterations = 80
+	start := make(chan struct{})
+	errors := make(chan error, 8)
+	var workers sync.WaitGroup
+
+	workers.Add(1)
+	go func() {
+		defer workers.Done()
+		<-start
+		for i := 0; i < iterations; i++ {
+			id := fmt.Sprintf("writer-%03d", i)
+			email := &Email{
+				Subject: id,
+				Time:    time.Unix(int64(i), 0).UTC(),
+				From:    []*mail.Address{{Address: "writer@example.test"}},
+				To:      []*mail.Address{{Address: "reader@example.test"}},
+				Text:    "concurrent needle",
+			}
+			if err := server.SaveEmailToStore(id, false, &Envelope{To: []string{"reader@example.test"}}, email); err != nil {
+				errors <- fmt.Errorf("save %s: %w", id, err)
+				return
+			}
+			if i%2 == 1 {
+				deleteID := fmt.Sprintf("writer-%03d", i-1)
+				if err := server.DeleteEmail(deleteID); err != nil {
+					errors <- fmt.Errorf("delete %s: %w", deleteID, err)
+					return
+				}
+			}
+		}
+	}()
+
+	workers.Add(1)
+	go func() {
+		defer workers.Done()
+		<-start
+		for i := 0; i < iterations*2; i++ {
+			if err := server.ReadEmail(fmt.Sprintf("id-%d", i%3+1)); err != nil {
+				errors <- fmt.Errorf("mark read: %w", err)
+				return
+			}
+		}
+	}()
+
+	for reader := 0; reader < 4; reader++ {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			<-start
+			for i := 0; i < iterations*2; i++ {
+				emails, total := server.QueryEmails(EmailQuery{Text: "needle", Offset: i % 7, Limit: 5})
+				if len(emails) > 5 || total < len(emails) {
+					errors <- fmt.Errorf("invalid full result: total %d, page %d", total, len(emails))
+					return
+				}
+				previews, previewTotal := server.QueryEmailPreviews(EmailQuery{SortBy: "subject", SortOrder: "asc", Limit: 5})
+				if len(previews) > 5 || previewTotal < len(previews) {
+					errors <- fmt.Errorf("invalid preview result: total %d, page %d", previewTotal, len(previews))
+					return
+				}
+			}
+		}()
+	}
+
+	close(start)
+	workers.Wait()
+	close(errors)
+	for err := range errors {
+		t.Error(err)
+	}
+}
+
+func newMailboxQueryTestServer(t *testing.T) (*MailServer, time.Time) {
+	t.Helper()
+	server, err := NewMailServer(1025, "localhost", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC)
+	emails := []struct {
+		id    string
+		read  bool
+		email *Email
+	}{
+		{id: "id-1", email: &Email{
+			Subject: "Alpha", Time: base, Text: "plain needle", Size: 30, SizeHuman: "30 B",
+			From:          []*mail.Address{{Name: "Alice Sender", Address: "alice@example.test"}},
+			To:            []*mail.Address{{Address: "team@example.test"}},
+			CC:            []*mail.Address{{Name: "Copy Recipient", Address: "copy@example.test"}},
+			CalculatedBCC: []*mail.Address{{Address: "hidden@example.test"}},
+			Attachments:   []*Attachment{{FileName: "alpha.txt"}},
+			Headers:       map[string]interface{}{"X-Trace": []string{"alpha"}},
+		}},
+		{id: "id-2", read: true, email: &Email{
+			Subject: "Beta", Time: base.Add(24 * time.Hour), HTML: "<b>html needle</b>\n", Size: 10, SizeHuman: "10 B",
+			From:        []*mail.Address{{Name: "Bob Sender", Address: "bob@example.test"}},
+			To:          []*mail.Address{{Address: "other@example.test"}},
+			Attachments: []*Attachment{{FileName: "beta.txt"}},
+			Headers:     map[string]interface{}{"X-Trace": []string{"beta"}},
+		}},
+		{id: "id-3", email: &Email{
+			Subject: "Gamma", Time: base.Add(48 * time.Hour), Text: "different", Size: 20, SizeHuman: "20 B",
+			From:    []*mail.Address{{Name: "Carol Sender", Address: "carol@example.test"}},
+			To:      []*mail.Address{{Address: "receiver@example.test"}},
+			Headers: map[string]interface{}{"X-Trace": []string{"gamma"}},
+		}},
+	}
+	for _, item := range emails {
+		if err := os.WriteFile(filepath.Join(server.mailDir, item.id+".eml"), make([]byte, item.email.Size), 0644); err != nil {
+			_ = server.Close()
+			t.Fatal(err)
+		}
+		envelopeTo := []string{item.email.To[0].Address}
+		if item.id == "id-1" {
+			envelopeTo = append(envelopeTo, "hidden@example.test")
+		}
+		envelope := &Envelope{From: item.email.From[0].Address, To: envelopeTo}
+		if err := server.SaveEmailToStore(item.id, item.read, envelope, item.email); err != nil {
+			_ = server.Close()
+			t.Fatal(err)
+		}
+	}
+	return server, base
+}
+
+func emailIDs(emails []*Email) []string {
+	ids := make([]string, 0, len(emails))
+	for _, email := range emails {
+		ids = append(ids, email.ID)
+	}
+	return ids
+}
+
+var (
+	benchmarkEmailsSink   []*Email
+	benchmarkPreviewsSink []EmailPreview
+	benchmarkTotalSink    int
+)
+
+func BenchmarkMailboxQuery10K(b *testing.B) {
+	server := benchmarkMailbox(10_000)
+	query := EmailQuery{Text: "needle", SortBy: "subject", SortOrder: "asc", Offset: 5_000, Limit: 50}
+
+	b.Run("before/full-get-all-then-paginate", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			benchmarkEmailsSink, benchmarkTotalSink = legacyMailboxQuery(server, query)
+		}
+	})
+	b.Run("after/full-paginate-then-clone", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			benchmarkEmailsSink, benchmarkTotalSink = server.QueryEmails(query)
+		}
+	})
+	b.Run("before/preview-get-all-then-paginate", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			emails, total := legacyMailboxQuery(server, query)
+			previews := make([]EmailPreview, 0, len(emails))
+			for _, email := range emails {
+				previews = append(previews, makeEmailPreview(snapshotEmailQueryEntry(email, true, true)))
+			}
+			benchmarkPreviewsSink, benchmarkTotalSink = previews, total
+		}
+	})
+	b.Run("after/preview-paginate-then-summarize", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			benchmarkPreviewsSink, benchmarkTotalSink = server.QueryEmailPreviews(query)
+		}
+	})
+}
+
+func benchmarkMailbox(count int) *MailServer {
 	server := &MailServer{
 		storeByID:      make(map[string]*Email, count),
 		storeOrder:     make([]string, 0, count),
 		receivedAtByID: make(map[string]time.Time, count),
 	}
+	text := "mailbox benchmark needle " + strings.Repeat("body ", 100)
 	for i := 0; i < count; i++ {
-		id := fmt.Sprintf("mail-%05d", i)
+		id := fmt.Sprintf("benchmark-%05d", i)
 		email := &Email{
-			ID: id, Time: time.Date(2026, 1, 1, 0, i, 0, 0, time.UTC),
-			Read: i%2 == 0, Subject: fmt.Sprintf("subject %05d", i),
-			From: []*mail.Address{{Name: "Sender", Address: fmt.Sprintf("sender%d@example.test", i%3)}},
-			To:   []*mail.Address{{Address: fmt.Sprintf("recipient%d@example.test", i%4)}},
-			Text: strings.Repeat("message body ", 128), Size: int64(i), SizeHuman: fmt.Sprintf("%d B", i),
-			Headers: map[string]interface{}{"X-Test": []string{"one", "two"}},
+			ID:            id,
+			Time:          time.Unix(int64(i), 0).UTC(),
+			Read:          i%2 == 0,
+			Subject:       fmt.Sprintf("Subject %05d", count-i),
+			From:          []*mail.Address{{Name: "Sender", Address: "sender@example.test"}},
+			To:            []*mail.Address{{Name: "Recipient", Address: "recipient@example.test"}},
+			CC:            []*mail.Address{{Address: "copy@example.test"}},
+			CalculatedBCC: []*mail.Address{{Address: "hidden@example.test"}},
+			Text:          text,
+			Attachments: []*Attachment{
+				{FileName: "one.txt", GeneratedFileName: "one.txt"},
+				{FileName: "two.txt", GeneratedFileName: "two.txt"},
+			},
+			Envelope:  &Envelope{From: "sender@example.test", To: []string{"recipient@example.test"}},
+			Size:      int64(i),
+			SizeHuman: "1 KiB",
+			Headers: map[string]interface{}{
+				"Received": []string{"first", "second"},
+				"Nested":   map[string]interface{}{"Values": []interface{}{"one", "two"}},
+			},
 		}
 		server.storeByID[id] = email
 		server.storeOrder = append(server.storeOrder, id)
@@ -33,88 +333,104 @@ func queryTestServer(count int) *MailServer {
 	return server
 }
 
-func TestQueryEmailsFiltersSortsAndPaginates(t *testing.T) {
-	server := queryTestServer(12)
-	page, total := server.QueryEmails(EmailQuery{
-		From: "sender1", To: "recipient1", Read: "false",
-		SortBy: "size", SortOrder: "desc", Offset: 1, Limit: 2,
-	})
-	if total != 1 || len(page) != 0 {
-		t.Fatalf("total, page length = %d, %d; want 1, 0", total, len(page))
-	}
-
-	page, total = server.QueryEmails(EmailQuery{Query: "body", SortBy: "subject", SortOrder: "desc", Offset: 2, Limit: 3})
-	if total != 12 || len(page) != 3 {
-		t.Fatalf("total, page length = %d, %d; want 12, 3", total, len(page))
-	}
-	if page[0].ID != "mail-00009" || page[2].ID != "mail-00007" {
-		t.Fatalf("unexpected page IDs: %s ... %s", page[0].ID, page[2].ID)
-	}
-}
-
-func TestQueryEmailsReturnsDetachedPage(t *testing.T) {
-	server := queryTestServer(4)
-	page, _ := server.QueryEmails(EmailQuery{Limit: 1})
-	page[0].Subject = "mutated"
-	page[0].From[0].Address = "mutated@example.test"
-	page[0].Headers["X-Test"].([]string)[0] = "mutated"
-
-	again, _ := server.QueryEmails(EmailQuery{Limit: 1})
-	if again[0].Subject == "mutated" || again[0].From[0].Address == "mutated@example.test" ||
-		again[0].Headers["X-Test"].([]string)[0] == "mutated" {
-		t.Fatal("query exposed mutable store state")
-	}
-}
-
-func TestQueryEmailPreviewsDuringConcurrentWrites(t *testing.T) {
-	server := queryTestServer(100)
-	var writers sync.WaitGroup
-	writers.Add(1)
-	go func() {
-		defer writers.Done()
-		for i := 100; i < 300; i++ {
-			id := fmt.Sprintf("mail-%05d", i)
-			server.storeMutex.Lock()
-			server.storeByID[id] = &Email{ID: id, Time: time.Now(), Subject: id, Text: "body"}
-			server.storeOrder = append(server.storeOrder, id)
-			server.storeMutex.Unlock()
-		}
-	}()
-	for i := 0; i < 200; i++ {
-		previews, total := server.QueryEmailPreviews(EmailQuery{Offset: i % 10, Limit: 25})
-		if total < len(previews) {
-			t.Fatalf("total %d is smaller than page %d", total, len(previews))
+func legacyMailboxQuery(server *MailServer, query EmailQuery) ([]*Email, int) {
+	emails := server.GetAllEmail()
+	matches := make([]*Email, 0, len(emails))
+	for _, email := range emails {
+		if legacyEmailMatches(email, query) {
+			matches = append(matches, email)
 		}
 	}
-	writers.Wait()
+	legacySortEmailMatches(matches, query.SortBy, query.SortOrder)
+	start, end := pageBounds(len(matches), query.Offset, query.Limit)
+	return matches[start:end], len(matches)
 }
 
-func BenchmarkMailboxQuery10K(b *testing.B) {
-	server := queryTestServer(10_000)
-	query := EmailQuery{Offset: 5_000, Limit: 50}
-	b.Run("before_clone_all", func(b *testing.B) {
-		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			server.storeMutex.RLock()
-			all := make([]*Email, 0, len(server.storeOrder))
-			for _, id := range server.storeOrder {
-				all = append(all, cloneEmail(server.storeByID[id]))
+func legacyEmailMatches(email *Email, query EmailQuery) bool {
+	if query.Text != "" {
+		queryLower := strings.ToLower(query.Text)
+		if !strings.Contains(strings.ToLower(email.Subject), queryLower) &&
+			!strings.Contains(strings.ToLower(email.Text), queryLower) &&
+			!strings.Contains(strings.ToLower(email.HTML), queryLower) {
+			return false
+		}
+	}
+	if query.From != "" && !legacyAddressesContain(email.From, strings.ToLower(query.From), true) {
+		return false
+	}
+	if query.To != "" {
+		toLower := strings.ToLower(query.To)
+		if !legacyAddressesContain(email.To, toLower, true) &&
+			!legacyAddressesContain(email.CC, toLower, true) &&
+			!legacyAddressesContain(email.CalculatedBCC, toLower, false) {
+			return false
+		}
+	}
+	if query.DateFrom != nil && email.Time.Before(*query.DateFrom) {
+		return false
+	}
+	if query.DateTo != nil && email.Time.After(*query.DateTo) {
+		return false
+	}
+	return query.Read == nil || email.Read == *query.Read
+}
+
+func legacyAddressesContain(addresses []*mail.Address, needle string, includeName bool) bool {
+	for _, address := range addresses {
+		if address == nil {
+			continue
+		}
+		if strings.Contains(strings.ToLower(address.Address), needle) ||
+			(includeName && strings.Contains(strings.ToLower(address.Name), needle)) {
+			return true
+		}
+	}
+	return false
+}
+
+func legacySortEmailMatches(emails []*Email, sortBy, sortOrder string) {
+	ascending := sortOrder == "asc"
+	switch sortBy {
+	case "":
+		sort.Slice(emails, func(i, j int) bool {
+			return emails[i].Time.After(emails[j].Time)
+		})
+	case "time":
+		sort.Slice(emails, func(i, j int) bool {
+			if ascending {
+				return emails[i].Time.Before(emails[j].Time)
 			}
-			server.storeMutex.RUnlock()
-			sort.Slice(all, func(i, j int) bool { return all[i].Time.After(all[j].Time) })
-			_ = all[query.Offset : query.Offset+query.Limit]
-		}
-	})
-	b.Run("after_paginate_then_clone", func(b *testing.B) {
-		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			_, _ = server.QueryEmails(query)
-		}
-	})
-	b.Run("after_preview_without_body_clone", func(b *testing.B) {
-		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			_, _ = server.QueryEmailPreviews(query)
-		}
-	})
+			return emails[i].Time.After(emails[j].Time)
+		})
+	case "subject":
+		sort.Slice(emails, func(i, j int) bool {
+			subjectI := strings.ToLower(emails[i].Subject)
+			subjectJ := strings.ToLower(emails[j].Subject)
+			if ascending {
+				return subjectI < subjectJ
+			}
+			return subjectI > subjectJ
+		})
+	case "from":
+		sort.Slice(emails, func(i, j int) bool {
+			fromI, fromJ := "", ""
+			if len(emails[i].From) > 0 && emails[i].From[0] != nil {
+				fromI = strings.ToLower(emails[i].From[0].Address)
+			}
+			if len(emails[j].From) > 0 && emails[j].From[0] != nil {
+				fromJ = strings.ToLower(emails[j].From[0].Address)
+			}
+			if ascending {
+				return fromI < fromJ
+			}
+			return fromI > fromJ
+		})
+	case "size":
+		sort.Slice(emails, func(i, j int) bool {
+			if ascending {
+				return emails[i].Size < emails[j].Size
+			}
+			return emails[i].Size > emails[j].Size
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- add a thread-safe mailbox query interface that captures only the scalar, string, and query-required address values needed for the existing text/from/to/date/read filters, sort behavior, offset, limit, and pre-pagination total
- release the store lock before body searching, sorting, pagination, and HTML preview normalization; reacquire it only to copy selected preview addresses or deep-clone the selected full-email page
- keep internal mutable `*Email` objects inside the mailserver boundary and return detached full snapshots or lightweight value summaries
- parse date/read filters once, cache lowercase sort keys, and use overflow-safe page bounds
- keep the REST routes, query parameters, response keys, JSON field names, default/capped pagination, and existing sort/filter semantics unchanged
- cover filtering, sorting, pagination boundaries, detached snapshots, concurrent saves/read-state writes/deletions, and race behavior
- document the change in the Unreleased changelog without Web UI changes

## Main branch sync

While this PR was under review, PR #73 landed the initial implementation and PR #75 added streaming MIME attachment storage. This branch is now rebased onto `46fac55`, preserves the attachment-streaming changelog and storage changes, and carries the stricter query snapshot strategy, broader race/compatibility coverage, and the fix for the review finding about holding the store lock during body processing.

## 10,000-message benchmark

Command:

```console
go test ./internal/mailserver -run '^$' -bench '^BenchmarkMailboxQuery10K$' -benchmem -benchtime=500ms -count=3
```

| Path | Legacy clone-all | This PR |
| --- | ---: | ---: |
| Full list | 22.9–23.1 ms/op, 16.96 MB/op, 250,026 allocs/op | 9.6–11.8 ms/op, 2.88 MB/op, 21,105 allocs/op |
| Preview | 23.3–24.0 ms/op, 16.99 MB/op, 250,327 allocs/op | 9.8–10.1 ms/op, 2.83 MB/op, 20,205 allocs/op |

The benchmark is informational only; no timing or allocation threshold is added to CI.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `go mod verify`
- `go build ./...`
- `gofmt -s -l .`
- `golangci-lint run --timeout=5m`
- `bun build ./web/*.js --target=browser`
- `bun test ./tests/web ./tests/docs` (59 passed)
