### PR TITLE
feat(web): add responsive email viewport presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to OwlMail are documented in this file. The format follows
 
 ### Added
 
+- Responsive HTML email preview width presets for 100%, 1440, 1024, 768,
+  425, 375, and 320 px without reloading the message or replacing its secure
+  iframe.
 - Real inbound SMTP AUTH with PLAIN and LOGIN mechanisms, constant-time
   credential checks, and protocol-level rejection of unauthenticated mail
   transactions.

--- a/tests/web/app.test.js
+++ b/tests/web/app.test.js
@@ -5,6 +5,7 @@ const { test } = require('bun:test');
 const vm = require('node:vm');
 
 const appSource = fs.readFileSync(path.join(__dirname, '../../web/app.js'), 'utf8');
+const styleSource = fs.readFileSync(path.join(__dirname, '../../web/style.css'), 'utf8');
 
 function createClassList() {
     const values = new Set();
@@ -17,7 +18,7 @@ function createClassList() {
     };
 }
 
-function createElement() {
+function createElement({ dataset = {} } = {}) {
     const listeners = new Map();
     const attributes = new Map();
     let innerHTML = '';
@@ -26,6 +27,10 @@ function createElement() {
         listeners,
         attributes,
         classList: createClassList(),
+        dataset,
+        style: {},
+        scrollLeft: 0,
+        scrollTop: 0,
         hidden: true,
         disabled: false,
         title: '',
@@ -71,11 +76,17 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
     const notificationStatus = createElement();
     const emailDetail = createElement();
     const emailList = createElement();
+    const emailViewportFrame = createElement();
+    const emailViewportStage = createElement();
+    const emailViewportButtons = ['100%', '1440', '1024', '768', '425', '375', '320']
+        .map((width) => createElement({ dataset: { viewportWidth: width } }));
     const elements = new Map([
         ['notificationToggle', notificationToggle],
         ['notificationStatus', notificationStatus],
         ['emailDetail', emailDetail],
-        ['emailList', emailList]
+        ['emailList', emailList],
+        ['emailViewportFrame', emailViewportFrame],
+        ['emailViewportStage', emailViewportStage]
     ]);
     const notifications = [];
     const fetchRequests = [];
@@ -108,7 +119,9 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
         addEventListener(name, handler) { documentListeners.set(name, handler); },
         getElementById(id) { return elements.get(id) || null; },
         querySelector() { return null; },
-        querySelectorAll() { return []; },
+        querySelectorAll(selector) {
+            return selector === '.email-viewport-preset' ? emailViewportButtons : [];
+        },
         createElement() { return createElement(); }
     };
     const navigator = { language: 'en-US' };
@@ -155,6 +168,9 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
         documentListeners,
         emailDetail,
         emailList,
+        emailViewportButtons,
+        emailViewportFrame,
+        emailViewportStage,
         fetchRequests,
         notificationStatus,
         notificationToggle,
@@ -256,6 +272,51 @@ test('HTML previews survive attribute parsing with a zero-permission sandbox', a
     assert.match(csp, /script-src 'none'/);
     assert.match(csp, /form-action 'none'/);
     assert.match(csp, /frame-src 'none'/);
+});
+
+test('HTML previews expose every responsive viewport preset', () => {
+    const harness = createHarness();
+    const preview = harness.run(`renderHTML('<p>Responsive message</p>', 'mail-42', [])`);
+
+    assert.match(preview, /role="group" aria-label="Preview width"/);
+    for (const width of ['100%', '1440', '1024', '768', '425', '375', '320']) {
+        assert.equal(preview.includes(`data-viewport-width="${width}"`), true);
+    }
+    assert.match(preview, /style="width: 100%;"/);
+    assert.match(preview, /sandbox=""/);
+    assert.match(preview, /referrerpolicy="no-referrer"/);
+});
+
+test('changing the viewport resizes the existing frame without reloading or losing stage scroll', () => {
+    const harness = createHarness();
+    const preview = harness.run(`renderHTML('<p>Keep me</p>', 'mail-42', [])`);
+    harness.emailDetail.innerHTML = preview;
+    harness.emailViewportFrame.style.width = '100%';
+    harness.emailViewportStage.scrollLeft = 47;
+    harness.emailViewportStage.scrollTop = 91;
+
+    harness.run("setEmailViewport('375')");
+
+    assert.equal(harness.emailViewportFrame.style.width, '375px');
+    assert.equal(harness.emailViewportStage.scrollLeft, 47);
+    assert.equal(harness.emailViewportStage.scrollTop, 91);
+    assert.equal(harness.emailDetail.innerHTML, preview);
+    assert.equal(harness.fetchRequests.length, 0);
+    assert.equal(harness.emailViewportButtons[5].attributes.get('aria-pressed'), 'true');
+    assert.equal(harness.emailViewportButtons[0].attributes.get('aria-pressed'), 'false');
+    assert.match(harness.emailDetail.innerHTML, /sandbox=""/);
+    assert.match(harness.emailDetail.innerHTML, /referrerpolicy="no-referrer"/);
+
+    harness.run("setEmailViewport('not-a-preset')");
+    assert.equal(harness.emailViewportFrame.style.width, '375px');
+});
+
+test('viewport controls wrap into touch-sized rows on narrow screens', () => {
+    const mobileStyles = styleSource.match(/@media \(max-width: 768px\)[\s\S]*?\/\* Scrollbar \*\//)?.[0] || '';
+
+    assert.match(mobileStyles, /\.email-viewport-toolbar\s*\{[\s\S]*?flex-direction:\s*column/);
+    assert.match(mobileStyles, /\.email-viewport-presets\s*\{[\s\S]*?width:\s*100%/);
+    assert.match(mobileStyles, /\.email-viewport-preset\s*\{[\s\S]*?min-height:\s*38px/);
 });
 
 test('remote tracking resources are blocked until the user explicitly loads them', () => {
@@ -404,6 +465,15 @@ test('English translations use singular forms', () => {
     assert.equal(harness.run("t('attachments', { count: 1 })"), '1 attachment');
     assert.equal(harness.run("t('minutesAgo', { minutes: 1 })"), '1 minute ago');
     assert.equal(harness.run("t('emailCount', { count: 2 })"), '2 emails');
+});
+
+test('every supported language translates the viewport controls', () => {
+    const harness = createHarness();
+
+    assert.equal(harness.run(`Object.values(i18n).every((translations) =>
+        Object.hasOwn(translations, 'emailViewportPresets')
+        && Object.hasOwn(translations, 'emailViewportWidth')
+    )`), true);
 });
 
 test('Traditional Chinese locales do not silently select Simplified Chinese', () => {

--- a/web/app.js
+++ b/web/app.js
@@ -53,6 +53,8 @@ const i18n = {
         remoteContentBlocked: '为保护隐私，远程图片、字体和样式默认已阻止。',
         loadRemoteContent: '加载远程内容',
         emailPreviewTitle: '隔离的邮件 HTML 预览',
+        emailViewportPresets: '预览宽度',
+        emailViewportWidth: '邮件预览宽度：{width}',
         // API Error Codes
         'EMAIL_NOT_FOUND': '邮件未找到',
         'EMAIL_FILE_NOT_FOUND': '邮件文件未找到',
@@ -132,6 +134,8 @@ const i18n = {
         remoteContentBlocked: 'Remote images, fonts, and styles are blocked by default for privacy.',
         loadRemoteContent: 'Load remote content',
         emailPreviewTitle: 'Isolated email HTML preview',
+        emailViewportPresets: 'Preview width',
+        emailViewportWidth: 'Email preview width: {width}',
         // API Error Codes
         'EMAIL_NOT_FOUND': 'Email not found',
         'EMAIL_FILE_NOT_FOUND': 'Email file not found',
@@ -205,6 +209,8 @@ const i18n = {
         remoteContentBlocked: 'Externe Bilder, Schriftarten und Stile sind aus Datenschutzgründen blockiert.',
         loadRemoteContent: 'Externe Inhalte laden',
         emailPreviewTitle: 'Isolierte HTML-E-Mail-Vorschau',
+        emailViewportPresets: 'Vorschaubreite',
+        emailViewportWidth: 'Breite der E-Mail-Vorschau: {width}',
         // API Error Codes
         'EMAIL_NOT_FOUND': 'E-Mail nicht gefunden',
         'EMAIL_FILE_NOT_FOUND': 'E-Mail-Datei nicht gefunden',
@@ -278,6 +284,8 @@ const i18n = {
         remoteContentBlocked: 'Immagini, font e stili remoti sono bloccati per impostazione predefinita.',
         loadRemoteContent: 'Carica contenuti remoti',
         emailPreviewTitle: 'Anteprima HTML email isolata',
+        emailViewportPresets: 'Larghezza anteprima',
+        emailViewportWidth: 'Larghezza anteprima email: {width}',
         // API Error Codes
         'EMAIL_NOT_FOUND': 'Email non trovata',
         'EMAIL_FILE_NOT_FOUND': 'File email non trovato',
@@ -351,6 +359,8 @@ const i18n = {
         remoteContentBlocked: 'Les images, polices et styles distants sont bloqués par défaut.',
         loadRemoteContent: 'Charger le contenu distant',
         emailPreviewTitle: 'Aperçu HTML isolé de l’e-mail',
+        emailViewportPresets: 'Largeur de l’aperçu',
+        emailViewportWidth: 'Largeur de l’aperçu de l’e-mail : {width}',
         // API Error Codes
         'EMAIL_NOT_FOUND': 'Email introuvable',
         'EMAIL_FILE_NOT_FOUND': 'Fichier email introuvable',
@@ -424,6 +434,8 @@ const i18n = {
         remoteContentBlocked: '개인정보 보호를 위해 원격 이미지, 글꼴 및 스타일이 기본적으로 차단됩니다.',
         loadRemoteContent: '원격 콘텐츠 불러오기',
         emailPreviewTitle: '격리된 이메일 HTML 미리보기',
+        emailViewportPresets: '미리보기 너비',
+        emailViewportWidth: '이메일 미리보기 너비: {width}',
         // API Error Codes
         'EMAIL_NOT_FOUND': '이메일을 찾을 수 없습니다',
         'EMAIL_FILE_NOT_FOUND': '이메일 파일을 찾을 수 없습니다',
@@ -497,6 +509,8 @@ const i18n = {
         remoteContentBlocked: 'プライバシー保護のため、外部の画像、フォント、スタイルは既定でブロックされます。',
         loadRemoteContent: '外部コンテンツを読み込む',
         emailPreviewTitle: '隔離されたメール HTML プレビュー',
+        emailViewportPresets: 'プレビュー幅',
+        emailViewportWidth: 'メールプレビュー幅: {width}',
         // API Error Codes
         'EMAIL_NOT_FOUND': 'メールが見つかりません',
         'EMAIL_FILE_NOT_FOUND': 'メールファイルが見つかりません',
@@ -755,6 +769,17 @@ let state = {
     searchQuery: '',
     ws: null
 };
+
+const EMAIL_VIEWPORT_PRESETS = Object.freeze([
+    { key: '100%', label: '100%', width: '100%' },
+    { key: '1440', label: '1440 px', width: '1440px' },
+    { key: '1024', label: '1024 px', width: '1024px' },
+    { key: '768', label: '768 px', width: '768px' },
+    { key: '425', label: '425 px', width: '425px' },
+    { key: '375', label: '375 px', width: '375px' },
+    { key: '320', label: '320 px', width: '320px' }
+]);
+let emailViewportPreset = '100%';
 
 // Remote resources are enabled only for the currently rendered message after
 // an explicit user action. The choice is intentionally not persisted.
@@ -1376,6 +1401,49 @@ function injectPreviewSecurityHead(html, allowRemote) {
     return `<head>${securityHead}</head>${html}`;
 }
 
+function renderEmailViewportPresets() {
+    return `
+        <div class="email-viewport-toolbar" role="group" aria-label="${t('emailViewportPresets')}">
+            <span class="email-viewport-label">${t('emailViewportPresets')}</span>
+            <div class="email-viewport-presets">
+                ${EMAIL_VIEWPORT_PRESETS.map((preset) => `
+                    <button type="button"
+                        class="email-viewport-preset"
+                        data-viewport-width="${preset.key}"
+                        aria-pressed="${emailViewportPreset === preset.key}"
+                        title="${t('emailViewportWidth', { width: preset.label })}"
+                        onclick="setEmailViewport('${preset.key}')">${preset.label}</button>
+                `).join('')}
+            </div>
+        </div>
+    `;
+}
+
+function setEmailViewport(presetKey) {
+    const preset = EMAIL_VIEWPORT_PRESETS.find((candidate) => candidate.key === presetKey);
+    if (!preset) return;
+
+    emailViewportPreset = preset.key;
+    const viewportFrame = document.getElementById('emailViewportFrame');
+    if (!viewportFrame) return;
+
+    const viewportStage = document.getElementById('emailViewportStage');
+    const scrollLeft = viewportStage ? viewportStage.scrollLeft : 0;
+    const scrollTop = viewportStage ? viewportStage.scrollTop : 0;
+
+    // Resize the existing frame instead of rendering the message again. The
+    // iframe node, srcdoc, sandbox, and its own scroll position stay intact.
+    viewportFrame.style.width = preset.width;
+    document.querySelectorAll('.email-viewport-preset').forEach((button) => {
+        button.setAttribute('aria-pressed', button.dataset.viewportWidth === preset.key ? 'true' : 'false');
+    });
+
+    if (viewportStage) {
+        viewportStage.scrollLeft = scrollLeft;
+        viewportStage.scrollTop = scrollTop;
+    }
+}
+
 function renderHTML(html, emailId, attachments) {
     const allowRemote = remoteContentAllowedEmailID === emailId;
     const remoteContentPresent = hasRemoteEmailResources(html);
@@ -1390,7 +1458,12 @@ function renderHTML(html, emailId, attachments) {
                     <button type="button" class="btn btn-secondary" onclick="loadRemoteContent('${emailId}')">${t('loadRemoteContent')}</button>
                 </div>
             ` : ''}
-            <iframe id="${iframeId}" title="${t('emailPreviewTitle')}" sandbox="" referrerpolicy="no-referrer" srcdoc="${escapeHtmlAttribute(previewDocument)}"></iframe>
+            ${renderEmailViewportPresets()}
+            <div id="emailViewportStage" class="email-viewport-stage">
+                <div id="emailViewportFrame" class="email-viewport-frame" style="width: ${EMAIL_VIEWPORT_PRESETS.find((preset) => preset.key === emailViewportPreset).width};">
+                    <iframe id="${iframeId}" title="${t('emailPreviewTitle')}" sandbox="" referrerpolicy="no-referrer" srcdoc="${escapeHtmlAttribute(previewDocument)}"></iframe>
+                </div>
+            </div>
         </div>
     `;
 }

--- a/web/style.css
+++ b/web/style.css
@@ -352,7 +352,75 @@ body {
     flex: 0 0 auto;
 }
 
+.email-viewport-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+.email-viewport-label {
+    flex: 0 0 auto;
+    color: #51606f;
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.email-viewport-presets {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 4px;
+    min-width: 0;
+}
+
+.email-viewport-preset {
+    min-height: 34px;
+    padding: 6px 9px;
+    border: 1px solid #cbd3da;
+    border-radius: 4px;
+    background: #fff;
+    color: #34495e;
+    cursor: pointer;
+    font: inherit;
+    font-size: 12px;
+    line-height: 1;
+}
+
+.email-viewport-preset:hover {
+    border-color: #3498db;
+}
+
+.email-viewport-preset:focus-visible {
+    outline: 2px solid #3498db;
+    outline-offset: 2px;
+}
+
+.email-viewport-preset[aria-pressed="true"] {
+    border-color: #2980b9;
+    background: #2980b9;
+    color: #fff;
+}
+
+.email-viewport-stage {
+    max-width: 100%;
+    overflow: auto;
+    padding: 12px;
+    border: 1px solid #dfe4e8;
+    border-radius: 4px;
+    background: #edf1f4;
+    overscroll-behavior: contain;
+}
+
+.email-viewport-frame {
+    margin-inline: auto;
+    background: #fff;
+    box-shadow: 0 1px 4px rgba(35, 47, 62, 0.12);
+}
+
 .email-detail-html iframe {
+    display: block;
     width: 100%;
     border: none;
     min-height: 400px;
@@ -518,6 +586,29 @@ body {
         flex-wrap: wrap;
         justify-content: flex-start;
     }
+
+    .email-detail-html {
+        padding: 12px;
+    }
+
+    .email-viewport-toolbar {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .email-viewport-presets {
+        justify-content: flex-start;
+        width: 100%;
+    }
+
+    .email-viewport-preset {
+        min-height: 38px;
+    }
+
+    .email-viewport-stage {
+        padding: 8px;
+    }
 }
 
 /* Scrollbar */
@@ -667,6 +758,32 @@ body.dark-theme .email-remote-content-notice {
     background: #3d3520;
     border-color: #806c35;
     color: #f0d98a;
+}
+
+body.dark-theme .email-viewport-label {
+    color: #b8c2cc;
+}
+
+body.dark-theme .email-viewport-preset {
+    border-color: #59636d;
+    background: #2d2d2d;
+    color: #e0e0e0;
+}
+
+body.dark-theme .email-viewport-preset[aria-pressed="true"] {
+    border-color: #3498db;
+    background: #2980b9;
+    color: #fff;
+}
+
+body.dark-theme .email-viewport-stage {
+    border-color: #444;
+    background: #111;
+}
+
+body.dark-theme .email-viewport-frame {
+    background: #fff;
+    box-shadow: none;
 }
 
 body.dark-theme .email-detail-attachments {


### PR DESCRIPTION
## Summary

- add 100%, 1440, 1024, 768, 425, 375, and 320 px presets to the HTML email preview
- resize the existing iframe wrapper in place so switching presets does not fetch or rerender the message
- preserve the outer preview scroll position and leave the iframe `sandbox`, `referrerpolicy`, CSP, and `srcdoc` untouched
- keep the controls usable on narrow screens with wrapping, larger touch targets, keyboard focus styling, and `aria-pressed`
- translate the new controls in every existing locale: Simplified Chinese, English, German, Italian, French, Korean, and Japanese
- update the Unreleased changelog

This PR is based on `main` after #77 merged. It does not change the mailbox list API, MCP integration, or server-side storage.

## Screenshot / visual review guide

| Capture | Expected result |
| --- | --- |
| Wide browser, 1440 px selected | The preview canvas becomes 1440 px wide and remains accessible through the stage's horizontal scrollbar; the message itself is not reloaded. |
| Wide browser, 375 px selected | The same iframe is centered in a 375 px white canvas and the selected button is visibly pressed. |
| Browser width at or below 768 px | The label and preset buttons wrap into touch-friendly rows; 425, 375, and 320 px remain reachable without clipping the page controls. |
| Dark theme | The stage and toolbar follow the dark inbox while the email canvas stays white. |

To reproduce the screenshots, open any captured HTML email, scroll inside the message and stage, then switch between 1440, 375, and 320 px. The selected preset changes without another `/api/v1/emails/:id` request, and the iframe retains `sandbox=""` plus `referrerpolicy="no-referrer"`.

## Test coverage

- exact preset list and initial 100% selection
- in-place width changes with no fetch or detail rerender
- preservation of stage scroll coordinates
- unchanged iframe security attributes
- invalid preset rejection
- narrow-screen wrapping and minimum touch height
- complete translation keys across all supported languages

## Verification

- `bun test ./tests/web ./tests/docs` — 67 passed
- `bun build ./web/*.js --target=browser`
- `node --check web/app.js`
- `git diff --check`
