### PR TITLE
feat(storage): add S3 readiness checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to OwlMail are documented in this file. The format follows
 
 ### Added
 
-- Cached S3 readiness checks using bounded, read-only `HeadBucket` probes,
+- Cached S3 readiness checks using bounded, prefix-scoped read-only probes,
   separate unauthenticated liveness and readiness endpoints, automatic recovery,
   safe error categories, and an opt-in strict startup check.
 - Real inbound SMTP AUTH with PLAIN and LOGIN mechanisms, constant-time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to OwlMail are documented in this file. The format follows
 
 ### Added
 
+- Cached S3 readiness checks using bounded, read-only `HeadBucket` probes,
+  separate unauthenticated liveness and readiness endpoints, automatic recovery,
+  safe error categories, and an opt-in strict startup check.
 - Real inbound SMTP AUTH with PLAIN and LOGIN mechanisms, constant-time
   credential checks, and protocol-level rejection of unauthenticated mail
   transactions.

--- a/README.de.md
+++ b/README.de.md
@@ -213,6 +213,9 @@ docker buildx build \
 | `-s3-secret-key` | `OWLMAIL_S3_SECRET_KEY` | - | Optionaler statischer geheimer Schlüssel |
 | `-s3-session-token` | `OWLMAIL_S3_SESSION_TOKEN` | - | Optionales Sitzungstoken |
 | `-s3-use-path-style` | `OWLMAIL_S3_USE_PATH_STYLE` | false | Pfadbasierte Bucket-Adressierung verwenden |
+| `-s3-startup-check` | `OWLMAIL_S3_STARTUP_CHECK` | false | Start bei fehlgeschlagener S3-Prüfung abbrechen |
+| `-s3-health-check-interval` | `OWLMAIL_S3_HEALTH_CHECK_INTERVAL` | 30s | Intervall der S3-Bereitschaftsprüfung |
+| `-s3-health-check-timeout` | `OWLMAIL_S3_HEALTH_CHECK_TIMEOUT` | 3s | Zeitlimit je S3-Bereitschaftsprüfung |
 | `-web-user` | `MAILDEV_WEB_USER` / `OWLMAIL_WEB_USER` | - | HTTP Basic Auth Benutzername |
 | `-web-password` | `MAILDEV_WEB_PASS` / `OWLMAIL_WEB_PASSWORD` | - | HTTP Basic Auth Passwort |
 | `-https` | `MAILDEV_HTTPS` / `OWLMAIL_HTTPS_ENABLED` | false | HTTPS aktivieren |
@@ -355,7 +358,8 @@ exakten Entsprechungen der aktuellen MailDev-API; siehe
 #### Konfiguration und System
 
 - `GET /config` - Konfigurationsinformationen abrufen
-- `GET /healthz` - Gesundheitsprüfung
+- `GET /healthz` - Lebenszeichenprüfung
+- `GET /readyz` - Bereitschaftsprüfung
 - `GET /reloadMailsFromDirectory` - E-Mails aus Verzeichnis neu laden
 - `GET /socket.io` - WebSocket-Verbindung (Standard WebSocket, nicht Socket.IO)
 
@@ -403,7 +407,8 @@ OwlMail bietet ein standardisierteres RESTful API-Design:
 - `GET /api/v1/settings/outgoing` - Ausgehende Konfiguration abrufen
 - `PUT /api/v1/settings/outgoing` - Ausgehende Konfiguration aktualisieren
 - `PATCH /api/v1/settings/outgoing` - Ausgehende Konfiguration teilweise aktualisieren
-- `GET /api/v1/health` - Gesundheitsprüfung
+- `GET /api/v1/health` - Lebenszeichenprüfung
+- `GET /api/v1/ready` - Bereitschaftsprüfung
 - `GET /api/v1/ws` - WebSocket-Verbindung
 
 Die aktuelle Schnittstelle einschließlich Unterressourcen, Authentifizierung,

--- a/README.fr.md
+++ b/README.fr.md
@@ -214,6 +214,9 @@ docker buildx build \
 | `-s3-secret-key` | `OWLMAIL_S3_SECRET_KEY` | - | Clé secrète statique facultative |
 | `-s3-session-token` | `OWLMAIL_S3_SESSION_TOKEN` | - | Jeton de session facultatif |
 | `-s3-use-path-style` | `OWLMAIL_S3_USE_PATH_STYLE` | false | Utiliser l’adressage de bucket par chemin |
+| `-s3-startup-check` | `OWLMAIL_S3_STARTUP_CHECK` | false | Échouer au démarrage si la vérification S3 échoue |
+| `-s3-health-check-interval` | `OWLMAIL_S3_HEALTH_CHECK_INTERVAL` | 30s | Intervalle de vérification de disponibilité S3 |
+| `-s3-health-check-timeout` | `OWLMAIL_S3_HEALTH_CHECK_TIMEOUT` | 3s | Délai de chaque vérification S3 |
 | `-web-user` | `MAILDEV_WEB_USER` / `OWLMAIL_WEB_USER` | - | HTTP Basic Auth username |
 | `-web-password` | `MAILDEV_WEB_PASS` / `OWLMAIL_WEB_PASSWORD` | - | HTTP Basic Auth password |
 | `-https` | `MAILDEV_HTTPS` / `OWLMAIL_HTTPS_ENABLED` | false | Enable HTTPS |
@@ -356,7 +359,8 @@ garantir une équivalence exacte avec l'API MailDev actuelle. Consultez la
 #### Configuration and System
 
 - `GET /config` - Get configuration information
-- `GET /healthz` - Health check
+- `GET /healthz` - Liveness check
+- `GET /readyz` - Readiness check
 - `GET /reloadMailsFromDirectory` - Reload emails from directory
 - `GET /socket.io` - WebSocket connection (standard WebSocket, not Socket.IO)
 
@@ -404,7 +408,8 @@ OwlMail provides a more standardized RESTful API design:
 - `GET /api/v1/settings/outgoing` - Get outgoing configuration
 - `PUT /api/v1/settings/outgoing` - Update outgoing configuration
 - `PATCH /api/v1/settings/outgoing` - Partially update outgoing configuration
-- `GET /api/v1/health` - Health check
+- `GET /api/v1/health` - Liveness check
+- `GET /api/v1/ready` - Readiness check
 - `GET /api/v1/ws` - WebSocket connection
 
 Le contrat actuel, avec sous-ressources, authentification, réponses et événements

--- a/README.it.md
+++ b/README.it.md
@@ -213,6 +213,9 @@ docker buildx build \
 | `-s3-secret-key` | `OWLMAIL_S3_SECRET_KEY` | - | Chiave segreta statica opzionale |
 | `-s3-session-token` | `OWLMAIL_S3_SESSION_TOKEN` | - | Token di sessione opzionale |
 | `-s3-use-path-style` | `OWLMAIL_S3_USE_PATH_STYLE` | false | Usa l’indirizzamento bucket path-style |
+| `-s3-startup-check` | `OWLMAIL_S3_STARTUP_CHECK` | false | Interrompe l'avvio se il controllo S3 fallisce |
+| `-s3-health-check-interval` | `OWLMAIL_S3_HEALTH_CHECK_INTERVAL` | 30s | Intervallo del controllo readiness S3 |
+| `-s3-health-check-timeout` | `OWLMAIL_S3_HEALTH_CHECK_TIMEOUT` | 3s | Timeout per ogni controllo S3 |
 | `-web-user` | `MAILDEV_WEB_USER` / `OWLMAIL_WEB_USER` | - | Nome utente HTTP Basic Auth |
 | `-web-password` | `MAILDEV_WEB_PASS` / `OWLMAIL_WEB_PASSWORD` | - | Password HTTP Basic Auth |
 | `-https` | `MAILDEV_HTTPS` / `OWLMAIL_HTTPS_ENABLED` | false | Abilita HTTPS |
@@ -354,7 +357,8 @@ equivalenti esatti dell'API MailDev corrente. Consulta il
 #### Configurazione e Sistema
 
 - `GET /config` - Ottieni informazioni di configurazione
-- `GET /healthz` - Controllo salute
+- `GET /healthz` - Controllo liveness
+- `GET /readyz` - Controllo readiness
 - `GET /reloadMailsFromDirectory` - Ricarica email da directory
 - `GET /socket.io` - Connessione WebSocket (WebSocket standard, non Socket.IO)
 
@@ -402,7 +406,8 @@ OwlMail fornisce un design API RESTful più standardizzato:
 - `GET /api/v1/settings/outgoing` - Ottieni configurazione in uscita
 - `PUT /api/v1/settings/outgoing` - Aggiorna configurazione in uscita
 - `PATCH /api/v1/settings/outgoing` - Aggiorna parzialmente configurazione in uscita
-- `GET /api/v1/health` - Controllo salute
+- `GET /api/v1/health` - Controllo liveness
+- `GET /api/v1/ready` - Controllo readiness
 - `GET /api/v1/ws` - Connessione WebSocket
 
 Il contratto corrente, incluse sottorisorse, autenticazione, risposte ed eventi

--- a/README.ja.md
+++ b/README.ja.md
@@ -213,6 +213,9 @@ docker buildx build \
 | `-s3-secret-key` | `OWLMAIL_S3_SECRET_KEY` | - | 任意の静的シークレットキー |
 | `-s3-session-token` | `OWLMAIL_S3_SESSION_TOKEN` | - | 任意のセッショントークン |
 | `-s3-use-path-style` | `OWLMAIL_S3_USE_PATH_STYLE` | false | パス形式のバケットアドレスを使用 |
+| `-s3-startup-check` | `OWLMAIL_S3_STARTUP_CHECK` | false | S3 チェック失敗時に起動を中止 |
+| `-s3-health-check-interval` | `OWLMAIL_S3_HEALTH_CHECK_INTERVAL` | 30s | S3 readiness 更新間隔 |
+| `-s3-health-check-timeout` | `OWLMAIL_S3_HEALTH_CHECK_TIMEOUT` | 3s | S3 チェックごとのタイムアウト |
 | `-web-user` | `MAILDEV_WEB_USER` / `OWLMAIL_WEB_USER` | - | HTTP Basic Auth username |
 | `-web-password` | `MAILDEV_WEB_PASS` / `OWLMAIL_WEB_PASSWORD` | - | HTTP Basic Auth password |
 | `-https` | `MAILDEV_HTTPS` / `OWLMAIL_HTTPS_ENABLED` | false | Enable HTTPS |
@@ -354,7 +357,8 @@ MailDev API と完全に同じではありません。
 #### Configuration and System
 
 - `GET /config` - Get configuration information
-- `GET /healthz` - Health check
+- `GET /healthz` - Liveness check
+- `GET /readyz` - Readiness check
 - `GET /reloadMailsFromDirectory` - Reload emails from directory
 - `GET /socket.io` - WebSocket connection (standard WebSocket, not Socket.IO)
 
@@ -402,7 +406,8 @@ OwlMail provides a more standardized RESTful API design:
 - `GET /api/v1/settings/outgoing` - Get outgoing configuration
 - `PUT /api/v1/settings/outgoing` - Update outgoing configuration
 - `PATCH /api/v1/settings/outgoing` - Partially update outgoing configuration
-- `GET /api/v1/health` - Health check
+- `GET /api/v1/health` - Liveness check
+- `GET /api/v1/ready` - Readiness check
 - `GET /api/v1/ws` - WebSocket connection
 
 サブリソース、認証、レスポンス、WebSocket イベントを含む現在の仕様は

--- a/README.ko.md
+++ b/README.ko.md
@@ -213,6 +213,9 @@ docker buildx build \
 | `-s3-secret-key` | `OWLMAIL_S3_SECRET_KEY` | - | 선택적 정적 시크릿 키 |
 | `-s3-session-token` | `OWLMAIL_S3_SESSION_TOKEN` | - | 선택적 세션 토큰 |
 | `-s3-use-path-style` | `OWLMAIL_S3_USE_PATH_STYLE` | false | 경로 스타일 버킷 주소 사용 |
+| `-s3-startup-check` | `OWLMAIL_S3_STARTUP_CHECK` | false | S3 검사 실패 시 시작 중단 |
+| `-s3-health-check-interval` | `OWLMAIL_S3_HEALTH_CHECK_INTERVAL` | 30s | S3 readiness 갱신 간격 |
+| `-s3-health-check-timeout` | `OWLMAIL_S3_HEALTH_CHECK_TIMEOUT` | 3s | S3 검사 제한 시간 |
 | `-web-user` | `MAILDEV_WEB_USER` / `OWLMAIL_WEB_USER` | - | HTTP Basic Auth username |
 | `-web-password` | `MAILDEV_WEB_PASS` / `OWLMAIL_WEB_PASSWORD` | - | HTTP Basic Auth password |
 | `-https` | `MAILDEV_HTTPS` / `OWLMAIL_HTTPS_ENABLED` | false | Enable HTTPS |
@@ -354,7 +357,8 @@ OwlMail은 일반적인 워크플로를 위해 버전 없는 경로를 유지하
 #### Configuration and System
 
 - `GET /config` - Get configuration information
-- `GET /healthz` - Health check
+- `GET /healthz` - Liveness check
+- `GET /readyz` - Readiness check
 - `GET /reloadMailsFromDirectory` - Reload emails from directory
 - `GET /socket.io` - WebSocket connection (standard WebSocket, not Socket.IO)
 
@@ -402,7 +406,8 @@ OwlMail provides a more standardized RESTful API design:
 - `GET /api/v1/settings/outgoing` - Get outgoing configuration
 - `PUT /api/v1/settings/outgoing` - Update outgoing configuration
 - `PATCH /api/v1/settings/outgoing` - Partially update outgoing configuration
-- `GET /api/v1/health` - Health check
+- `GET /api/v1/health` - Liveness check
+- `GET /api/v1/ready` - Readiness check
 - `GET /api/v1/ws` - WebSocket connection
 
 하위 리소스, 인증, 응답 및 WebSocket 이벤트를 포함한 현재 계약은

--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ the message body; clicking one focuses OwlMail and opens the message.
 | `-s3-secret-key` | `OWLMAIL_S3_SECRET_KEY` | - | Optional static secret key |
 | `-s3-session-token` | `OWLMAIL_S3_SESSION_TOKEN` | - | Optional static credential session token |
 | `-s3-use-path-style` | `OWLMAIL_S3_USE_PATH_STYLE` | false | Use path-style bucket addressing for compatible services |
+| `-s3-startup-check` | `OWLMAIL_S3_STARTUP_CHECK` | false | Fail startup unless the S3 bucket health check succeeds |
+| `-s3-health-check-interval` | `OWLMAIL_S3_HEALTH_CHECK_INTERVAL` | 30s | Background S3 readiness refresh interval |
+| `-s3-health-check-timeout` | `OWLMAIL_S3_HEALTH_CHECK_TIMEOUT` | 3s | Timeout for each S3 readiness probe |
 | `-web-user` | `MAILDEV_WEB_USER` / `OWLMAIL_WEB_USER` | - | HTTP Basic Auth username |
 | `-web-password` | `MAILDEV_WEB_PASS` / `OWLMAIL_WEB_PASSWORD` | - | HTTP Basic Auth password |
 | `-https` | `MAILDEV_HTTPS` / `OWLMAIL_HTTPS_ENABLED` | false | Enable HTTPS |
@@ -332,6 +335,13 @@ request or startup; pending deletions are not republished. Upload must finish
 before SMTP accepts the message transaction. `OWLMAIL_MAIL_MAX_DISK_MB` measures
 local files and does not include S3 object bytes.
 
+OwlMail uses `HeadBucket` to refresh a cached S3 readiness result every 30
+seconds by default. `/readyz` and `/api/v1/ready` return that cache and never
+contact S3 synchronously. Existing `/healthz` and `/api/v1/health` endpoints are
+liveness checks and stay healthy during a temporary S3 outage. Startup remains
+non-strict for compatibility; set `OWLMAIL_S3_STARTUP_CHECK=true` to require the
+first bounded probe to succeed before listeners start.
+
 ## 📡 API Documentation
 
 ### API Response Format
@@ -411,7 +421,8 @@ the [API reference](./docs/en/API-Reference.md#maildev-migration-boundary).
 #### Configuration and System
 
 - `GET /config` - Get configuration information
-- `GET /healthz` - Health check
+- `GET /healthz` - Liveness check
+- `GET /readyz` - Cached dependency readiness check
 - `GET /reloadMailsFromDirectory` - Reload emails from directory
 - `GET /socket.io` - WebSocket connection (standard WebSocket, not Socket.IO)
 
@@ -459,7 +470,8 @@ OwlMail provides a more standardized RESTful API design:
 - `GET /api/v1/settings/outgoing` - Get outgoing configuration
 - `PUT /api/v1/settings/outgoing` - Update outgoing configuration
 - `PATCH /api/v1/settings/outgoing` - Partially update outgoing configuration
-- `GET /api/v1/health` - Health check
+- `GET /api/v1/health` - Liveness check
+- `GET /api/v1/ready` - Cached dependency readiness check
 - `GET /api/v1/version` - Version info
 - `GET /api/v1/ws` - WebSocket connection
 

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ request or startup; pending deletions are not republished. Upload must finish
 before SMTP accepts the message transaction. `OWLMAIL_MAIL_MAX_DISK_MB` measures
 local files and does not include S3 object bytes.
 
-OwlMail uses `HeadBucket` to refresh a cached S3 readiness result every 30
+OwlMail uses a bounded, prefix-scoped `ListObjectsV2` request to refresh a cached S3 readiness result every 30
 seconds by default. `/readyz` and `/api/v1/ready` return that cache and never
 contact S3 synchronously. Existing `/healthz` and `/api/v1/health` endpoints are
 liveness checks and stay healthy during a temporary S3 outage. Startup remains

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -321,7 +321,7 @@ export OWLMAIL_S3_USE_PATH_STYLE=true
 该邮件对应的对象前缀。只有附件上传完成后 SMTP 才会接受本次邮件事务。
 `OWLMAIL_MAIL_MAX_DISK_MB` 只统计本地文件，不包含 S3 对象占用。
 
-OwlMail 默认每 30 秒使用 `HeadBucket` 刷新一次 S3 readiness 缓存。
+OwlMail 默认每 30 秒使用带附件前缀且限制结果数量的 `ListObjectsV2` 刷新一次 S3 readiness 缓存。
 `/readyz` 和 `/api/v1/ready` 只读取缓存，不会在请求中同步访问 S3；现有
 `/healthz` 和 `/api/v1/health` 是 liveness，S3 暂时不可用时仍保持正常。
 为兼容已有部署，默认不会因首次探测失败而退出；如需严格启动检查，请设置

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -230,6 +230,9 @@ Notifications API 需要 HTTPS，或 `http://localhost` 等受信任的本地来
 | `-s3-secret-key` | `OWLMAIL_S3_SECRET_KEY` | - | 可选静态秘密密钥 |
 | `-s3-session-token` | `OWLMAIL_S3_SESSION_TOKEN` | - | 可选静态凭据会话令牌 |
 | `-s3-use-path-style` | `OWLMAIL_S3_USE_PATH_STYLE` | false | 为兼容服务使用路径式存储桶寻址 |
+| `-s3-startup-check` | `OWLMAIL_S3_STARTUP_CHECK` | false | S3 存储桶健康检查失败时阻止启动 |
+| `-s3-health-check-interval` | `OWLMAIL_S3_HEALTH_CHECK_INTERVAL` | 30s | 后台刷新 S3 readiness 的间隔 |
+| `-s3-health-check-timeout` | `OWLMAIL_S3_HEALTH_CHECK_TIMEOUT` | 3s | 每次 S3 readiness 探测的超时 |
 | `-web-user` | `MAILDEV_WEB_USER` / `OWLMAIL_WEB_USER` | - | HTTP Basic Auth 用户名 |
 | `-web-password` | `MAILDEV_WEB_PASS` / `OWLMAIL_WEB_PASSWORD` | - | HTTP Basic Auth 密码 |
 | `-https` | `MAILDEV_HTTPS` / `OWLMAIL_HTTPS_ENABLED` | false | 启用 HTTPS |
@@ -318,6 +321,12 @@ export OWLMAIL_S3_USE_PATH_STYLE=true
 该邮件对应的对象前缀。只有附件上传完成后 SMTP 才会接受本次邮件事务。
 `OWLMAIL_MAIL_MAX_DISK_MB` 只统计本地文件，不包含 S3 对象占用。
 
+OwlMail 默认每 30 秒使用 `HeadBucket` 刷新一次 S3 readiness 缓存。
+`/readyz` 和 `/api/v1/ready` 只读取缓存，不会在请求中同步访问 S3；现有
+`/healthz` 和 `/api/v1/health` 是 liveness，S3 暂时不可用时仍保持正常。
+为兼容已有部署，默认不会因首次探测失败而退出；如需严格启动检查，请设置
+`OWLMAIL_S3_STARTUP_CHECK=true`。
+
 ## 📡 API 文档
 
 ### API 响应格式
@@ -396,7 +405,8 @@ API 的精确等价实现；差异见 [API 参考](./docs/zh-CN/API-Reference.md
 #### 配置和系统
 
 - `GET /config` - 获取配置信息
-- `GET /healthz` - 健康检查
+- `GET /healthz` - 存活检查
+- `GET /readyz` - 缓存的依赖就绪检查
 - `GET /reloadMailsFromDirectory` - 重新加载邮件目录
 - `GET /socket.io` - WebSocket 连接（标准 WebSocket，非 Socket.IO）
 
@@ -444,7 +454,8 @@ OwlMail 提供了更规范的 RESTful API 设计：
 - `GET /api/v1/settings/outgoing` - 获取出站配置
 - `PUT /api/v1/settings/outgoing` - 更新出站配置
 - `PATCH /api/v1/settings/outgoing` - 部分更新出站配置
-- `GET /api/v1/health` - 健康检查
+- `GET /api/v1/health` - 存活检查
+- `GET /api/v1/ready` - 缓存的依赖就绪检查
 - `GET /api/v1/version` - 版本信息
 - `GET /api/v1/ws` - WebSocket 连接
 

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -162,7 +162,39 @@ func setupAttachmentStore(cfg *config.Config) (attachmentstore.Store, error) {
 	if err != nil {
 		return nil, fmt.Errorf("configure S3 attachment storage: %w", err)
 	}
-	return store, nil
+	return setupAttachmentStoreHealth(cfg, store)
+}
+
+func setupAttachmentStoreHealth(cfg *config.Config, store attachmentstore.Store) (attachmentstore.Store, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config is nil")
+	}
+	if store == nil {
+		return nil, fmt.Errorf("attachment store is nil")
+	}
+	interval, err := time.ParseDuration(cfg.S3HealthInterval)
+	if err != nil || interval <= 0 {
+		return nil, fmt.Errorf("invalid S3 health check interval %q", cfg.S3HealthInterval)
+	}
+	timeout, err := time.ParseDuration(cfg.S3HealthTimeout)
+	if err != nil || timeout <= 0 {
+		return nil, fmt.Errorf("invalid S3 health check timeout %q", cfg.S3HealthTimeout)
+	}
+	initial := attachmentstore.HealthStatus{Category: attachmentstore.HealthChecking}
+	if cfg.S3StartupCheck {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		status := attachmentstore.CheckHealth(ctx, store)
+		cancel()
+		if !status.Ready {
+			return nil, fmt.Errorf("S3 startup check failed: %s", status.Category)
+		}
+		initial = status
+	}
+	monitored, err := attachmentstore.NewMonitoredStore(store, interval, timeout, initial)
+	if err != nil {
+		return nil, fmt.Errorf("configure S3 health monitoring: %w", err)
+	}
+	return monitored, nil
 }
 
 func setupStoragePolicy(cfg *config.Config) (mailserver.StoragePolicy, error) {
@@ -457,7 +489,16 @@ func createMailServer(cfg *config.Config) (*mailserver.MailServer, error) {
 		AttachmentStore: attachmentStore,
 	})
 	if err != nil {
+		if closer, ok := attachmentStore.(io.Closer); ok {
+			_ = closer.Close()
+		}
 		return nil, fmt.Errorf("failed to create mail server: %w", err)
+	}
+	if closer, ok := attachmentStore.(io.Closer); ok {
+		if err := server.AddCloser(closer); err != nil {
+			_ = server.Close()
+			return nil, fmt.Errorf("register attachment store health monitor: %w", err)
+		}
 	}
 	storagePolicy, err := setupStoragePolicy(cfg)
 	if err != nil {

--- a/cmd/owlmail/main_test.go
+++ b/cmd/owlmail/main_test.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -15,6 +18,7 @@ import (
 
 	"github.com/emersion/go-message/mail"
 	"github.com/soulteary/cli-kit/testutil"
+	"github.com/soulteary/owlmail/internal/attachmentstore"
 	"github.com/soulteary/owlmail/internal/common"
 	"github.com/soulteary/owlmail/internal/config"
 	"github.com/soulteary/owlmail/internal/mailserver"
@@ -951,14 +955,41 @@ func TestSetupAttachmentStore(t *testing.T) {
 		t.Fatalf("disabled setupAttachmentStore() = %#v, %v", store, err)
 	}
 
+}
+
+type testHealthStore struct {
+	err error
+}
+
+func (store *testHealthStore) CheckHealth(context.Context) error { return store.err }
+func (store *testHealthStore) Put(context.Context, string, string, string, io.Reader, int64) error {
+	return nil
+}
+func (store *testHealthStore) Open(context.Context, string, string) (*attachmentstore.Object, error) {
+	return nil, errors.New("not implemented")
+}
+func (store *testHealthStore) DeleteEmail(context.Context, string) error { return nil }
+
+func TestSetupAttachmentStoreHealthStrictAndCompatible(t *testing.T) {
 	cfg := config.DefaultConfig()
-	cfg.S3Enabled = true
-	cfg.S3Bucket = "owlmail-test"
-	cfg.S3AccessKeyID = "access"
-	cfg.S3SecretAccessKey = "secret"
-	store, err = setupAttachmentStore(cfg)
-	if err != nil || store == nil {
-		t.Fatalf("enabled setupAttachmentStore() = %#v, %v", store, err)
+	cfg.S3HealthInterval = "10ms"
+	cfg.S3HealthTimeout = "10ms"
+	fake := &testHealthStore{err: errors.New("https://access:secret@example.test private detail")}
+
+	cfg.S3StartupCheck = true
+	if _, err := setupAttachmentStoreHealth(cfg, fake); err == nil || !strings.Contains(err.Error(), attachmentstore.HealthUnavailable) || strings.Contains(err.Error(), "secret") || strings.Contains(err.Error(), "example.test") {
+		t.Fatalf("strict startup error = %v", err)
+	}
+
+	cfg.S3StartupCheck = false
+	store, err := setupAttachmentStoreHealth(cfg, fake)
+	if err != nil {
+		t.Fatalf("non-strict setup error = %v", err)
+	}
+	if closer, ok := store.(io.Closer); ok {
+		_ = closer.Close()
+	} else {
+		t.Fatal("monitored store is not closable")
 	}
 }
 

--- a/docs/en/API-Reference.md
+++ b/docs/en/API-Reference.md
@@ -146,7 +146,8 @@ reported in process logs after the HTTP response.
 | `GET /api/v1/settings/outgoing` | current outgoing SMTP settings; password is omitted |
 | `PUT /api/v1/settings/outgoing` | replace outgoing SMTP settings |
 | `PATCH /api/v1/settings/outgoing` | update selected outgoing SMTP fields |
-| `GET /api/v1/health` | unauthenticated liveness check |
+| `GET /api/v1/health` | unauthenticated liveness check, independent of S3 |
+| `GET /api/v1/ready` | unauthenticated cached dependency readiness check |
 | `GET /api/v1/version` | build/version information |
 | `GET /api/v1/ws` | native WebSocket endpoint |
 
@@ -226,6 +227,7 @@ for existing OwlMail integrations. Prefer `/api/v1` for new code.
 | `PUT /config/outgoing` | `PUT /api/v1/settings/outgoing` |
 | `PATCH /config/outgoing` | `PATCH /api/v1/settings/outgoing` |
 | `GET /healthz` | `GET /api/v1/health` |
+| `GET /readyz` | `GET /api/v1/ready` |
 | `GET /reloadMailsFromDirectory` | reload the configured mail directory |
 
 ## WebSocket protocol

--- a/docs/en/Operations.md
+++ b/docs/en/Operations.md
@@ -114,7 +114,8 @@ AWS SDK default credential chain is used, including environment credentials,
 shared configuration, and workload roles. Use path-style addressing only when
 the selected S3-compatible service requires it.
 
-When S3 is enabled, OwlMail immediately starts a read-only `HeadBucket` probe
+When S3 is enabled, OwlMail immediately starts a bounded, read-only
+`ListObjectsV2` probe scoped to the configured attachment prefix
 and refreshes the cached result every 30 seconds. Each probe has a three-second
 deadline by default. Configure these bounds with
 `OWLMAIL_S3_HEALTH_CHECK_INTERVAL` and `OWLMAIL_S3_HEALTH_CHECK_TIMEOUT` (or the

--- a/docs/en/Operations.md
+++ b/docs/en/Operations.md
@@ -41,10 +41,11 @@ process-specific temporary directory `owlmail-<pid>` while parsed state is held
 in memory. That location is not a durable archive. This profile is intended for
 one developer on a trusted machine.
 
-Readiness check:
+Liveness and readiness checks:
 
 ```bash
 curl --fail http://localhost:1080/healthz
+curl --fail http://localhost:1080/readyz
 ```
 
 ### 2. Local inbox with persistence
@@ -112,6 +113,27 @@ endpoint empty for AWS S3. Static credentials are optional: when omitted, the
 AWS SDK default credential chain is used, including environment credentials,
 shared configuration, and workload roles. Use path-style addressing only when
 the selected S3-compatible service requires it.
+
+When S3 is enabled, OwlMail immediately starts a read-only `HeadBucket` probe
+and refreshes the cached result every 30 seconds. Each probe has a three-second
+deadline by default. Configure these bounds with
+`OWLMAIL_S3_HEALTH_CHECK_INTERVAL` and `OWLMAIL_S3_HEALTH_CHECK_TIMEOUT` (or the
+matching flags). Readiness requests never wait for S3:
+
+- `/healthz` and `/api/v1/health` are liveness endpoints. They do not depend on
+  S3, so a temporary outage does not trigger a process restart loop.
+- `/readyz` and `/api/v1/ready` report the cached dependency state and return
+  HTTP 503 until the latest S3 probe succeeds.
+- Response details are restricted to stable categories such as `checking`,
+  `permission_denied`, `not_found`, `timeout`, `network`, and `unavailable`;
+  provider messages, endpoints, and credentials are never returned.
+
+The compatibility default is non-strict: a failed initial probe leaves the
+process running but not ready, and later successful probes recover readiness.
+Set `OWLMAIL_S3_STARTUP_CHECK=true` (or `-s3-startup-check`) when a deployment
+must reject bad buckets, credentials, or connectivity before opening listeners.
+The strict check uses the same configured timeout and reports only the safe
+error category.
 
 OwlMail streams attachments into local staging files, writes a durable rollback
 marker, uploads every object under `<prefix>/<email-id>/`, and only then commits
@@ -181,8 +203,9 @@ password cannot be printed. Retrieve startup output with:
 docker logs owlmail
 ```
 
-Basic Auth protects the UI, API, assets, and WebSocket endpoints, but
-`/healthz` and `/api/v1/health` intentionally remain public for probes. Use
+Basic Auth protects the UI, API, assets, and WebSocket endpoints, but the
+`/healthz`, `/readyz`, `/api/v1/health`, and `/api/v1/ready` probe endpoints
+intentionally remain public. Use
 HTTPS or a trusted reverse proxy when credentials cross a network.
 
 When TLS terminates at that proxy, set `OWLMAIL_WEB_EXTERNAL_SCHEME=https` so
@@ -315,11 +338,11 @@ in-process request, not delivery by the downstream SMTP server; inspect logs and
 the destination system when delivery confirmation matters.
 
 Configuration is not yet validated by one uniform startup pass. S3 option shape
-is checked when that backend is enabled, but reachability and credentials can
-still fail when an object operation is first attempted. Other components may
-normalize values or fail later during listener setup. Treat startup and operation
-warnings as actionable, and verify both health endpoints, SMTP receipt, and
-attachment download after configuration changes.
+is checked when that backend is enabled, while its background readiness probe
+detects bucket, credential, and network failures before the first attachment
+delivery. Other components may normalize values or fail later during listener
+setup. Treat startup and operation warnings as actionable, and verify liveness,
+readiness, SMTP receipt, and attachment download after configuration changes.
 
 ## Backup and upgrade procedure
 
@@ -327,7 +350,7 @@ attachment download after configuration changes.
 2. Copy or snapshot the complete mail directory/volume.
 3. Record the image tag or binary version and effective flags/environment.
 4. Start the new version against a copy when the archive is important.
-5. Check `/healthz`, open representative HTML messages and attachments, then
+5. Check `/healthz` and `/readyz`, open representative HTML messages and attachments, then
    send a new test message.
 6. Keep the backup until rollback is no longer required.
 
@@ -344,6 +367,7 @@ tags are intentionally moving.
 | SMTP returns `530 Authentication required` | Authenticate with the configured username/password, or remove both values to intentionally use NO AUTH mode |
 | OwlMail fails after setting one SMTP credential | Configure both `-smtp-user` and `-smtp-password`, or remove both; partial credentials never fall back to NO AUTH |
 | Container is unhealthy with HTTPS | Override the image's HTTP healthcheck with an HTTPS probe and correct certificate trust |
+| `/readyz` returns 503 with S3 enabled | Use the safe category to distinguish bucket/permission, timeout, network, and general availability failures; inspect protected process/provider logs for details |
 | Browser notification does not appear | Enable it from the inbox, use HTTPS or localhost, and restore site permission in browser settings |
 | Webhook delivery is slow | Check receiver latency, timeout and retry settings; lower retries or fix the receiver before raising concurrency |
 | SMTP works but direct SMTPS does not | Publish port 465, check certificate paths and runtime permission to bind a privileged port |
@@ -356,5 +380,6 @@ Useful checks:
 ```bash
 docker logs --tail 200 owlmail
 curl --fail http://localhost:1080/healthz
+curl --fail http://localhost:1080/readyz
 curl -u admin:secret http://localhost:1080/api/v1/version
 ```

--- a/docs/zh-CN/API-Reference.md
+++ b/docs/zh-CN/API-Reference.md
@@ -139,7 +139,8 @@ curl -u admin:secret http://localhost:1080/api/v1/emails
 | `GET /api/v1/settings/outgoing` | 返回出站 SMTP 设置；不返回密码 |
 | `PUT /api/v1/settings/outgoing` | 整体替换出站 SMTP 设置 |
 | `PATCH /api/v1/settings/outgoing` | 更新部分出站 SMTP 字段 |
-| `GET /api/v1/health` | 无需鉴权的存活检查 |
+| `GET /api/v1/health` | 无需鉴权且不依赖 S3 的存活检查 |
+| `GET /api/v1/ready` | 无需鉴权、读取缓存依赖状态的就绪检查 |
 | `GET /api/v1/version` | 构建/版本信息 |
 | `GET /api/v1/ws` | 原生 WebSocket 端点 |
 
@@ -215,6 +216,7 @@ curl -u admin:secret \
 | `PUT /config/outgoing` | `PUT /api/v1/settings/outgoing` |
 | `PATCH /config/outgoing` | `PATCH /api/v1/settings/outgoing` |
 | `GET /healthz` | `GET /api/v1/health` |
+| `GET /readyz` | `GET /api/v1/ready` |
 | `GET /reloadMailsFromDirectory` | 重新加载已配置邮件目录 |
 
 ## WebSocket 协议

--- a/docs/zh-CN/Operations.md
+++ b/docs/zh-CN/Operations.md
@@ -94,7 +94,7 @@ OwlMail 接收附件前，存储桶必须已经存在。endpoint 留空时使用
 可以不配置，此时使用 AWS SDK 默认凭据链，包括环境凭据、共享配置和工作负载角色。
 只有选定的 S3 兼容服务要求时，才开启路径式寻址。
 
-启用 S3 后，OwlMail 会立即执行只读的 `HeadBucket` 探测，并默认每 30 秒刷新一次
+启用 S3 后，OwlMail 会立即执行限定附件前缀和结果数量的只读 `ListObjectsV2` 探测，并默认每 30 秒刷新一次
 缓存结果；每次探测默认最多等待 3 秒。可以通过
 `OWLMAIL_S3_HEALTH_CHECK_INTERVAL`、`OWLMAIL_S3_HEALTH_CHECK_TIMEOUT` 或对应命令行
 参数调整：

--- a/docs/zh-CN/Operations.md
+++ b/docs/zh-CN/Operations.md
@@ -36,10 +36,11 @@ EML 数据，避免再创建一个邮箱规模的内存缓冲区。
 原始邮件和附件写入当前进程专用的临时目录 `owlmail-<pid>`，解析后的状态保存在
 内存中；该目录不是持久归档。该档位适合可信机器上的单开发者场景。
 
-就绪检查：
+存活与就绪检查：
 
 ```bash
 curl --fail http://localhost:1080/healthz
+curl --fail http://localhost:1080/readyz
 ```
 
 ### 2. 带持久化的本地收件箱
@@ -92,6 +93,23 @@ OWLMAIL_S3_USE_PATH_STYLE=true \
 OwlMail 接收附件前，存储桶必须已经存在。endpoint 留空时使用 AWS S3。静态密钥
 可以不配置，此时使用 AWS SDK 默认凭据链，包括环境凭据、共享配置和工作负载角色。
 只有选定的 S3 兼容服务要求时，才开启路径式寻址。
+
+启用 S3 后，OwlMail 会立即执行只读的 `HeadBucket` 探测，并默认每 30 秒刷新一次
+缓存结果；每次探测默认最多等待 3 秒。可以通过
+`OWLMAIL_S3_HEALTH_CHECK_INTERVAL`、`OWLMAIL_S3_HEALTH_CHECK_TIMEOUT` 或对应命令行
+参数调整：
+
+- `/healthz` 和 `/api/v1/health` 是 liveness，不依赖 S3；S3 暂时不可用不会导致
+  进程被反复重启。
+- `/readyz` 和 `/api/v1/ready` 只返回缓存的依赖状态，不会同步访问 S3；最近一次
+  探测成功前返回 HTTP 503，恢复后自动返回 200。
+- 响应只包含 `checking`、`permission_denied`、`not_found`、`timeout`、`network`、
+  `unavailable` 等稳定类别，不返回供应商错误、endpoint 或任何凭据。
+
+为兼容已有部署，默认使用非严格启动：首次探测失败时进程继续运行，但 readiness
+失败，后续探测成功即可恢复。如果部署必须在监听端口前验证 bucket、凭据和网络，
+设置 `OWLMAIL_S3_STARTUP_CHECK=true` 或 `-s3-startup-check`。严格检查使用相同的探测
+超时，并且启动错误也只报告安全类别。
 
 OwlMail 会把附件流式写入本地暂存文件并写入持久回滚标记，再把全部对象上传至
 `<prefix>/<email-id>/`，最后提交 `.eml` 标记。上传失败会拒绝 SMTP 事务并清理
@@ -150,8 +168,8 @@ OwlMail 会启动失败。查看启动输出：
 docker logs owlmail
 ```
 
-Basic Auth 保护 UI、API、静态资源和 WebSocket，但 `/healthz` 与
-`/api/v1/health` 会有意保持公开，便于探针检查。凭据通过网络传输时，应启用
+Basic Auth 保护 UI、API、静态资源和 WebSocket，但 `/healthz`、`/readyz`、
+`/api/v1/health` 和 `/api/v1/ready` 会有意保持公开，便于探针检查。凭据通过网络传输时，应启用
 HTTPS 或可信反向代理。
 
 若 TLS 在反向代理终止，请设置 `OWLMAIL_WEB_EXTERNAL_SCHEME=https`，让已鉴权的
@@ -264,10 +282,10 @@ SMTP TLS 只有在 `-tls-cert` 与 `-tls-key` 同时存在时才使用指定证�
 出站中继同样是异步的。API 成功响应只确认进程内请求已被接受，不代表下游 SMTP
 已经完成投递；需要确认投递时，应检查 OwlMail 日志与目标系统。
 
-项目尚未通过一次统一启动校验覆盖所有配置。启用 S3 时会先检查其配置结构，但
-可达性和凭据仍可能在首次对象操作时才暴露错误；其他组件也可能在监听器启动阶段
-才归一化取值或失败。请把启动及运行告警视为需要处理的问题，并在修改配置后同时
-验证健康端点、SMTP 收件和附件下载。
+项目尚未通过一次统一启动校验覆盖所有配置。启用 S3 时会检查配置结构，并通过后台
+readiness 探测在首封附件邮件之前发现 bucket、凭据和网络问题；其他组件仍可能在
+监听器启动阶段才归一化取值或失败。请把启动及运行告警视为需要处理的问题，并在
+修改配置后同时验证 liveness、readiness、SMTP 收件和附件下载。
 
 ## 备份与升级流程
 
@@ -275,7 +293,7 @@ SMTP TLS 只有在 `-tls-cert` 与 `-tls-key` 同时存在时才使用指定证�
 2. 完整复制或快照邮件目录/卷。
 3. 记录镜像标签或二进制版本及有效参数/环境变量。
 4. 重要归档应先让新版本读取副本。
-5. 检查 `/healthz`、抽样打开 HTML 和附件，再发送一封新测试邮件。
+5. 检查 `/healthz` 和 `/readyz`、抽样打开 HTML 和附件，再发送一封新测试邮件。
 6. 在不再需要回滚前保留备份。
 
 可复现环境应记录并部署正式发布的
@@ -290,6 +308,7 @@ SMTP TLS 只有在 `-tls-cert` 与 `-tls-key` 同时存在时才使用指定证�
 | 浏览器反复要求凭据 | 核对实际用户名/密码；自动密码重启后会变化；必要时清除浏览器缓存凭据 |
 | 设置 SMTP 凭据后入口仍然开放 | 当前入站 SMTP 鉴权未强制执行；使用接口绑定与网络控制隔离监听器 |
 | HTTPS 容器显示 unhealthy | 用 HTTPS 探针和正确证书信任覆盖镜像的 HTTP healthcheck |
+| 启用 S3 后 `/readyz` 返回 503 | 根据安全类别区分 bucket/权限、超时、网络及一般可用性问题；详细信息只查看受保护的进程或供应商日志 |
 | 浏览器没有通知 | 在收件箱中开启，使用 HTTPS 或 localhost，并在浏览器网站设置中恢复权限 |
 | Webhook 投递慢 | 检查接收器延迟、超时和重试；提高并发前先修复接收器或减少重试 |
 | SMTP 正常但直接 SMTPS 失败 | 发布 465 端口，核对证书路径及运行时绑定特权端口的权限 |
@@ -302,5 +321,6 @@ SMTP TLS 只有在 `-tls-cert` 与 `-tls-key` 同时存在时才使用指定证�
 ```bash
 docker logs --tail 200 owlmail
 curl --fail http://localhost:1080/healthz
+curl --fail http://localhost:1080/readyz
 curl -u admin:secret http://localhost:1080/api/v1/version
 ```

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gofiber/fiber/v3/middleware/cors"
 	"github.com/gorilla/websocket"
 	"github.com/soulteary/health-kit/v2"
+	"github.com/soulteary/owlmail/internal/attachmentstore"
 	"github.com/soulteary/owlmail/internal/mailserver"
 	"github.com/soulteary/owlmail/internal/types"
 	webassets "github.com/soulteary/owlmail/web"
@@ -114,7 +115,7 @@ func (api *API) setupRoutes() {
 
 	// HTTP Basic Auth middleware if configured
 	if authEnabled {
-		app.Use(basicAuthMiddleware(api.authUser, api.authPassword, "/healthz", "/api/v1/health"))
+		app.Use(basicAuthMiddleware(api.authUser, api.authPassword, "/healthz", "/readyz", "/api/v1/health", "/api/v1/ready"))
 	}
 
 	// Static files are embedded in the executable so the UI and help page work
@@ -153,6 +154,7 @@ func (api *API) setupRoutes() {
 		if strings.HasPrefix(path, "/email") ||
 			strings.HasPrefix(path, "/config") ||
 			strings.HasPrefix(path, "/healthz") ||
+			strings.HasPrefix(path, "/readyz") ||
 			strings.HasPrefix(path, "/socket.io") ||
 			strings.HasPrefix(path, "/api/") ||
 			strings.HasPrefix(path, "/style.css") ||
@@ -215,6 +217,7 @@ func (api *API) setupImprovedAPIRoutes(app *fiber.App) {
 
 	// Health check (adaptor for health-kit)
 	v1.Get("/health", adaptor.HTTPHandler(health.LivenessHandler("owlmail")))
+	v1.Get("/ready", api.readiness)
 	// Version info (adaptor for version-kit)
 	v1.Get("/version", adaptor.HTTPHandler(version.Handler()))
 	// WebSocket (adaptor for gorilla/websocket Upgrade)
@@ -290,7 +293,46 @@ func (api *API) setupMailDevCompatibleRoutes(app *fiber.App) {
 
 	// Health check route (MailDev compatible)
 	app.Get("/healthz", adaptor.HTTPHandler(health.LivenessHandler("owlmail")))
+	app.Get("/readyz", api.readiness)
 
 	// Reload mails from directory route (MailDev compatible)
 	app.Get("/reloadMailsFromDirectory", api.reloadMailsFromDirectory)
+}
+
+func (api *API) readiness(c fiber.Ctx) error {
+	status := api.mailServer.GetAttachmentReadiness()
+	code := http.StatusOK
+	state := "ready"
+	if !status.Ready {
+		code = http.StatusServiceUnavailable
+		state = "not_ready"
+	}
+	return c.Status(code).JSON(fiber.Map{
+		"status":  state,
+		"service": "owlmail",
+		"checks": fiber.Map{
+			"attachment_store": fiber.Map{
+				"status":   state,
+				"category": safeHealthCategory(status.Category),
+			},
+		},
+	})
+}
+
+func safeHealthCategory(category string) string {
+	switch category {
+	case attachmentstore.HealthOK,
+		attachmentstore.HealthDisabled,
+		attachmentstore.HealthUnsupported,
+		attachmentstore.HealthChecking,
+		attachmentstore.HealthPermissionDenied,
+		attachmentstore.HealthNotFound,
+		attachmentstore.HealthTimeout,
+		attachmentstore.HealthNetwork,
+		attachmentstore.HealthUnavailable,
+		attachmentstore.HealthClosed:
+		return category
+	default:
+		return attachmentstore.HealthUnavailable
+	}
 }

--- a/internal/api/api_middleware_test.go
+++ b/internal/api/api_middleware_test.go
@@ -399,3 +399,24 @@ func TestHealthzSkippedAuth(t *testing.T) {
 		t.Errorf("Expected status 200, got %d", resp.StatusCode)
 	}
 }
+
+func TestReadinessSkippedAuth(t *testing.T) {
+	tmpDir := t.TempDir()
+	server, err := mailserver.NewMailServer(1025, "localhost", tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	api := NewAPIWithAuth(server, 1080, "localhost", "user", "pass")
+	for _, path := range []string{"/readyz", "/api/v1/ready"} {
+		req, _ := http.NewRequest(http.MethodGet, path, nil)
+		resp, err := api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
+		if err != nil {
+			t.Fatalf("%s error = %v", path, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("%s status = %d, want 200", path, resp.StatusCode)
+		}
+	}
+}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -11,9 +12,23 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/soulteary/owlmail/internal/attachmentstore"
 	"github.com/soulteary/owlmail/internal/mailserver"
 	"github.com/soulteary/owlmail/internal/types"
 )
+
+type readinessTestStore struct {
+	status attachmentstore.HealthStatus
+}
+
+func (store *readinessTestStore) Put(context.Context, string, string, string, io.Reader, int64) error {
+	return nil
+}
+func (store *readinessTestStore) Open(context.Context, string, string) (*attachmentstore.Object, error) {
+	return nil, os.ErrNotExist
+}
+func (store *readinessTestStore) DeleteEmail(context.Context, string) error { return nil }
+func (store *readinessTestStore) Readiness() attachmentstore.HealthStatus { return store.status }
 
 func setupTestAPI(t *testing.T) (*API, *mailserver.MailServer, string) {
 	tmpDir := t.TempDir()
@@ -124,6 +139,76 @@ func TestAPIHealthCheck(t *testing.T) {
 	}
 	if response["service"] != "owlmail" {
 		t.Errorf("Expected service 'owlmail', got '%v'", response["service"])
+	}
+}
+
+func TestReadinessIsIndependentFromLiveness(t *testing.T) {
+	store := &readinessTestStore{status: attachmentstore.HealthStatus{
+		Category: attachmentstore.HealthPermissionDenied,
+	}}
+	server, err := mailserver.NewMailServerWithOptions(1025, "localhost", t.TempDir(), mailserver.ServerOptions{AttachmentStore: store})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	api := NewAPI(server, 1080, "localhost")
+
+	for _, path := range []string{"/readyz", "/api/v1/ready"} {
+		req, _ := http.NewRequest(http.MethodGet, path, nil)
+		resp, err := api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
+		if err != nil {
+			t.Fatalf("%s error = %v", path, err)
+		}
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			t.Fatalf("%s status = %d", path, resp.StatusCode)
+		}
+		var payload struct {
+			Status string `json:"status"`
+			Checks map[string]struct {
+				Status   string `json:"status"`
+				Category string `json:"category"`
+			} `json:"checks"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+		if payload.Status != "not_ready" || payload.Checks["attachment_store"].Category != attachmentstore.HealthPermissionDenied {
+			t.Fatalf("%s payload = %#v", path, payload)
+		}
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "/healthz", nil)
+	resp, err := api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("liveness during S3 failure = %d", resp.StatusCode)
+	}
+}
+
+func TestReadinessSanitizesUnknownCategory(t *testing.T) {
+	store := &readinessTestStore{status: attachmentstore.HealthStatus{Category: "https://access:secret@objects.example.test"}}
+	server, err := mailserver.NewMailServerWithOptions(1025, "localhost", t.TempDir(), mailserver.ServerOptions{AttachmentStore: store})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	api := NewAPI(server, 1080, "localhost")
+	req, _ := http.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if strings.Contains(string(body), "secret") || strings.Contains(string(body), "example.test") || !strings.Contains(string(body), attachmentstore.HealthUnavailable) {
+		t.Fatalf("unsafe readiness body = %s", body)
 	}
 }
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -28,7 +28,7 @@ func (store *readinessTestStore) Open(context.Context, string, string) (*attachm
 	return nil, os.ErrNotExist
 }
 func (store *readinessTestStore) DeleteEmail(context.Context, string) error { return nil }
-func (store *readinessTestStore) Readiness() attachmentstore.HealthStatus { return store.status }
+func (store *readinessTestStore) Readiness() attachmentstore.HealthStatus   { return store.status }
 
 func setupTestAPI(t *testing.T) (*API, *mailserver.MailServer, string) {
 	tmpDir := t.TempDir()

--- a/internal/attachmentstore/health.go
+++ b/internal/attachmentstore/health.go
@@ -1,0 +1,153 @@
+package attachmentstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/smithy-go"
+)
+
+// MonitoredStore decorates a health-capable Store with a background probe and
+// a cached readiness result. Store operations retain their original behavior.
+type MonitoredStore struct {
+	Store
+	checker  HealthChecker
+	interval time.Duration
+	timeout  time.Duration
+
+	mu     sync.RWMutex
+	status HealthStatus
+	cancel context.CancelFunc
+	done   chan struct{}
+	once   sync.Once
+}
+
+// NewMonitoredStore starts a background probe. The first probe runs
+// asynchronously so non-strict startup remains compatible when S3 is down.
+func NewMonitoredStore(store Store, interval, timeout time.Duration, initial ...HealthStatus) (*MonitoredStore, error) {
+	if store == nil {
+		return nil, fmt.Errorf("attachment store cannot be nil")
+	}
+	checker, ok := store.(HealthChecker)
+	if !ok {
+		return nil, fmt.Errorf("attachment store does not support health checks")
+	}
+	if interval <= 0 {
+		return nil, fmt.Errorf("attachment health check interval must be positive")
+	}
+	if timeout <= 0 {
+		return nil, fmt.Errorf("attachment health check timeout must be positive")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	status := HealthStatus{Category: HealthChecking}
+	if len(initial) > 0 {
+		status = initial[0]
+	}
+	monitored := &MonitoredStore{
+		Store:    store,
+		checker:  checker,
+		interval: interval,
+		timeout:  timeout,
+		status:   status,
+		cancel:   cancel,
+		done:     make(chan struct{}),
+	}
+	go monitored.run(ctx)
+	return monitored, nil
+}
+
+func (store *MonitoredStore) run(ctx context.Context) {
+	defer close(store.done)
+	store.probe(ctx)
+	ticker := time.NewTicker(store.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			store.probe(ctx)
+		}
+	}
+}
+
+func (store *MonitoredStore) probe(parent context.Context) {
+	ctx, cancel := context.WithTimeout(parent, store.timeout)
+	err := store.checker.CheckHealth(ctx)
+	cancel()
+	status := HealthStatus{Ready: err == nil, Category: ClassifyHealthError(err)}
+	store.mu.Lock()
+	store.status = status
+	store.mu.Unlock()
+}
+
+// Readiness returns the most recent probe result without contacting S3.
+func (store *MonitoredStore) Readiness() HealthStatus {
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+	return store.status
+}
+
+// Close stops future probes and waits for an in-flight probe to observe
+// cancellation. It is safe to call more than once.
+func (store *MonitoredStore) Close() error {
+	store.once.Do(func() {
+		store.cancel()
+		<-store.done
+		store.mu.Lock()
+		store.status = HealthStatus{Category: HealthClosed}
+		store.mu.Unlock()
+		if closer, ok := store.Store.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	})
+	return nil
+}
+
+// CheckHealth performs one bounded caller-controlled probe and returns only a
+// categorized result. Callers must supply a context with an appropriate
+// deadline when using this for strict startup.
+func CheckHealth(ctx context.Context, store Store) HealthStatus {
+	checker, ok := store.(HealthChecker)
+	if !ok {
+		return HealthStatus{Ready: true, Category: HealthUnsupported}
+	}
+	err := checker.CheckHealth(ctx)
+	return HealthStatus{Ready: err == nil, Category: ClassifyHealthError(err)}
+}
+
+// ClassifyHealthError maps provider errors to a stable, disclosure-safe
+// category suitable for readiness responses and startup messages.
+func ClassifyHealthError(err error) string {
+	if err == nil {
+		return HealthOK
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return HealthTimeout
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch strings.ToLower(apiErr.ErrorCode()) {
+		case "accessdenied", "forbidden", "invalidaccesskeyid", "signaturedoesnotmatch", "expiredtoken", "invalidtoken":
+			return HealthPermissionDenied
+		case "nosuchbucket", "notfound", "404":
+			return HealthNotFound
+		case "requesttimeout", "requesttimeoutexception", "timeout":
+			return HealthTimeout
+		}
+	}
+	var networkErr net.Error
+	if errors.As(err, &networkErr) {
+		if networkErr.Timeout() {
+			return HealthTimeout
+		}
+		return HealthNetwork
+	}
+	return HealthUnavailable
+}

--- a/internal/attachmentstore/s3.go
+++ b/internal/attachmentstore/s3.go
@@ -26,18 +26,26 @@ type S3Config struct {
 }
 
 type s3Client interface {
-	HeadBucket(context.Context, *s3.HeadBucketInput, ...func(*s3.Options)) (*s3.HeadBucketOutput, error)
 	PutObject(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error)
 	GetObject(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error)
 	ListObjectsV2(context.Context, *s3.ListObjectsV2Input, ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
 	DeleteObject(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
 }
 
-// CheckHealth verifies that the configured bucket exists and is accessible
-// using a read-only S3 operation.
+// CheckHealth verifies the configured bucket and attachment prefix using the
+// same prefix-scoped read permission needed by attachment cleanup. MaxKeys
+// keeps the read-only probe bounded.
 func (store *S3Store) CheckHealth(ctx context.Context) error {
-	if _, err := store.client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: aws.String(store.bucket)}); err != nil {
-		return fmt.Errorf("head S3 bucket: %w", err)
+	prefix := store.prefix
+	if prefix != "" {
+		prefix += "/"
+	}
+	if _, err := store.client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+		Bucket:  aws.String(store.bucket),
+		Prefix:  aws.String(prefix),
+		MaxKeys: aws.Int32(1),
+	}); err != nil {
+		return fmt.Errorf("check S3 attachment prefix: %w", err)
 	}
 	return nil
 }

--- a/internal/attachmentstore/s3.go
+++ b/internal/attachmentstore/s3.go
@@ -26,10 +26,20 @@ type S3Config struct {
 }
 
 type s3Client interface {
+	HeadBucket(context.Context, *s3.HeadBucketInput, ...func(*s3.Options)) (*s3.HeadBucketOutput, error)
 	PutObject(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error)
 	GetObject(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error)
 	ListObjectsV2(context.Context, *s3.ListObjectsV2Input, ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
 	DeleteObject(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+}
+
+// CheckHealth verifies that the configured bucket exists and is accessible
+// using a read-only S3 operation.
+func (store *S3Store) CheckHealth(ctx context.Context) error {
+	if _, err := store.client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: aws.String(store.bucket)}); err != nil {
+		return fmt.Errorf("head S3 bucket: %w", err)
+	}
+	return nil
 }
 
 // S3Store stores attachments as <prefix>/<email-id>/<generated-filename>.

--- a/internal/attachmentstore/s3_test.go
+++ b/internal/attachmentstore/s3_test.go
@@ -5,12 +5,16 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net"
 	"sort"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
 )
 
 type fakeS3Client struct {
@@ -20,6 +24,39 @@ type fakeS3Client struct {
 	getErr       error
 	listErr      error
 	deleteErr    error
+	headMu       sync.Mutex
+	headErr      error
+	headBlock    bool
+	headCalls    int
+}
+
+func (client *fakeS3Client) HeadBucket(ctx context.Context, _ *s3.HeadBucketInput, _ ...func(*s3.Options)) (*s3.HeadBucketOutput, error) {
+	client.headMu.Lock()
+	client.headCalls++
+	err := client.headErr
+	block := client.headBlock
+	client.headMu.Unlock()
+	if block {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &s3.HeadBucketOutput{}, nil
+}
+
+func (client *fakeS3Client) setHeadResult(err error, block bool) {
+	client.headMu.Lock()
+	client.headErr = err
+	client.headBlock = block
+	client.headMu.Unlock()
+}
+
+func (client *fakeS3Client) headCallCount() int {
+	client.headMu.Lock()
+	defer client.headMu.Unlock()
+	return client.headCalls
 }
 
 func newFakeS3Client() *fakeS3Client {
@@ -133,6 +170,74 @@ func TestS3StorePutOpenAndDeleteEmail(t *testing.T) {
 	if _, ok := client.objects["owlmail/attachments/mail-10/keep.txt"]; !ok {
 		t.Fatal("neighboring email prefix was deleted")
 	}
+}
+
+func TestS3StoreCheckHealth(t *testing.T) {
+	client := newFakeS3Client()
+	store := newS3Store(client, "mail-bucket", "attachments")
+	if err := store.CheckHealth(context.Background()); err != nil {
+		t.Fatalf("CheckHealth() error = %v", err)
+	}
+	client.setHeadResult(&smithy.GenericAPIError{Code: "AccessDenied", Message: "secret provider detail"}, false)
+	status := CheckHealth(context.Background(), store)
+	if status.Ready || status.Category != HealthPermissionDenied {
+		t.Fatalf("permission status = %#v", status)
+	}
+	client.setHeadResult(&smithy.GenericAPIError{Code: "NoSuchBucket", Message: "missing"}, false)
+	if status := CheckHealth(context.Background(), store); status.Ready || status.Category != HealthNotFound {
+		t.Fatalf("missing bucket status = %#v", status)
+	}
+	client.setHeadResult(&net.DNSError{Err: "dial failed", Name: "objects.example.test"}, false)
+	if status := CheckHealth(context.Background(), store); status.Ready || status.Category != HealthNetwork {
+		t.Fatalf("network status = %#v", status)
+	}
+	if got := client.headCallCount(); got != 4 {
+		t.Fatalf("HeadBucket calls = %d, want 4", got)
+	}
+}
+
+func TestMonitoredS3StoreTimeoutRecoveryAndClose(t *testing.T) {
+	client := newFakeS3Client()
+	client.setHeadResult(nil, true)
+	store := newS3Store(client, "mail-bucket", "attachments")
+	monitored, err := NewMonitoredStore(store, 10*time.Millisecond, 15*time.Millisecond)
+	if err != nil {
+		t.Fatalf("NewMonitoredStore() error = %v", err)
+	}
+	waitForHealthStatus(t, monitored, HealthTimeout)
+
+	client.setHeadResult(nil, false)
+	waitForHealthStatus(t, monitored, HealthOK)
+	if !monitored.Readiness().Ready {
+		t.Fatalf("recovered readiness = %#v", monitored.Readiness())
+	}
+
+	if err := monitored.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if status := monitored.Readiness(); status.Ready || status.Category != HealthClosed {
+		t.Fatalf("closed readiness = %#v", status)
+	}
+	calls := client.headCallCount()
+	time.Sleep(30 * time.Millisecond)
+	if got := client.headCallCount(); got != calls {
+		t.Fatalf("HeadBucket called after Close: before=%d after=%d", calls, got)
+	}
+	if err := monitored.Close(); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+}
+
+func waitForHealthStatus(t *testing.T, provider ReadinessProvider, category string) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if status := provider.Readiness(); status.Category == category {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("health category = %q, want %q", provider.Readiness().Category, category)
 }
 
 func TestS3StorePropagatesClientErrors(t *testing.T) {

--- a/internal/attachmentstore/s3_test.go
+++ b/internal/attachmentstore/s3_test.go
@@ -24,39 +24,30 @@ type fakeS3Client struct {
 	getErr       error
 	listErr      error
 	deleteErr    error
-	headMu       sync.Mutex
-	headErr      error
-	headBlock    bool
-	headCalls    int
+	healthMu     sync.Mutex
+	healthErr    error
+	healthBlock  bool
+	healthCalls  int
+	healthPrefix string
 }
 
-func (client *fakeS3Client) HeadBucket(ctx context.Context, _ *s3.HeadBucketInput, _ ...func(*s3.Options)) (*s3.HeadBucketOutput, error) {
-	client.headMu.Lock()
-	client.headCalls++
-	err := client.headErr
-	block := client.headBlock
-	client.headMu.Unlock()
-	if block {
-		<-ctx.Done()
-		return nil, ctx.Err()
-	}
-	if err != nil {
-		return nil, err
-	}
-	return &s3.HeadBucketOutput{}, nil
+func (client *fakeS3Client) setHealthResult(err error, block bool) {
+	client.healthMu.Lock()
+	client.healthErr = err
+	client.healthBlock = block
+	client.healthMu.Unlock()
 }
 
-func (client *fakeS3Client) setHeadResult(err error, block bool) {
-	client.headMu.Lock()
-	client.headErr = err
-	client.headBlock = block
-	client.headMu.Unlock()
+func (client *fakeS3Client) healthCallCount() int {
+	client.healthMu.Lock()
+	defer client.healthMu.Unlock()
+	return client.healthCalls
 }
 
-func (client *fakeS3Client) headCallCount() int {
-	client.headMu.Lock()
-	defer client.headMu.Unlock()
-	return client.headCalls
+func (client *fakeS3Client) lastHealthPrefix() string {
+	client.healthMu.Lock()
+	defer client.healthMu.Unlock()
+	return client.healthPrefix
 }
 
 func newFakeS3Client() *fakeS3Client {
@@ -94,7 +85,22 @@ func (client *fakeS3Client) GetObject(_ context.Context, input *s3.GetObjectInpu
 	}, nil
 }
 
-func (client *fakeS3Client) ListObjectsV2(_ context.Context, input *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+func (client *fakeS3Client) ListObjectsV2(ctx context.Context, input *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	if aws.ToInt32(input.MaxKeys) == 1 {
+		client.healthMu.Lock()
+		client.healthCalls++
+		client.healthPrefix = aws.ToString(input.Prefix)
+		err := client.healthErr
+		block := client.healthBlock
+		client.healthMu.Unlock()
+		if block {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
 	if client.listErr != nil {
 		return nil, client.listErr
 	}
@@ -178,27 +184,41 @@ func TestS3StoreCheckHealth(t *testing.T) {
 	if err := store.CheckHealth(context.Background()); err != nil {
 		t.Fatalf("CheckHealth() error = %v", err)
 	}
-	client.setHeadResult(&smithy.GenericAPIError{Code: "AccessDenied", Message: "secret provider detail"}, false)
+	client.setHealthResult(&smithy.GenericAPIError{Code: "AccessDenied", Message: "secret provider detail"}, false)
 	status := CheckHealth(context.Background(), store)
 	if status.Ready || status.Category != HealthPermissionDenied {
 		t.Fatalf("permission status = %#v", status)
 	}
-	client.setHeadResult(&smithy.GenericAPIError{Code: "NoSuchBucket", Message: "missing"}, false)
+	client.setHealthResult(&smithy.GenericAPIError{Code: "NoSuchBucket", Message: "missing"}, false)
 	if status := CheckHealth(context.Background(), store); status.Ready || status.Category != HealthNotFound {
 		t.Fatalf("missing bucket status = %#v", status)
 	}
-	client.setHeadResult(&net.DNSError{Err: "dial failed", Name: "objects.example.test"}, false)
+	client.setHealthResult(&net.DNSError{Err: "dial failed", Name: "objects.example.test"}, false)
 	if status := CheckHealth(context.Background(), store); status.Ready || status.Category != HealthNetwork {
 		t.Fatalf("network status = %#v", status)
 	}
-	if got := client.headCallCount(); got != 4 {
-		t.Fatalf("HeadBucket calls = %d, want 4", got)
+	if got := client.healthCallCount(); got != 4 {
+		t.Fatalf("health ListObjectsV2 calls = %d, want 4", got)
+	}
+}
+
+func TestS3StoreCheckHealthUsesConfiguredPrefix(t *testing.T) {
+	client := newFakeS3Client()
+	store := newS3Store(client, "mail-bucket", "/owlmail/attachments/")
+	if err := store.CheckHealth(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := client.healthCallCount(); got != 1 {
+		t.Fatalf("health calls = %d, want 1", got)
+	}
+	if got := client.lastHealthPrefix(); got != "owlmail/attachments/" {
+		t.Fatalf("health prefix = %q", got)
 	}
 }
 
 func TestMonitoredS3StoreTimeoutRecoveryAndClose(t *testing.T) {
 	client := newFakeS3Client()
-	client.setHeadResult(nil, true)
+	client.setHealthResult(nil, true)
 	store := newS3Store(client, "mail-bucket", "attachments")
 	monitored, err := NewMonitoredStore(store, 10*time.Millisecond, 15*time.Millisecond)
 	if err != nil {
@@ -206,7 +226,7 @@ func TestMonitoredS3StoreTimeoutRecoveryAndClose(t *testing.T) {
 	}
 	waitForHealthStatus(t, monitored, HealthTimeout)
 
-	client.setHeadResult(nil, false)
+	client.setHealthResult(nil, false)
 	waitForHealthStatus(t, monitored, HealthOK)
 	if !monitored.Readiness().Ready {
 		t.Fatalf("recovered readiness = %#v", monitored.Readiness())
@@ -218,10 +238,10 @@ func TestMonitoredS3StoreTimeoutRecoveryAndClose(t *testing.T) {
 	if status := monitored.Readiness(); status.Ready || status.Category != HealthClosed {
 		t.Fatalf("closed readiness = %#v", status)
 	}
-	calls := client.headCallCount()
+	calls := client.healthCallCount()
 	time.Sleep(30 * time.Millisecond)
-	if got := client.headCallCount(); got != calls {
-		t.Fatalf("HeadBucket called after Close: before=%d after=%d", calls, got)
+	if got := client.healthCallCount(); got != calls {
+		t.Fatalf("health probe called after Close: before=%d after=%d", calls, got)
 	}
 	if err := monitored.Close(); err != nil {
 		t.Fatalf("second Close() error = %v", err)

--- a/internal/attachmentstore/store.go
+++ b/internal/attachmentstore/store.go
@@ -20,3 +20,35 @@ type Store interface {
 	Open(ctx context.Context, emailID, filename string) (*Object, error)
 	DeleteEmail(ctx context.Context, emailID string) error
 }
+
+// HealthChecker is implemented by stores that can verify their backing
+// service without modifying it. Implementations must honor ctx deadlines.
+type HealthChecker interface {
+	CheckHealth(ctx context.Context) error
+}
+
+// HealthStatus is the cached, disclosure-safe state exposed to readiness
+// handlers. Category never contains provider error text or configuration.
+type HealthStatus struct {
+	Ready    bool
+	Category string
+}
+
+const (
+	HealthOK               = "ok"
+	HealthDisabled         = "disabled"
+	HealthUnsupported      = "unsupported"
+	HealthChecking         = "checking"
+	HealthPermissionDenied = "permission_denied"
+	HealthNotFound         = "not_found"
+	HealthTimeout          = "timeout"
+	HealthNetwork          = "network"
+	HealthUnavailable      = "unavailable"
+	HealthClosed           = "closed"
+)
+
+// ReadinessProvider exposes a cached health result. Calling Readiness must not
+// perform network I/O.
+type ReadinessProvider interface {
+	Readiness() HealthStatus
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,8 @@ const DefaultSMTPMaxMessageMB = 100
 
 const DefaultS3Region = "us-east-1"
 const DefaultS3Prefix = "owlmail/attachments"
+const DefaultS3HealthCheckInterval = "30s"
+const DefaultS3HealthCheckTimeout = "3s"
 
 // DefaultWebhookMaxConcurrency is the recommended concurrent email delivery
 // limit. Zero remains available as an explicit unlimited mode.
@@ -259,6 +261,9 @@ type Config struct {
 	S3SecretAccessKey string
 	S3SessionToken    string
 	S3UsePathStyle    bool
+	S3StartupCheck    bool
+	S3HealthInterval  string
+	S3HealthTimeout   string
 
 	// Webhook forwarding configuration
 	WebhookConfig          string
@@ -312,6 +317,9 @@ func DefaultConfig() *Config {
 		S3SecretAccessKey:      "",
 		S3SessionToken:         "",
 		S3UsePathStyle:         false,
+		S3StartupCheck:         false,
+		S3HealthInterval:       DefaultS3HealthCheckInterval,
+		S3HealthTimeout:        DefaultS3HealthCheckTimeout,
 		WebhookConfig:          "",
 		WebhookMaxConcurrency:  DefaultWebhookMaxConcurrency,
 		WebhookRedisURL:        "",
@@ -362,6 +370,9 @@ type FlagRefs struct {
 	S3SecretAccessKey      *string
 	S3SessionToken         *string
 	S3UsePathStyle         *bool
+	S3StartupCheck         *bool
+	S3HealthInterval       *string
+	S3HealthTimeout        *string
 	WebhookConfig          *string
 	WebhookMaxConcurrency  *int
 	WebhookRedisURL        *string
@@ -414,6 +425,9 @@ func DefineFlags(fs *flag.FlagSet) *FlagRefs {
 		S3SecretAccessKey:      fs.String("s3-secret-key", cfg.S3SecretAccessKey, "S3 static secret key (optional)"),
 		S3SessionToken:         fs.String("s3-session-token", cfg.S3SessionToken, "S3 static credential session token (optional)"),
 		S3UsePathStyle:         fs.Bool("s3-use-path-style", cfg.S3UsePathStyle, "Use path-style S3 bucket addressing"),
+		S3StartupCheck:         fs.Bool("s3-startup-check", cfg.S3StartupCheck, "Require a successful S3 health check before startup"),
+		S3HealthInterval:       fs.String("s3-health-check-interval", cfg.S3HealthInterval, "Interval between cached S3 readiness checks"),
+		S3HealthTimeout:        fs.String("s3-health-check-timeout", cfg.S3HealthTimeout, "Timeout for each S3 health check"),
 		WebhookConfig:          fs.String("webhook-config", cfg.WebhookConfig, "JSON file path for webhook forwarding targets"),
 		WebhookMaxConcurrency:  fs.Int("webhook-max-concurrency", cfg.WebhookMaxConcurrency, "Maximum concurrent webhook deliveries (0 = unlimited)"),
 		WebhookRedisURL:        fs.String("webhook-redis-url", cfg.WebhookRedisURL, "Redis URL for durable webhook delivery"),
@@ -475,6 +489,9 @@ func ResolveConfig(fs *flag.FlagSet, refs *FlagRefs) *Config {
 		S3SecretAccessKey:      resolveStringWithFlag(fs, "s3-secret-key", "OWLMAIL_S3_SECRET_KEY", *refs.S3SecretAccessKey),
 		S3SessionToken:         resolveStringWithFlag(fs, "s3-session-token", "OWLMAIL_S3_SESSION_TOKEN", *refs.S3SessionToken),
 		S3UsePathStyle:         resolveBoolWithFlag(fs, "s3-use-path-style", "OWLMAIL_S3_USE_PATH_STYLE", *refs.S3UsePathStyle),
+		S3StartupCheck:         resolveBoolWithFlag(fs, "s3-startup-check", "OWLMAIL_S3_STARTUP_CHECK", *refs.S3StartupCheck),
+		S3HealthInterval:       resolveStringWithFlag(fs, "s3-health-check-interval", "OWLMAIL_S3_HEALTH_CHECK_INTERVAL", *refs.S3HealthInterval),
+		S3HealthTimeout:        resolveStringWithFlag(fs, "s3-health-check-timeout", "OWLMAIL_S3_HEALTH_CHECK_TIMEOUT", *refs.S3HealthTimeout),
 		WebhookConfig:          resolveStringWithFlag(fs, "webhook-config", "OWLMAIL_WEBHOOK_CONFIG", *refs.WebhookConfig),
 		WebhookMaxConcurrency:  resolveIntWithFlag(fs, "webhook-max-concurrency", "OWLMAIL_WEBHOOK_MAX_CONCURRENCY", *refs.WebhookMaxConcurrency),
 		WebhookRedisURL:        resolveStringWithFlag(fs, "webhook-redis-url", "OWLMAIL_WEBHOOK_REDIS_URL", *refs.WebhookRedisURL),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -280,7 +280,7 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.UseUUIDForEmailID != false {
 		t.Errorf("DefaultConfig().UseUUIDForEmailID = %v, want %v", cfg.UseUUIDForEmailID, false)
 	}
-	if cfg.S3Enabled || cfg.S3Endpoint != "" || cfg.S3Bucket != "" || cfg.S3Region != DefaultS3Region || cfg.S3Prefix != DefaultS3Prefix || cfg.S3UsePathStyle {
+	if cfg.S3Enabled || cfg.S3Endpoint != "" || cfg.S3Bucket != "" || cfg.S3Region != DefaultS3Region || cfg.S3Prefix != DefaultS3Prefix || cfg.S3UsePathStyle || cfg.S3StartupCheck || cfg.S3HealthInterval != DefaultS3HealthCheckInterval || cfg.S3HealthTimeout != DefaultS3HealthCheckTimeout {
 		t.Errorf("unexpected default S3 attachment config: %#v", cfg)
 	}
 	if cfg.WebhookConfig != "" {
@@ -337,12 +337,15 @@ func TestSMTPAndS3ConfigResolution(t *testing.T) {
 			"-s3-secret-key", "secret",
 			"-s3-session-token", "token",
 			"-s3-use-path-style",
+			"-s3-startup-check",
+			"-s3-health-check-interval", "45s",
+			"-s3-health-check-timeout", "4s",
 		})
 		if err != nil {
 			t.Fatalf("Parse() error = %v", err)
 		}
 		cfg := ResolveConfig(fs, refs)
-		if cfg.SMTPMaxMessageMB != 256 || !cfg.S3Enabled || cfg.S3Endpoint != "http://minio:9000" || cfg.S3Region != "test-region-1" || cfg.S3Bucket != "owlmail-test" || cfg.S3Prefix != "mail/attachments" || cfg.S3AccessKeyID != "access" || cfg.S3SecretAccessKey != "secret" || cfg.S3SessionToken != "token" || !cfg.S3UsePathStyle {
+		if cfg.SMTPMaxMessageMB != 256 || !cfg.S3Enabled || cfg.S3Endpoint != "http://minio:9000" || cfg.S3Region != "test-region-1" || cfg.S3Bucket != "owlmail-test" || cfg.S3Prefix != "mail/attachments" || cfg.S3AccessKeyID != "access" || cfg.S3SecretAccessKey != "secret" || cfg.S3SessionToken != "token" || !cfg.S3UsePathStyle || !cfg.S3StartupCheck || cfg.S3HealthInterval != "45s" || cfg.S3HealthTimeout != "4s" {
 			t.Fatalf("unexpected resolved CLI config: %#v", cfg)
 		}
 	})
@@ -358,6 +361,9 @@ func TestSMTPAndS3ConfigResolution(t *testing.T) {
 		t.Setenv("OWLMAIL_S3_SECRET_KEY", "env-secret")
 		t.Setenv("OWLMAIL_S3_SESSION_TOKEN", "env-token")
 		t.Setenv("OWLMAIL_S3_USE_PATH_STYLE", "true")
+		t.Setenv("OWLMAIL_S3_STARTUP_CHECK", "true")
+		t.Setenv("OWLMAIL_S3_HEALTH_CHECK_INTERVAL", "1m")
+		t.Setenv("OWLMAIL_S3_HEALTH_CHECK_TIMEOUT", "5s")
 
 		fs := flag.NewFlagSet("smtp-s3-env", flag.ContinueOnError)
 		refs := DefineFlags(fs)
@@ -365,7 +371,7 @@ func TestSMTPAndS3ConfigResolution(t *testing.T) {
 			t.Fatalf("Parse() error = %v", err)
 		}
 		cfg := ResolveConfig(fs, refs)
-		if cfg.SMTPMaxMessageMB != 512 || !cfg.S3Enabled || cfg.S3Endpoint != "https://objects.example.test" || cfg.S3Region != "region-2" || cfg.S3Bucket != "mail-bucket" || cfg.S3Prefix != "tenant/owlmail" || cfg.S3AccessKeyID != "env-access" || cfg.S3SecretAccessKey != "env-secret" || cfg.S3SessionToken != "env-token" || !cfg.S3UsePathStyle {
+		if cfg.SMTPMaxMessageMB != 512 || !cfg.S3Enabled || cfg.S3Endpoint != "https://objects.example.test" || cfg.S3Region != "region-2" || cfg.S3Bucket != "mail-bucket" || cfg.S3Prefix != "tenant/owlmail" || cfg.S3AccessKeyID != "env-access" || cfg.S3SecretAccessKey != "env-secret" || cfg.S3SessionToken != "env-token" || !cfg.S3UsePathStyle || !cfg.S3StartupCheck || cfg.S3HealthInterval != "1m" || cfg.S3HealthTimeout != "5s" {
 			t.Fatalf("unexpected resolved environment config: %#v", cfg)
 		}
 	})

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -98,6 +98,14 @@ func ValidateConfig(cfg *Config) error {
 				return fmt.Errorf("S3 endpoint must be an HTTP or HTTPS URL without credentials, query, or fragment")
 			}
 		}
+		interval, err := time.ParseDuration(cfg.S3HealthInterval)
+		if err != nil || interval <= 0 {
+			return fmt.Errorf("S3 health check interval must be a positive duration")
+		}
+		timeout, err := time.ParseDuration(cfg.S3HealthTimeout)
+		if err != nil || timeout <= 0 {
+			return fmt.Errorf("S3 health check timeout must be a positive duration")
+		}
 	}
 
 	// Validate auto relay rules file path if specified

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -334,6 +334,16 @@ func TestValidateConfig(t *testing.T) {
 		if err := ValidateConfig(cfg); err != nil {
 			t.Fatalf("valid S3 attachment config error = %v", err)
 		}
+
+		cfg.S3HealthInterval = "0s"
+		if err := ValidateConfig(cfg); err == nil {
+			t.Error("non-positive S3 health interval should fail")
+		}
+		cfg.S3HealthInterval = DefaultS3HealthCheckInterval
+		cfg.S3HealthTimeout = "invalid"
+		if err := ValidateConfig(cfg); err == nil {
+			t.Error("invalid S3 health timeout should fail")
+		}
 	})
 
 	t.Run("valid full config", func(t *testing.T) {

--- a/internal/mailserver/types.go
+++ b/internal/mailserver/types.go
@@ -145,6 +145,18 @@ func (ms *MailServer) GetMailDir() string {
 	return ms.mailDir
 }
 
+// GetAttachmentReadiness returns the cached attachment-store state. It never
+// performs provider I/O and therefore is safe to use from an HTTP probe.
+func (ms *MailServer) GetAttachmentReadiness() attachmentstore.HealthStatus {
+	if ms.attachmentStore == nil {
+		return attachmentstore.HealthStatus{Ready: true, Category: attachmentstore.HealthDisabled}
+	}
+	if provider, ok := ms.attachmentStore.(attachmentstore.ReadinessProvider); ok {
+		return provider.Readiness()
+	}
+	return attachmentstore.HealthStatus{Ready: true, Category: attachmentstore.HealthUnsupported}
+}
+
 // GetAuthConfig returns the SMTP authentication configuration
 func (ms *MailServer) GetAuthConfig() *SMTPAuthConfig {
 	return ms.authConfig


### PR DESCRIPTION
## Summary

- add a testable attachment-store health contract and use a bounded, prefix-scoped `ListObjectsV2` read to validate S3 without requiring bucket-wide permissions
- add bounded background probes with cached, disclosure-safe readiness state and recovery
- keep `/healthz` and `/api/v1/health` as liveness; add public `/readyz` and `/api/v1/ready`
- add opt-in strict startup validation while preserving non-strict startup by default
- document the new flags, probe semantics, operational guidance, and compatibility behavior

## Configuration

| Flag | Environment | Default |
|---|---|---|
| `-s3-startup-check` | `OWLMAIL_S3_STARTUP_CHECK` | `false` |
| `-s3-health-check-interval` | `OWLMAIL_S3_HEALTH_CHECK_INTERVAL` | `30s` |
| `-s3-health-check-timeout` | `OWLMAIL_S3_HEALTH_CHECK_TIMEOUT` | `3s` |

The default remains compatible: an unavailable S3 service does not terminate OwlMail. It makes readiness fail until a later cached probe succeeds. Strict startup is explicitly opt-in.

## Safety and least privilege

Readiness responses expose only a state and allow-listed category. They do not include provider error messages, endpoint configuration, access keys, secret keys, or session tokens.

The probe carries the configured attachment prefix and requests at most one key, so policies that grant `s3:ListBucket` only for that prefix are supported.

## Tests

Added fake-S3 coverage for success, missing bucket, insufficient permission, network failure, timeout, recovery, prefix scoping, and monitor shutdown, plus API, authentication, configuration, and strict/non-strict startup regression tests.

Repository CI runs the full Go 1.27 race/coverage, vet, formatting, lint, build, CodeQL, and Bun browser/documentation suites.
