### PR TITLE
security(smtp): optionally require TLS for AUTH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to OwlMail are documented in this file. The format follows
 - Real inbound SMTP AUTH with PLAIN and LOGIN mechanisms, constant-time
   credential checks, and protocol-level rejection of unauthenticated mail
   transactions.
+- Optional `-smtp-auth-require-tls` /
+  `OWLMAIL_SMTP_AUTH_REQUIRE_TLS` policy that rejects PLAIN/LOGIN on cleartext
+  connections while preserving STARTTLS, SMTPS, and anonymous NO AUTH delivery.
 - Optional S3-compatible object storage for decoded attachments, including
   bounded transactional uploads and rollback, restart-safe metadata, bounded
   streaming downloads, recoverable deletion and quarantine cleanup,

--- a/README.de.md
+++ b/README.de.md
@@ -233,6 +233,7 @@ docker buildx build \
 | `-webhook-shutdown-timeout` | `OWLMAIL_WEBHOOK_SHUTDOWN_TIMEOUT` | 15s | Graceful webhook drain deadline |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | Eingehender SMTP-Benutzername; zusammen mit dem Passwort erzwingt er AUTH |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | Eingehendes SMTP-Passwort; zusammen mit dem Benutzernamen erzwingt es AUTH |
+| `-smtp-auth-require-tls` | `OWLMAIL_SMTP_AUTH_REQUIRE_TLS` | false | PLAIN/LOGIN vor TLS ablehnen; SMTP TLS muss aktiviert sein |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | SMTP TLS aktivieren |
 | `-tls-cert` | `MAILDEV_INCOMING_CERT` / `OWLMAIL_TLS_CERT` | - | SMTP TLS-Zertifikatsdatei |
 | `-tls-key` | `MAILDEV_INCOMING_KEY` / `OWLMAIL_TLS_KEY` | - | SMTP TLS-Private-Key-Datei |
@@ -474,6 +475,14 @@ dennoch angeboten und beliebige Zugangsdaten akzeptiert, damit Anwendungen mit
 obligatorischen SMTP-Zugangsdaten ohne Serverkonfiguration getestet werden
 können. Sind beide Werte gesetzt, ist SMTP AUTH erforderlich. Ein einzelner
 Wert verhindert den Start, statt unbemerkt auf NO AUTH zurückzufallen.
+
+Aktivieren Sie `-smtp-auth-require-tls` (oder
+`OWLMAIL_SMTP_AUTH_REQUIRE_TLS=true`) zusammen mit SMTP TLS, damit Zugangsdaten
+nicht über eine unverschlüsselte Verbindung übertragen werden. SMTP im Klartext
+bietet PLAIN/LOGIN dann weder an noch akzeptiert es diese Verfahren; nach
+STARTTLS und über SMTPS funktioniert AUTH weiterhin. Die anonyme Zustellung im
+NO-AUTH-Modus bleibt erhalten. Ohne aktivierte, nutzbare SMTP-TLS-Konfiguration
+verhindert diese Option den Start.
 
 > [!WARNING]
 > NO AUTH bietet absichtlich keine Zugriffskontrolle. PLAIN/LOGIN sind für die

--- a/README.fr.md
+++ b/README.fr.md
@@ -234,6 +234,7 @@ docker buildx build \
 | `-webhook-shutdown-timeout` | `OWLMAIL_WEBHOOK_SHUTDOWN_TIMEOUT` | 15s | Graceful webhook drain deadline |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | Nom d’utilisateur SMTP entrant ; avec le mot de passe, rend AUTH obligatoire |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | Mot de passe SMTP entrant ; avec le nom d’utilisateur, rend AUTH obligatoire |
+| `-smtp-auth-require-tls` | `OWLMAIL_SMTP_AUTH_REQUIRE_TLS` | false | Refuser PLAIN/LOGIN avant TLS ; nécessite l’activation de SMTP TLS |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | Enable SMTP TLS |
 | `-tls-cert` | `MAILDEV_INCOMING_CERT` / `OWLMAIL_TLS_CERT` | - | SMTP TLS certificate file |
 | `-tls-key` | `MAILDEV_INCOMING_KEY` / `OWLMAIL_TLS_KEY` | - | SMTP TLS private key file |
@@ -473,6 +474,13 @@ remise sans authentification est autorisée et PLAIN/LOGIN acceptent aussi des
 identifiants arbitraires pour les applications qui imposent des paramètres
 SMTP. Avec les deux valeurs, SMTP AUTH devient obligatoire. Une seule valeur
 empêche le démarrage au lieu de revenir silencieusement à NO AUTH.
+
+Activez `-smtp-auth-require-tls` (ou
+`OWLMAIL_SMTP_AUTH_REQUIRE_TLS=true`) avec SMTP TLS pour éviter de transmettre
+les identifiants en clair. SMTP non chiffré n’annonce ni n’accepte alors
+PLAIN/LOGIN ; AUTH reste disponible après STARTTLS et via SMTPS. La remise
+anonyme du mode NO AUTH reste inchangée. Sans configuration SMTP TLS activée et
+utilisable, cette option empêche le démarrage.
 
 > [!WARNING]
 > NO AUTH ne fournit volontairement aucun contrôle d’accès. PLAIN/LOGIN restent

--- a/README.it.md
+++ b/README.it.md
@@ -233,6 +233,7 @@ docker buildx build \
 | `-webhook-shutdown-timeout` | `OWLMAIL_WEBHOOK_SHUTDOWN_TIMEOUT` | 15s | Graceful webhook drain deadline |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | Nome utente SMTP in ingresso; insieme alla password rende AUTH obbligatorio |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | Password SMTP in ingresso; insieme al nome utente rende AUTH obbligatorio |
+| `-smtp-auth-require-tls` | `OWLMAIL_SMTP_AUTH_REQUIRE_TLS` | false | Rifiuta PLAIN/LOGIN prima di TLS; richiede SMTP TLS attivo |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | Abilita TLS SMTP |
 | `-tls-cert` | `MAILDEV_INCOMING_CERT` / `OWLMAIL_TLS_CERT` | - | File certificato TLS SMTP |
 | `-tls-key` | `MAILDEV_INCOMING_KEY` / `OWLMAIL_TLS_KEY` | - | File chiave privata TLS SMTP |
@@ -471,6 +472,13 @@ consegna non autenticata e credenziali PLAIN/LOGIN arbitrarie per le applicazion
 che richiedono comunque parametri SMTP. Con entrambi i valori SMTP AUTH diventa
 obbligatorio. Un solo valore impedisce l’avvio invece di tornare silenziosamente
 a NO AUTH.
+
+Abilita `-smtp-auth-require-tls` (o
+`OWLMAIL_SMTP_AUTH_REQUIRE_TLS=true`) insieme a SMTP TLS per impedire che le
+credenziali attraversino una connessione in chiaro. SMTP in chiaro non annuncia
+né accetta PLAIN/LOGIN; AUTH continua a funzionare dopo STARTTLS e tramite
+SMTPS. La consegna anonima in modalità NO AUTH resta invariata. Senza una
+configurazione SMTP TLS attiva e utilizzabile, l’opzione impedisce l’avvio.
 
 > [!WARNING]
 > NO AUTH non fornisce deliberatamente controllo degli accessi. PLAIN/LOGIN è

--- a/README.ja.md
+++ b/README.ja.md
@@ -233,6 +233,7 @@ docker buildx build \
 | `-webhook-shutdown-timeout` | `OWLMAIL_WEBHOOK_SHUTDOWN_TIMEOUT` | 15s | Graceful webhook drain deadline |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | 受信 SMTP ユーザー名。パスワードと同時設定すると AUTH を必須化 |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | 受信 SMTP パスワード。ユーザー名と同時設定すると AUTH を必須化 |
+| `-smtp-auth-require-tls` | `OWLMAIL_SMTP_AUTH_REQUIRE_TLS` | false | TLS 確立前の PLAIN/LOGIN を拒否。SMTP TLS の有効化が必要 |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | Enable SMTP TLS |
 | `-tls-cert` | `MAILDEV_INCOMING_CERT` / `OWLMAIL_TLS_CERT` | - | SMTP TLS certificate file |
 | `-tls-key` | `MAILDEV_INCOMING_KEY` / `OWLMAIL_TLS_KEY` | - | SMTP TLS private key file |
@@ -470,6 +471,13 @@ EOF
 AUTH** モードになります。未認証の配送に加え、SMTP 設定を必須とするアプリの
 ために任意の PLAIN/LOGIN 認証情報も受け入れます。両方を設定すると SMTP AUTH
 が必須になります。片方だけの設定は NO AUTH に戻らず、起動エラーになります。
+
+認証情報を平文接続で送信させない場合は、SMTP TLS とともに
+`-smtp-auth-require-tls`（または `OWLMAIL_SMTP_AUTH_REQUIRE_TLS=true`）を
+有効にします。平文 SMTP では PLAIN/LOGIN を通知せず、受け付けませんが、
+STARTTLS 後および SMTPS では AUTH を利用できます。NO AUTH モードの匿名配送は
+変わりません。有効かつ利用可能な SMTP TLS 設定がない場合、このオプションを
+有効にすると起動に失敗します。
 
 > [!WARNING]
 > NO AUTH は意図的にアクセス制御を提供しません。開発互換性のため

--- a/README.ko.md
+++ b/README.ko.md
@@ -233,6 +233,7 @@ docker buildx build \
 | `-webhook-shutdown-timeout` | `OWLMAIL_WEBHOOK_SHUTDOWN_TIMEOUT` | 15s | Graceful webhook drain deadline |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | 인바운드 SMTP 사용자 이름; 비밀번호와 함께 설정하면 AUTH 필수 |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | 인바운드 SMTP 비밀번호; 사용자 이름과 함께 설정하면 AUTH 필수 |
+| `-smtp-auth-require-tls` | `OWLMAIL_SMTP_AUTH_REQUIRE_TLS` | false | TLS 전 PLAIN/LOGIN 거부; SMTP TLS 활성화 필요 |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | Enable SMTP TLS |
 | `-tls-cert` | `MAILDEV_INCOMING_CERT` / `OWLMAIL_TLS_CERT` | - | SMTP TLS certificate file |
 | `-tls-key` | `MAILDEV_INCOMING_KEY` / `OWLMAIL_TLS_KEY` | - | SMTP TLS private key file |
@@ -470,6 +471,13 @@ EOF
 사용됩니다. 인증 없는 전송과 함께 SMTP 자격 증명을 요구하는 애플리케이션을 위해
 임의의 PLAIN/LOGIN 자격 증명도 허용합니다. 두 값을 모두 설정하면 SMTP AUTH가
 필수가 됩니다. 하나만 설정하면 NO AUTH로 조용히 돌아가지 않고 시작에 실패합니다.
+
+자격 증명이 평문 연결을 통과하지 않도록 하려면 SMTP TLS와 함께
+`-smtp-auth-require-tls`(또는 `OWLMAIL_SMTP_AUTH_REQUIRE_TLS=true`)를
+활성화하세요. 평문 SMTP는 PLAIN/LOGIN을 광고하거나 허용하지 않지만 STARTTLS 후와
+SMTPS에서는 AUTH가 정상 작동합니다. NO AUTH 모드의 익명 전송은 그대로 유지됩니다.
+활성화되고 사용 가능한 SMTP TLS 설정이 없으면 이 옵션을 켠 상태로 시작할 수
+없습니다.
 
 > [!WARNING]
 > NO AUTH는 의도적으로 접근 제어를 제공하지 않습니다. 개발 호환성을 위해

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ the message body; clicking one focuses OwlMail and opens the message.
 | `-webhook-shutdown-timeout` | `OWLMAIL_WEBHOOK_SHUTDOWN_TIMEOUT` | 15s | Graceful webhook drain deadline |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | Inbound SMTP username; configure together with the password to require AUTH |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | Inbound SMTP password; configure together with the username to require AUTH |
+| `-smtp-auth-require-tls` | `OWLMAIL_SMTP_AUTH_REQUIRE_TLS` | false | Reject PLAIN/LOGIN before TLS; requires SMTP TLS to be enabled |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | Enable SMTP TLS |
 | `-tls-cert` | `MAILDEV_INCOMING_CERT` / `OWLMAIL_TLS_CERT` | - | SMTP TLS certificate file |
 | `-tls-key` | `MAILDEV_INCOMING_KEY` / `OWLMAIL_TLS_KEY` | - | SMTP TLS private key file |
@@ -550,6 +551,13 @@ Configure both values to require real SMTP AUTH. OwlMail rejects a transaction
 before authentication with `530 5.7.0` and rejects invalid credentials with
 `535 5.7.8`. Configuring only one value fails startup instead of silently
 falling back to NO AUTH.
+
+Set `-smtp-auth-require-tls` (or `OWLMAIL_SMTP_AUTH_REQUIRE_TLS=true`) together
+with SMTP TLS to prevent credentials from crossing a cleartext connection.
+Plaintext SMTP then neither advertises nor accepts PLAIN/LOGIN, while AUTH works
+after STARTTLS and over SMTPS. Anonymous delivery remains available in NO AUTH
+mode. Enabling this option without an enabled, usable SMTP TLS configuration
+fails startup.
 
 > [!WARNING]
 > NO AUTH deliberately provides no access-control boundary. PLAIN and LOGIN can

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -250,6 +250,7 @@ Notifications API 需要 HTTPS，或 `http://localhost` 等受信任的本地来
 | `-webhook-shutdown-timeout` | `OWLMAIL_WEBHOOK_SHUTDOWN_TIMEOUT` | 15s | Webhook 优雅排空截止时间 |
 | `-smtp-user` | `MAILDEV_INCOMING_USER` / `OWLMAIL_SMTP_USER` | - | 入站 SMTP 用户名；与密码同时配置后强制 AUTH |
 | `-smtp-password` | `MAILDEV_INCOMING_PASS` / `OWLMAIL_SMTP_PASSWORD` | - | 入站 SMTP 密码；与用户名同时配置后强制 AUTH |
+| `-smtp-auth-require-tls` | `OWLMAIL_SMTP_AUTH_REQUIRE_TLS` | false | TLS 建立前拒绝 PLAIN/LOGIN；必须同时启用 SMTP TLS |
 | `-tls` | `MAILDEV_INCOMING_SECURE` / `OWLMAIL_TLS_ENABLED` | false | 启用 SMTP TLS |
 | `-tls-cert` | `MAILDEV_INCOMING_CERT` / `OWLMAIL_TLS_CERT` | - | SMTP TLS 证书文件 |
 | `-tls-key` | `MAILDEV_INCOMING_KEY` / `OWLMAIL_TLS_KEY` | - | SMTP TLS 私钥文件 |
@@ -531,6 +532,12 @@ Webhook 目标支持不区分大小写的通配规则、JSON 安全的自定义�
 
 同时配置两项后启用真正的强制 SMTP AUTH。未认证事务会收到 `530 5.7.0`，错误
 凭据会收到 `535 5.7.8`。只配置其中一项时启动失败，不会静默回退到 NO AUTH。
+
+若希望保留默认开发体验，同时避免凭据经过明文连接，可在启用 SMTP TLS 的同时
+设置 `-smtp-auth-require-tls`（或 `OWLMAIL_SMTP_AUTH_REQUIRE_TLS=true`）。此时
+明文 SMTP 既不会声明也不会接受 PLAIN/LOGIN；STARTTLS 后及 SMTPS 连接仍可正常
+认证。NO AUTH 模式下的匿名投递不受影响。开启此选项但没有启用且可用的 SMTP TLS
+配置时，服务会直接启动失败。
 
 > [!WARNING]
 > NO AUTH 有意不提供访问控制；为兼容开发环境，PLAIN/LOGIN 也允许在未启用 TLS

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -427,6 +427,9 @@ func createMailServer(cfg *config.Config) (*mailserver.MailServer, error) {
 
 	// Setup TLS config
 	tlsConfig := setupTLSConfig(cfg)
+	if cfg.SMTPAuthRequireTLS && tlsConfig == nil {
+		return nil, fmt.Errorf("SMTP AUTH cannot require TLS without an enabled TLS configuration")
+	}
 	attachmentStore, err := setupAttachmentStore(cfg)
 	if err != nil {
 		return nil, err
@@ -447,6 +450,7 @@ func createMailServer(cfg *config.Config) (*mailserver.MailServer, error) {
 	server, err := mailserver.NewMailServerWithOptions(cfg.SMTPPort, cfg.SMTPHost, cfg.MailDir, mailserver.ServerOptions{
 		OutgoingConfig:  outgoingConfig,
 		AuthConfig:      authConfig,
+		AuthRequireTLS:  cfg.SMTPAuthRequireTLS,
 		TLSConfig:       tlsConfig,
 		UseUUIDForID:    cfg.UseUUIDForEmailID,
 		MaxMessageBytes: int64(maxMessageMB) << 20,

--- a/cmd/owlmail/main_test.go
+++ b/cmd/owlmail/main_test.go
@@ -918,6 +918,13 @@ func TestCreateMailServer(t *testing.T) {
 		t.Fatal("createMailServer() with partial SMTP credentials should fail")
 	}
 
+	requireTLSWithoutTLS := *cfg
+	requireTLSWithoutTLS.MailDir = t.TempDir()
+	requireTLSWithoutTLS.SMTPAuthRequireTLS = true
+	if _, err := createMailServer(&requireTLSWithoutTLS); err == nil || !strings.Contains(err.Error(), "SMTP AUTH cannot require TLS") {
+		t.Fatalf("createMailServer() error = %v, want clear missing SMTP TLS error", err)
+	}
+
 	// Test with invalid outgoing config (invalid rules file)
 	tmpDir5 := t.TempDir()
 	cfg = &config.Config{

--- a/docs/en/API-Reference.md
+++ b/docs/en/API-Reference.md
@@ -177,7 +177,10 @@ The `smtpAuth` object returned by the settings endpoint is `null` in NO AUTH
 mode and reflects the configured username (never the password) when required
 authentication is enabled. With both `OWLMAIL_SMTP_USER` and
 `OWLMAIL_SMTP_PASSWORD` set, PLAIN/LOGIN authentication is enforced. Supplying
-only one credential fails startup. See
+only one credential fails startup. `OWLMAIL_SMTP_AUTH_REQUIRE_TLS=true` makes
+AUTH available only after STARTTLS or over SMTPS and requires SMTP TLS to be
+enabled; it does not change anonymous delivery in NO AUTH mode. This startup
+policy is not writable through the settings API. See
 [Operations](./Operations.md#smtp-ingress-limits-and-authentication-modes).
 
 ```bash

--- a/docs/en/Operations.md
+++ b/docs/en/Operations.md
@@ -242,6 +242,13 @@ setup. Setting both values requires SMTP AUTH: unauthenticated transactions are
 rejected with `530 5.7.0`, and invalid credentials with `535 5.7.8`. Supplying
 only one value fails startup.
 
+For deployments that must not expose authentication payloads on a cleartext
+connection, set `-smtp-auth-require-tls` or
+`OWLMAIL_SMTP_AUTH_REQUIRE_TLS=true` and enable SMTP TLS. The plaintext listener
+then rejects PLAIN/LOGIN, while both STARTTLS sessions and direct SMTPS accept
+AUTH. NO AUTH still permits anonymous delivery. Enabling the policy without an
+enabled TLS configuration fails startup before a listener is opened.
+
 > [!WARNING]
 > NO AUTH is intentionally open. OwlMail also permits PLAIN/LOGIN on a
 > non-TLS connection for development compatibility. Keep the listener on a

--- a/docs/zh-CN/API-Reference.md
+++ b/docs/zh-CN/API-Reference.md
@@ -167,7 +167,10 @@ curl -u admin:secret http://localhost:1080/api/v1/emails
 NO AUTH 模式下，设置端点返回的 `smtpAuth` 为 `null`；启用强制认证后，该对象只
 返回配置的用户名，不会返回密码。同时设置 `OWLMAIL_SMTP_USER` 与
 `OWLMAIL_SMTP_PASSWORD` 后会强制执行 PLAIN/LOGIN 认证；只设置其中一项会启动
-失败。详见[运维与排障](./Operations.md#smtp-入口限制与鉴权模式)。
+失败。设置 `OWLMAIL_SMTP_AUTH_REQUIRE_TLS=true` 后，AUTH 只能在 STARTTLS 后或
+SMTPS 连接上执行，并要求启用 SMTP TLS；NO AUTH 模式下的匿名投递不受影响。该
+启动策略不能通过设置 API 修改。详见
+[运维与排障](./Operations.md#smtp-入口限制与鉴权模式)。
 
 ```bash
 curl -u admin:secret \

--- a/docs/zh-CN/Operations.md
+++ b/docs/zh-CN/Operations.md
@@ -204,6 +204,11 @@ SMTP 与 SMTPS 默认单封邮件上限为 100 MiB。可通过 `-smtp-max-messag
 同时设置两项后强制 SMTP AUTH；未认证事务返回 `530 5.7.0`，错误凭据返回
 `535 5.7.8`。只设置其中一项会启动失败。
 
+如果部署环境不允许认证载荷经过明文连接，请设置 `-smtp-auth-require-tls` 或
+`OWLMAIL_SMTP_AUTH_REQUIRE_TLS=true`，并启用 SMTP TLS。此时明文监听器会拒绝
+PLAIN/LOGIN，STARTTLS 会话和直接 SMTPS 连接仍可正常 AUTH；NO AUTH 模式仍允许
+匿名投递。开启策略但未启用 TLS 配置时，服务会在打开监听器前启动失败。
+
 > [!WARNING]
 > NO AUTH 有意保持开放。为兼容开发环境，OwlMail 也允许在非 TLS 连接上使用
 > PLAIN/LOGIN。请将监听器限制在可信接口，并在使用真实凭据前启用 TLS。

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -233,8 +233,9 @@ type Config struct {
 	AutoRelayRules string
 
 	// SMTP authentication
-	SMTPUser     string
-	SMTPPassword string
+	SMTPUser           string
+	SMTPPassword       string
+	SMTPAuthRequireTLS bool
 
 	// TLS configuration for SMTP
 	TLSEnabled  bool
@@ -296,6 +297,7 @@ func DefaultConfig() *Config {
 		AutoRelayRules:         "",
 		SMTPUser:               "",
 		SMTPPassword:           "",
+		SMTPAuthRequireTLS:     false,
 		TLSEnabled:             false,
 		TLSCertFile:            "",
 		TLSKeyFile:             "",
@@ -345,6 +347,7 @@ type FlagRefs struct {
 	AutoRelayRules         *string
 	SMTPUser               *string
 	SMTPPassword           *string
+	SMTPAuthRequireTLS     *bool
 	TLSEnabled             *bool
 	TLSCertFile            *string
 	TLSKeyFile             *string
@@ -396,6 +399,7 @@ func DefineFlags(fs *flag.FlagSet) *FlagRefs {
 		AutoRelayRules:         fs.String("auto-relay-rules", cfg.AutoRelayRules, "JSON file path for auto relay rules"),
 		SMTPUser:               fs.String("smtp-user", cfg.SMTPUser, "SMTP username; set with smtp-password to require authentication"),
 		SMTPPassword:           fs.String("smtp-password", cfg.SMTPPassword, "SMTP password; set with smtp-user to require authentication"),
+		SMTPAuthRequireTLS:     fs.Bool("smtp-auth-require-tls", cfg.SMTPAuthRequireTLS, "Require TLS before accepting SMTP AUTH"),
 		TLSEnabled:             fs.Bool("tls", cfg.TLSEnabled, "Enable TLS/STARTTLS for SMTP server"),
 		TLSCertFile:            fs.String("tls-cert", cfg.TLSCertFile, "TLS certificate file path"),
 		TLSKeyFile:             fs.String("tls-key", cfg.TLSKeyFile, "TLS private key file path"),
@@ -451,8 +455,9 @@ func ResolveConfig(fs *flag.FlagSet, refs *FlagRefs) *Config {
 		AutoRelayAddr:  resolveStringWithFlag(fs, "auto-relay-addr", "OWLMAIL_AUTO_RELAY_ADDR", *refs.AutoRelayAddr),
 		AutoRelayRules: resolveStringWithFlag(fs, "auto-relay-rules", "OWLMAIL_AUTO_RELAY_RULES", *refs.AutoRelayRules),
 
-		SMTPUser:     resolveStringWithFlag(fs, "smtp-user", "OWLMAIL_SMTP_USER", *refs.SMTPUser),
-		SMTPPassword: resolveStringWithFlag(fs, "smtp-password", "OWLMAIL_SMTP_PASSWORD", *refs.SMTPPassword),
+		SMTPUser:           resolveStringWithFlag(fs, "smtp-user", "OWLMAIL_SMTP_USER", *refs.SMTPUser),
+		SMTPPassword:       resolveStringWithFlag(fs, "smtp-password", "OWLMAIL_SMTP_PASSWORD", *refs.SMTPPassword),
+		SMTPAuthRequireTLS: resolveBoolWithFlag(fs, "smtp-auth-require-tls", "OWLMAIL_SMTP_AUTH_REQUIRE_TLS", *refs.SMTPAuthRequireTLS),
 
 		TLSEnabled:  resolveBoolWithFlag(fs, "tls", "OWLMAIL_TLS_ENABLED", *refs.TLSEnabled),
 		TLSCertFile: resolveStringWithFlag(fs, "tls-cert", "OWLMAIL_TLS_CERT", *refs.TLSCertFile),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -274,6 +274,9 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.TLSEnabled != false {
 		t.Errorf("DefaultConfig().TLSEnabled = %v, want %v", cfg.TLSEnabled, false)
 	}
+	if cfg.SMTPAuthRequireTLS {
+		t.Error("DefaultConfig().SMTPAuthRequireTLS = true, want false")
+	}
 	if cfg.UseUUIDForEmailID != false {
 		t.Errorf("DefaultConfig().UseUUIDForEmailID = %v, want %v", cfg.UseUUIDForEmailID, false)
 	}
@@ -292,6 +295,31 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.WebhookRedisURL != "" || cfg.WebhookRedisPrefix != "owlmail:webhooks" || cfg.WebhookShutdownTimeout != "15s" {
 		t.Errorf("unexpected default webhook queue config: %#v", cfg)
 	}
+}
+
+func TestSMTPAuthRequireTLSResolution(t *testing.T) {
+	t.Run("CLI flag", func(t *testing.T) {
+		fs := flag.NewFlagSet("smtp-auth-require-tls", flag.ContinueOnError)
+		refs := DefineFlags(fs)
+		if err := fs.Parse([]string{"-smtp-auth-require-tls"}); err != nil {
+			t.Fatal(err)
+		}
+		if cfg := ResolveConfig(fs, refs); !cfg.SMTPAuthRequireTLS {
+			t.Fatal("CLI flag did not enable SMTP AUTH TLS requirement")
+		}
+	})
+
+	t.Run("environment variable", func(t *testing.T) {
+		t.Setenv("OWLMAIL_SMTP_AUTH_REQUIRE_TLS", "true")
+		fs := flag.NewFlagSet("smtp-auth-require-tls-env", flag.ContinueOnError)
+		refs := DefineFlags(fs)
+		if err := fs.Parse(nil); err != nil {
+			t.Fatal(err)
+		}
+		if cfg := ResolveConfig(fs, refs); !cfg.SMTPAuthRequireTLS {
+			t.Fatal("OWLMAIL_SMTP_AUTH_REQUIRE_TLS did not enable SMTP AUTH TLS requirement")
+		}
+	})
 }
 
 func TestSMTPAndS3ConfigResolution(t *testing.T) {

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -40,6 +40,9 @@ func ValidateConfig(cfg *Config) error {
 	if (cfg.SMTPUser == "") != (cfg.SMTPPassword == "") {
 		return fmt.Errorf("SMTP username and password must be configured together")
 	}
+	if cfg.SMTPAuthRequireTLS && !cfg.TLSEnabled {
+		return fmt.Errorf("SMTP AUTH cannot require TLS unless SMTP TLS is enabled")
+	}
 	if cfg.WebExternalScheme != "" && cfg.WebExternalScheme != "http" && cfg.WebExternalScheme != "https" {
 		return fmt.Errorf("web external scheme must be http or https")
 	}

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -171,6 +172,21 @@ func TestValidateConfig(t *testing.T) {
 		cfg.SMTPUser = "user"
 		if err := ValidateConfig(cfg); err != nil {
 			t.Fatalf("complete SMTP credentials should be valid: %v", err)
+		}
+	})
+
+	t.Run("SMTP AUTH requires TLS without SMTP TLS", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.SMTPAuthRequireTLS = true
+		if err := ValidateConfig(cfg); err == nil || !strings.Contains(err.Error(), "SMTP AUTH cannot require TLS") {
+			t.Fatalf("ValidateConfig() error = %v, want clear SMTP AUTH TLS configuration error", err)
+		}
+
+		cfg.TLSEnabled = true
+		cfg.TLSCertFile = "/path/to/cert.pem"
+		cfg.TLSKeyFile = "/path/to/key.pem"
+		if err := ValidateConfig(cfg); err != nil {
+			t.Fatalf("ValidateConfig() with SMTP TLS enabled error = %v", err)
 		}
 	})
 

--- a/internal/mailserver/auth_test.go
+++ b/internal/mailserver/auth_test.go
@@ -3,6 +3,7 @@ package mailserver
 import (
 	"bytes"
 	"crypto/sha256"
+	"crypto/tls"
 	"errors"
 	"net"
 	"strings"
@@ -192,6 +193,103 @@ func TestSMTPAuthRequiredMode(t *testing.T) {
 	}
 }
 
+func TestSMTPAuthRequireTLSRejectsPlaintext(t *testing.T) {
+	authConfig := &SMTPAuthConfig{Enabled: true, Username: "user", Password: "pass"}
+	_, address := startSMTPAuthTLSTestServer(t, authConfig, false)
+
+	for name, authClient := range map[string]sasl.Client{
+		"PLAIN": sasl.NewPlainClient("", "user", "pass"),
+		"LOGIN": sasl.NewLoginClient("user", "pass"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			client := dialSMTPTestClient(t, address)
+			defer func() { _ = client.Close() }()
+			if client.SupportsAuth(name) {
+				t.Fatalf("plaintext connection advertised AUTH %s", name)
+			}
+			if err := client.Auth(authClient); err == nil {
+				t.Fatalf("plaintext AUTH %s succeeded", name)
+			}
+		})
+	}
+}
+
+func TestSMTPAuthRequireTLSAllowsSTARTTLS(t *testing.T) {
+	authConfig := &SMTPAuthConfig{Enabled: true, Username: "user", Password: "pass"}
+	server, address := startSMTPAuthTLSTestServer(t, authConfig, false)
+
+	for name, authClient := range map[string]sasl.Client{
+		"PLAIN": sasl.NewPlainClient("", "user", "pass"),
+		"LOGIN": sasl.NewLoginClient("user", "pass"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			client, err := smtp.DialStartTLS(address, insecureSMTPTestTLSConfig())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = client.Close() }()
+			if !client.SupportsAuth(name) {
+				t.Fatalf("STARTTLS connection did not advertise AUTH %s", name)
+			}
+			if err := client.Auth(authClient); err != nil {
+				t.Fatalf("STARTTLS AUTH %s failed: %v", name, err)
+			}
+			sendSMTPTestMessage(t, client, strings.ToLower(name)+"-starttls@example.test")
+			quitSMTPTestClient(t, client)
+		})
+	}
+
+	if got := len(server.GetAllEmail()); got != 2 {
+		t.Fatalf("stored STARTTLS messages = %d, want 2", got)
+	}
+}
+
+func TestSMTPAuthRequireTLSAllowsSMTPS(t *testing.T) {
+	authConfig := &SMTPAuthConfig{Enabled: true, Username: "user", Password: "pass"}
+	server, address := startSMTPAuthTLSTestServer(t, authConfig, true)
+
+	for name, authClient := range map[string]sasl.Client{
+		"PLAIN": sasl.NewPlainClient("", "user", "pass"),
+		"LOGIN": sasl.NewLoginClient("user", "pass"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			client, err := smtp.DialTLS(address, insecureSMTPTestTLSConfig())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = client.Close() }()
+			if !client.SupportsAuth(name) {
+				t.Fatalf("SMTPS connection did not advertise AUTH %s", name)
+			}
+			if err := client.Auth(authClient); err != nil {
+				t.Fatalf("SMTPS AUTH %s failed: %v", name, err)
+			}
+			sendSMTPTestMessage(t, client, strings.ToLower(name)+"-smtps@example.test")
+			quitSMTPTestClient(t, client)
+		})
+	}
+
+	if got := len(server.GetAllEmail()); got != 2 {
+		t.Fatalf("stored SMTPS messages = %d, want 2", got)
+	}
+}
+
+func TestSMTPAuthRequireTLSKeepsNoAuthAnonymousDelivery(t *testing.T) {
+	server, address := startSMTPAuthTLSTestServer(t, nil, false)
+	client := dialSMTPTestClient(t, address)
+	defer func() { _ = client.Close() }()
+
+	if client.SupportsAuth(sasl.Plain) || client.SupportsAuth(sasl.Login) {
+		t.Fatal("plaintext NO AUTH connection advertised AUTH while TLS was required")
+	}
+	sendSMTPTestMessage(t, client, "anonymous@example.test")
+	quitSMTPTestClient(t, client)
+
+	if got := len(server.GetAllEmail()); got != 1 {
+		t.Fatalf("stored anonymous messages = %d, want 1", got)
+	}
+}
+
 func startSMTPAuthTestServer(t *testing.T, authConfig *SMTPAuthConfig) (*MailServer, string) {
 	t.Helper()
 	server, err := NewMailServerWithConfig(1025, "127.0.0.1", t.TempDir(), nil, authConfig, nil)
@@ -216,6 +314,49 @@ func startSMTPAuthTestServer(t *testing.T, authConfig *SMTPAuthConfig) (*MailSer
 		}
 	})
 	return server, listener.Addr().String()
+}
+
+func startSMTPAuthTLSTestServer(t *testing.T, authConfig *SMTPAuthConfig, implicitTLS bool) (*MailServer, string) {
+	t.Helper()
+	server, err := NewMailServerWithOptions(1025, "127.0.0.1", t.TempDir(), ServerOptions{
+		AuthConfig:     authConfig,
+		AuthRequireTLS: true,
+		TLSConfig:      &TLSConfig{Enabled: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		_ = server.Close()
+		t.Fatal(err)
+	}
+	listener := net.Listener(rawListener)
+	serve := server.smtpServer
+	if implicitTLS {
+		serve = server.smtpsServer
+		listener = tls.NewListener(rawListener, serve.TLSConfig)
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- serve.Serve(listener)
+	}()
+	t.Cleanup(func() {
+		_ = server.Close()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("SMTP TLS test server did not stop")
+		}
+	})
+	return server, rawListener.Addr().String()
+}
+
+func insecureSMTPTestTLSConfig() *tls.Config {
+	return &tls.Config{
+		// The test server uses a fresh self-signed certificate.
+		InsecureSkipVerify: true, //nolint:gosec
+	}
 }
 
 func dialSMTPTestClient(t *testing.T, address string) *smtp.Client {

--- a/internal/mailserver/config.go
+++ b/internal/mailserver/config.go
@@ -42,6 +42,9 @@ func NewMailServerWithFullConfig(port int, host, mailDir string, outgoingConfig 
 // NewMailServerWithOptions creates a mail server with optional external
 // attachment storage and a configurable SMTP message-size limit.
 func NewMailServerWithOptions(port int, host, mailDir string, options ServerOptions) (*MailServer, error) {
+	if options.AuthRequireTLS && (options.TLSConfig == nil || !options.TLSConfig.Enabled) {
+		return nil, fmt.Errorf("SMTP AUTH cannot require TLS without an enabled TLS configuration")
+	}
 	if options.AuthConfig != nil && options.AuthConfig.Enabled && (options.AuthConfig.Username == "" || options.AuthConfig.Password == "") {
 		return nil, fmt.Errorf("SMTP username and password are both required when authentication is enabled")
 	}
@@ -88,6 +91,7 @@ func NewMailServerWithOptions(port int, host, mailDir string, options ServerOpti
 		listeners:               make(map[string][]eventListener),
 		authConfig:              options.AuthConfig,
 		authVerifier:            authVerifier,
+		authRequireTLS:          options.AuthRequireTLS,
 		tlsConfig:               options.TLSConfig,
 		useUUIDForID:            options.UseUUIDForID,
 	}
@@ -125,10 +129,9 @@ func (ms *MailServer) setupSMTPServer() error {
 	s.MaxMessageBytes = ms.maxMessageBytes
 	s.MaxRecipients = 50
 
-	// OwlMail is a development SMTP server. PLAIN and LOGIN must remain usable
-	// without TLS for local testing; deployments that carry real credentials
-	// should enable TLS or isolate the listener.
-	s.AllowInsecureAuth = true
+	// Preserve the development-friendly default while allowing deployments to
+	// require an encrypted transport before PLAIN or LOGIN is accepted.
+	s.AllowInsecureAuth = !ms.authRequireTLS
 
 	// Configure TLS for STARTTLS
 	if ms.tlsConfig != nil && ms.tlsConfig.Enabled {
@@ -165,7 +168,7 @@ func (ms *MailServer) setupSMTPServer() error {
 		smtps.MaxMessageBytes = ms.maxMessageBytes
 		smtps.MaxRecipients = 50
 
-		smtps.AllowInsecureAuth = true
+		smtps.AllowInsecureAuth = !ms.authRequireTLS
 
 		// Use same TLS config
 		smtps.TLSConfig = s.TLSConfig

--- a/internal/mailserver/lifecycle.go
+++ b/internal/mailserver/lifecycle.go
@@ -43,7 +43,12 @@ func (ms *MailServer) Listen() error {
 	if ms.authRequired() {
 		common.Log("SMTP AUTH required (PLAIN/LOGIN)")
 	} else {
-		common.Log("SMTP NO AUTH mode enabled (unauthenticated delivery and arbitrary PLAIN/LOGIN credentials accepted)")
+		common.Log("SMTP NO AUTH mode enabled (unauthenticated delivery accepted)")
+	}
+	if ms.authRequireTLS {
+		common.Log("SMTP AUTH restricted to TLS connections")
+	} else if !ms.authRequired() {
+		common.Log("Arbitrary PLAIN/LOGIN credentials accepted for development clients")
 	}
 	if ms.tlsConfig != nil && ms.tlsConfig.Enabled {
 		common.Log("SMTP TLS/STARTTLS enabled")

--- a/internal/mailserver/mailserver_config_test.go
+++ b/internal/mailserver/mailserver_config_test.go
@@ -2,6 +2,7 @@ package mailserver
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -69,6 +70,18 @@ func TestNewMailServerWithCustomMessageLimit(t *testing.T) {
 	}
 	if server.smtpsServer == nil || server.smtpsServer.MaxMessageBytes != limit {
 		t.Fatalf("SMTPS MaxMessageBytes was not configured: %#v", server.smtpsServer)
+	}
+}
+
+func TestNewMailServerRejectsAuthRequireTLSWithoutTLS(t *testing.T) {
+	for _, tlsConfig := range []*TLSConfig{nil, {Enabled: false}} {
+		_, err := NewMailServerWithOptions(1025, "localhost", t.TempDir(), ServerOptions{
+			AuthRequireTLS: true,
+			TLSConfig:      tlsConfig,
+		})
+		if err == nil || !strings.Contains(err.Error(), "SMTP AUTH cannot require TLS") {
+			t.Fatalf("TLS config %#v error = %v, want clear configuration error", tlsConfig, err)
+		}
 	}
 }
 

--- a/internal/mailserver/types.go
+++ b/internal/mailserver/types.go
@@ -54,6 +54,7 @@ type TLSConfig struct {
 type ServerOptions struct {
 	OutgoingConfig  *outgoing.OutgoingConfig
 	AuthConfig      *SMTPAuthConfig
+	AuthRequireTLS  bool
 	TLSConfig       *TLSConfig
 	UseUUIDForID    bool
 	MaxMessageBytes int64
@@ -104,6 +105,7 @@ type MailServer struct {
 	}
 	authConfig          *SMTPAuthConfig
 	authVerifier        *credentialVerifier
+	authRequireTLS      bool
 	tlsConfig           *TLSConfig
 	useUUIDForID        bool
 	storagePolicy       StoragePolicy
@@ -146,6 +148,12 @@ func (ms *MailServer) GetMailDir() string {
 // GetAuthConfig returns the SMTP authentication configuration
 func (ms *MailServer) GetAuthConfig() *SMTPAuthConfig {
 	return ms.authConfig
+}
+
+// GetAuthRequireTLS reports whether SMTP AUTH is restricted to encrypted
+// connections. Anonymous delivery in NO AUTH mode is unaffected.
+func (ms *MailServer) GetAuthRequireTLS() bool {
+	return ms.authRequireTLS
 }
 
 // GetTLSConfig returns the TLS configuration

--- a/web/help.html
+++ b/web/help.html
@@ -94,6 +94,7 @@ SMTP_SECURE=false</code></pre>
                                 <tr><td>Attachment storage</td><td><code>-s3-enabled</code> and S3 options</td><td><code>OWLMAIL_S3_ENABLED</code> and S3 variables</td><td>Local mail directory</td></tr>
                                 <tr><td>Web authentication</td><td><code>-web-user</code>, <code>-web-password</code></td><td><code>OWLMAIL_WEB_USER</code>, <code>OWLMAIL_WEB_PASSWORD</code></td><td>Disabled; partial credentials are completed safely</td></tr>
                                 <tr><td>SMTP authentication</td><td><code>-smtp-user</code>, <code>-smtp-password</code></td><td><code>OWLMAIL_SMTP_USER</code>, <code>OWLMAIL_SMTP_PASSWORD</code></td><td>NO AUTH; set both to require PLAIN/LOGIN</td></tr>
+                                <tr><td>Require TLS for SMTP AUTH</td><td><code>-smtp-auth-require-tls</code></td><td><code>OWLMAIL_SMTP_AUTH_REQUIRE_TLS</code></td><td>Disabled; requires SMTP TLS when enabled</td></tr>
                                 <tr><td>SMTP TLS</td><td><code>-tls</code>, <code>-tls-cert</code>, <code>-tls-key</code></td><td><code>OWLMAIL_TLS_ENABLED</code>, certificate/key variables</td><td>Disabled</td></tr>
                                 <tr><td>Web HTTPS</td><td><code>-https</code>, <code>-https-cert</code>, <code>-https-key</code></td><td><code>OWLMAIL_HTTPS_ENABLED</code>, certificate/key variables</td><td>Disabled</td></tr>
                                 <tr><td>Webhook forwarding</td><td><code>-webhook-config</code></td><td><code>OWLMAIL_WEBHOOK_CONFIG</code></td><td>Disabled</td></tr>
@@ -103,7 +104,7 @@ SMTP_SECURE=false</code></pre>
                     </div>
                     <h3>Web authentication defaults</h3>
                     <p>With only a username, OwlMail generates a random 32-character password and prints it once to stderr at startup. With only a password, the username defaults to <code>admin</code>. Supplying neither value disables authentication; supplying both uses them unchanged. Generated passwords change after every restart, so configure both values when credentials must remain stable. Startup fails if the generated password cannot be written to stderr. Use Basic Auth only over localhost or HTTPS.</p>
-                    <aside class="note"><strong>SMTP authentication modes:</strong> omitting both credentials selects NO AUTH, which permits unauthenticated delivery and accepts arbitrary PLAIN/LOGIN credentials for test clients. Setting both requires valid AUTH; setting only one fails startup. PLAIN/LOGIN is permitted without TLS for development compatibility, so enable TLS before using real credentials. Each SMTP/SMTPS connection uses 10-second read and write timeouts; a message is limited to 100 MiB by default (configurable with <code>-smtp-max-message-mb</code>) and 50 recipients.</aside>
+                    <aside class="note"><strong>SMTP authentication modes:</strong> omitting both credentials selects NO AUTH, which permits unauthenticated delivery and accepts arbitrary PLAIN/LOGIN credentials for test clients. Setting both requires valid AUTH; setting only one fails startup. PLAIN/LOGIN is permitted without TLS for development compatibility by default. Enable <code>-smtp-auth-require-tls</code> with SMTP TLS to reject AUTH on cleartext connections while allowing it after STARTTLS and over SMTPS; anonymous NO AUTH delivery is unchanged, and missing TLS makes startup fail. Each SMTP/SMTPS connection uses 10-second read and write timeouts; a message is limited to 100 MiB by default (configurable with <code>-smtp-max-message-mb</code>) and 50 recipients.</aside>
                     <h3>Persistent Docker example</h3>
                     <pre><code>docker run -d --name owlmail \
   -p 1025:1025 -p 1080:1080 \
@@ -229,6 +230,7 @@ SMTP_SECURE=false</code></pre>
                                 <tr><td>附件存储</td><td><code>-s3-enabled</code> 及 S3 参数</td><td><code>OWLMAIL_S3_ENABLED</code> 及 S3 变量</td><td>本地邮件目录</td></tr>
                                 <tr><td>Web 认证</td><td><code>-web-user</code>、<code>-web-password</code></td><td><code>OWLMAIL_WEB_USER</code>、<code>OWLMAIL_WEB_PASSWORD</code></td><td>关闭；单项凭据会安全补全</td></tr>
                                 <tr><td>SMTP 鉴权</td><td><code>-smtp-user</code>、<code>-smtp-password</code></td><td><code>OWLMAIL_SMTP_USER</code>、<code>OWLMAIL_SMTP_PASSWORD</code></td><td>默认 NO AUTH；同时设置两项后强制 PLAIN/LOGIN</td></tr>
+                                <tr><td>SMTP AUTH 强制 TLS</td><td><code>-smtp-auth-require-tls</code></td><td><code>OWLMAIL_SMTP_AUTH_REQUIRE_TLS</code></td><td>默认关闭；开启时要求 SMTP TLS</td></tr>
                                 <tr><td>SMTP TLS</td><td><code>-tls</code>、证书和私钥参数</td><td><code>OWLMAIL_TLS_ENABLED</code>、证书和私钥变量</td><td>关闭</td></tr>
                                 <tr><td>Web HTTPS</td><td><code>-https</code>、证书和私钥参数</td><td><code>OWLMAIL_HTTPS_ENABLED</code>、证书和私钥变量</td><td>关闭</td></tr>
                                 <tr><td>Webhook 转发</td><td><code>-webhook-config</code></td><td><code>OWLMAIL_WEBHOOK_CONFIG</code></td><td>关闭</td></tr>
@@ -238,7 +240,7 @@ SMTP_SECURE=false</code></pre>
                     </div>
                     <h3>Web 认证默认策略</h3>
                     <p>只配置用户名时，OwlMail 会生成 32 字符随机密码，并在启动时向 stderr 输出一次；只配置密码时，用户名默认为 <code>admin</code>。两项均不配置表示关闭认证，两项均配置则原样使用。自动密码会在每次重启后变化，需要稳定凭据时应同时配置两项；如果无法将自动生成的密码写入 stderr，OwlMail 会启动失败。Basic Auth 只应在 localhost 或 HTTPS 上使用。</p>
-                    <aside class="note"><strong>SMTP 鉴权模式：</strong>两项凭据都省略时使用 NO AUTH，允许不认证投递，也接受测试客户端提交的任意 PLAIN/LOGIN 凭据；同时设置两项后强制验证，只设置一项会启动失败。为兼容开发环境，PLAIN/LOGIN 可在未启用 TLS 时使用，因此使用真实凭据前应启用 TLS。每个 SMTP/SMTPS 连接的读写超时均为 10 秒；单封邮件默认最大 100 MiB（可用 <code>-smtp-max-message-mb</code> 调整），最多 50 个收件人。</aside>
+                    <aside class="note"><strong>SMTP 鉴权模式：</strong>两项凭据都省略时使用 NO AUTH，允许不认证投递，也接受测试客户端提交的任意 PLAIN/LOGIN 凭据；同时设置两项后强制验证，只设置一项会启动失败。为兼容开发环境，默认允许在未启用 TLS 时使用 PLAIN/LOGIN。启用 SMTP TLS 并设置 <code>-smtp-auth-require-tls</code> 后，明文连接会拒绝 AUTH，STARTTLS 后及 SMTPS 仍可正常认证；NO AUTH 匿名投递不变，缺少 TLS 配置会启动失败。每个 SMTP/SMTPS 连接的读写超时均为 10 秒；单封邮件默认最大 100 MiB（可用 <code>-smtp-max-message-mb</code> 调整），最多 50 个收件人。</aside>
                     <h3>Docker 持久化示例</h3>
                     <pre><code>docker run -d --name owlmail \
   -p 1025:1025 -p 1080:1080 \


### PR DESCRIPTION
## Summary

- add `-smtp-auth-require-tls` and `OWLMAIL_SMTP_AUTH_REQUIRE_TLS` with a development-compatible default of `false`
- reject PLAIN/LOGIN on cleartext SMTP when enabled, while allowing AUTH after STARTTLS and over direct SMTPS
- fail startup when the policy is enabled without SMTP TLS, while preserving anonymous NO AUTH delivery
- document the policy in every translated README, the English/Chinese API and operations guides, embedded help, and CHANGELOG

## Security behavior

- no SMTP username, password, or authentication payload is added to logs
- cleartext connections do not advertise AUTH when the policy is enabled and explicit PLAIN/LOGIN attempts fail
- NO AUTH remains open for anonymous delivery; with the policy disabled it retains the existing arbitrary-credential development compatibility

## Tests

- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
- Web/document contract suite: 59 tests passed (same test files loaded through Node's native runner because Bun was unavailable locally)

Protocol coverage includes plaintext PLAIN/LOGIN rejection, STARTTLS success, SMTPS success, invalid configuration, default compatibility, and NO AUTH anonymous-delivery regression.