### PR TITLE
feat(storage): add S3 readiness checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,10 @@ All notable changes to OwlMail are documented in this file. The format follows
   streaming downloads, recoverable deletion and quarantine cleanup,
   content-verified legacy attachment mapping, retention cleanup, and
   compatibility with existing local attachments.
-- Cached S3 readiness checks using read-only `HeadBucket`, separate liveness
-  and readiness endpoints, bounded probe timeouts, automatic recovery, and an
-  opt-in strict startup check that preserves the non-strict default behavior.
+- Cached S3 readiness checks using preferred read-only `HeadBucket` with a
+  bounded prefix-scoped fallback for least-privilege policies, separate
+  liveness and readiness endpoints, bounded probe timeouts, automatic recovery,
+  and an opt-in strict startup check that preserves the non-strict default.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable changes to OwlMail are documented in this file. The format follows
   streaming downloads, recoverable deletion and quarantine cleanup,
   content-verified legacy attachment mapping, retention cleanup, and
   compatibility with existing local attachments.
+- Cached S3 readiness checks using read-only `HeadBucket`, separate liveness
+  and readiness endpoints, bounded probe timeouts, automatic recovery, and an
+  opt-in strict startup check that preserves the non-strict default behavior.
 
 ### Changed
 

--- a/README.de.md
+++ b/README.de.md
@@ -213,6 +213,9 @@ docker buildx build \
 | `-s3-secret-key` | `OWLMAIL_S3_SECRET_KEY` | - | Optionaler statischer geheimer Schlüssel |
 | `-s3-session-token` | `OWLMAIL_S3_SESSION_TOKEN` | - | Optionales Sitzungstoken |
 | `-s3-use-path-style` | `OWLMAIL_S3_USE_PATH_STYLE` | false | Pfadbasierte Bucket-Adressierung verwenden |
+| `-s3-startup-check` | `OWLMAIL_S3_STARTUP_CHECK` | false | Start abbrechen, wenn die erste schreibgeschützte S3-Bucket-Prüfung fehlschlägt |
+| `-s3-health-check-interval` | `OWLMAIL_S3_HEALTH_CHECK_INTERVAL` | 30s | Intervall für S3-Readiness-Prüfungen im Hintergrund |
+| `-s3-health-check-timeout` | `OWLMAIL_S3_HEALTH_CHECK_TIMEOUT` | 5s | Zeitlimit pro S3-Readiness-Prüfung |
 | `-web-user` | `MAILDEV_WEB_USER` / `OWLMAIL_WEB_USER` | - | HTTP Basic Auth Benutzername |
 | `-web-password` | `MAILDEV_WEB_PASS` / `OWLMAIL_WEB_PASSWORD` | - | HTTP Basic Auth Passwort |
 | `-https` | `MAILDEV_HTTPS` / `OWLMAIL_HTTPS_ENABLED` | false | HTTPS aktivieren |

--- a/README.fr.md
+++ b/README.fr.md
@@ -214,6 +214,9 @@ docker buildx build \
 | `-s3-secret-key` | `OWLMAIL_S3_SECRET_KEY` | - | Clé secrète statique facultative |
 | `-s3-session-token` | `OWLMAIL_S3_SESSION_TOKEN` | - | Jeton de session facultatif |
 | `-s3-use-path-style` | `OWLMAIL_S3_USE_PATH_STYLE` | false | Utiliser l’adressage de bucket par chemin |
+| `-s3-startup-check` | `OWLMAIL_S3_STARTUP_CHECK` | false | Arrêter le démarrage si la première vérification S3 en lecture seule échoue |
+| `-s3-health-check-interval` | `OWLMAIL_S3_HEALTH_CHECK_INTERVAL` | 30s | Intervalle de rafraîchissement de la disponibilité S3 |
+| `-s3-health-check-timeout` | `OWLMAIL_S3_HEALTH_CHECK_TIMEOUT` | 5s | Délai maximal de chaque vérification S3 |
 | `-web-user` | `MAILDEV_WEB_USER` / `OWLMAIL_WEB_USER` | - | HTTP Basic Auth username |
 | `-web-password` | `MAILDEV_WEB_PASS` / `OWLMAIL_WEB_PASSWORD` | - | HTTP Basic Auth password |
 | `-https` | `MAILDEV_HTTPS` / `OWLMAIL_HTTPS_ENABLED` | false | Enable HTTPS |

--- a/README.it.md
+++ b/README.it.md
@@ -213,6 +213,9 @@ docker buildx build \
 | `-s3-secret-key` | `OWLMAIL_S3_SECRET_KEY` | - | Chiave segreta statica opzionale |
 | `-s3-session-token` | `OWLMAIL_S3_SESSION_TOKEN` | - | Token di sessione opzionale |
 | `-s3-use-path-style` | `OWLMAIL_S3_USE_PATH_STYLE` | false | Usa l’indirizzamento bucket path-style |
+| `-s3-startup-check` | `OWLMAIL_S3_STARTUP_CHECK` | false | Interrompe l’avvio se il primo controllo S3 in sola lettura fallisce |
+| `-s3-health-check-interval` | `OWLMAIL_S3_HEALTH_CHECK_INTERVAL` | 30s | Intervallo dei controlli readiness S3 in background |
+| `-s3-health-check-timeout` | `OWLMAIL_S3_HEALTH_CHECK_TIMEOUT` | 5s | Timeout per ogni controllo readiness S3 |
 | `-web-user` | `MAILDEV_WEB_USER` / `OWLMAIL_WEB_USER` | - | Nome utente HTTP Basic Auth |
 | `-web-password` | `MAILDEV_WEB_PASS` / `OWLMAIL_WEB_PASSWORD` | - | Password HTTP Basic Auth |
 | `-https` | `MAILDEV_HTTPS` / `OWLMAIL_HTTPS_ENABLED` | false | Abilita HTTPS |

--- a/README.ja.md
+++ b/README.ja.md
@@ -213,6 +213,9 @@ docker buildx build \
 | `-s3-secret-key` | `OWLMAIL_S3_SECRET_KEY` | - | 任意の静的シークレットキー |
 | `-s3-session-token` | `OWLMAIL_S3_SESSION_TOKEN` | - | 任意のセッショントークン |
 | `-s3-use-path-style` | `OWLMAIL_S3_USE_PATH_STYLE` | false | パス形式のバケットアドレスを使用 |
+| `-s3-startup-check` | `OWLMAIL_S3_STARTUP_CHECK` | false | 最初の読み取り専用 S3 バケット確認に失敗した場合は起動を中止 |
+| `-s3-health-check-interval` | `OWLMAIL_S3_HEALTH_CHECK_INTERVAL` | 30s | バックグラウンド S3 readiness 確認間隔 |
+| `-s3-health-check-timeout` | `OWLMAIL_S3_HEALTH_CHECK_TIMEOUT` | 5s | 各 S3 readiness 確認のタイムアウト |
 | `-web-user` | `MAILDEV_WEB_USER` / `OWLMAIL_WEB_USER` | - | HTTP Basic Auth username |
 | `-web-password` | `MAILDEV_WEB_PASS` / `OWLMAIL_WEB_PASSWORD` | - | HTTP Basic Auth password |
 | `-https` | `MAILDEV_HTTPS` / `OWLMAIL_HTTPS_ENABLED` | false | Enable HTTPS |

--- a/README.ko.md
+++ b/README.ko.md
@@ -213,6 +213,9 @@ docker buildx build \
 | `-s3-secret-key` | `OWLMAIL_S3_SECRET_KEY` | - | 선택적 정적 시크릿 키 |
 | `-s3-session-token` | `OWLMAIL_S3_SESSION_TOKEN` | - | 선택적 세션 토큰 |
 | `-s3-use-path-style` | `OWLMAIL_S3_USE_PATH_STYLE` | false | 경로 스타일 버킷 주소 사용 |
+| `-s3-startup-check` | `OWLMAIL_S3_STARTUP_CHECK` | false | 최초 읽기 전용 S3 버킷 확인 실패 시 시작 중단 |
+| `-s3-health-check-interval` | `OWLMAIL_S3_HEALTH_CHECK_INTERVAL` | 30s | 백그라운드 S3 readiness 확인 간격 |
+| `-s3-health-check-timeout` | `OWLMAIL_S3_HEALTH_CHECK_TIMEOUT` | 5s | 각 S3 readiness 확인 제한 시간 |
 | `-web-user` | `MAILDEV_WEB_USER` / `OWLMAIL_WEB_USER` | - | HTTP Basic Auth username |
 | `-web-password` | `MAILDEV_WEB_PASS` / `OWLMAIL_WEB_PASSWORD` | - | HTTP Basic Auth password |
 | `-https` | `MAILDEV_HTTPS` / `OWLMAIL_HTTPS_ENABLED` | false | Enable HTTPS |

--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ the message body; clicking one focuses OwlMail and opens the message.
 | `-s3-secret-key` | `OWLMAIL_S3_SECRET_KEY` | - | Optional static secret key |
 | `-s3-session-token` | `OWLMAIL_S3_SESSION_TOKEN` | - | Optional static credential session token |
 | `-s3-use-path-style` | `OWLMAIL_S3_USE_PATH_STYLE` | false | Use path-style bucket addressing for compatible services |
+| `-s3-startup-check` | `OWLMAIL_S3_STARTUP_CHECK` | false | Fail startup if the initial read-only S3 bucket check fails |
+| `-s3-health-check-interval` | `OWLMAIL_S3_HEALTH_CHECK_INTERVAL` | 30s | Background S3 readiness refresh interval |
+| `-s3-health-check-timeout` | `OWLMAIL_S3_HEALTH_CHECK_TIMEOUT` | 5s | Deadline for each S3 readiness probe |
 | `-web-user` | `MAILDEV_WEB_USER` / `OWLMAIL_WEB_USER` | - | HTTP Basic Auth username |
 | `-web-password` | `MAILDEV_WEB_PASS` / `OWLMAIL_WEB_PASSWORD` | - | HTTP Basic Auth password |
 | `-https` | `MAILDEV_HTTPS` / `OWLMAIL_HTTPS_ENABLED` | false | Enable HTTPS |
@@ -319,6 +322,8 @@ export OWLMAIL_S3_PREFIX=owlmail/attachments
 export OWLMAIL_S3_ACCESS_KEY=replace-me
 export OWLMAIL_S3_SECRET_KEY=replace-me
 export OWLMAIL_S3_USE_PATH_STYLE=true
+# Optional: fail startup if the first HeadBucket check fails.
+export OWLMAIL_S3_STARTUP_CHECK=true
 ./owlmail -mail-directory ./owlmail-data
 ```
 
@@ -331,6 +336,15 @@ per-message fence and all local recovery evidence, then retries on the next
 request or startup; pending deletions are not republished. Upload must finish
 before SMTP accepts the message transaction. `OWLMAIL_MAIL_MAX_DISK_MB` measures
 local files and does not include S3 object bytes.
+
+OwlMail checks S3 with the read-only `HeadBucket` operation. By default the
+initial check runs asynchronously: startup remains compatible, while
+`GET /readyz` and `GET /api/v1/ready` return `503` until a check succeeds.
+Set `OWLMAIL_S3_STARTUP_CHECK=true` to make only the initial check fatal.
+Subsequent S3 outages never terminate the process; they make readiness fail
+until a background check recovers. Readiness requests return the cached result
+and never wait on S3. Liveness remains available at `/healthz` and
+`/api/v1/health`.
 
 ## 📡 API Documentation
 
@@ -411,7 +425,8 @@ the [API reference](./docs/en/API-Reference.md#maildev-migration-boundary).
 #### Configuration and System
 
 - `GET /config` - Get configuration information
-- `GET /healthz` - Health check
+- `GET /healthz` - Process liveness check
+- `GET /readyz` - Cached dependency readiness check
 - `GET /reloadMailsFromDirectory` - Reload emails from directory
 - `GET /socket.io` - WebSocket connection (standard WebSocket, not Socket.IO)
 
@@ -459,7 +474,8 @@ OwlMail provides a more standardized RESTful API design:
 - `GET /api/v1/settings/outgoing` - Get outgoing configuration
 - `PUT /api/v1/settings/outgoing` - Update outgoing configuration
 - `PATCH /api/v1/settings/outgoing` - Partially update outgoing configuration
-- `GET /api/v1/health` - Health check
+- `GET /api/v1/health` - Process liveness check
+- `GET /api/v1/ready` - Cached dependency readiness check
 - `GET /api/v1/version` - Version info
 - `GET /api/v1/ws` - WebSocket connection
 

--- a/README.md
+++ b/README.md
@@ -337,7 +337,8 @@ request or startup; pending deletions are not republished. Upload must finish
 before SMTP accepts the message transaction. `OWLMAIL_MAIL_MAX_DISK_MB` measures
 local files and does not include S3 object bytes.
 
-OwlMail checks S3 with the read-only `HeadBucket` operation. By default the
+OwlMail prefers the read-only `HeadBucket` operation and falls back to a
+one-key, prefix-scoped `ListObjectsV2` check for least-privilege policies. By default the
 initial check runs asynchronously: startup remains compatible, while
 `GET /readyz` and `GET /api/v1/ready` return `503` until a check succeeds.
 Set `OWLMAIL_S3_STARTUP_CHECK=true` to make only the initial check fatal.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -323,7 +323,8 @@ export OWLMAIL_S3_STARTUP_CHECK=true
 该邮件对应的对象前缀。只有附件上传完成后 SMTP 才会接受本次邮件事务。
 `OWLMAIL_MAIL_MAX_DISK_MB` 只统计本地文件，不包含 S3 对象占用。
 
-OwlMail 使用只读 `HeadBucket` 探测 S3。默认异步执行首次探测，以保持既有启动行为；
+OwlMail 优先使用只读 `HeadBucket` 探测 S3；若最小权限策略不允许 bucket 级探测，
+则回退到最多读取一个键、限定附件前缀的 `ListObjectsV2`。默认异步执行首次探测，以保持既有启动行为；
 在探测成功前，`GET /readyz` 与 `GET /api/v1/ready` 返回 `503`。设置
 `OWLMAIL_S3_STARTUP_CHECK=true` 后，仅首次探测失败会终止启动。运行期间 S3
 暂时不可用只会让 readiness 失败，不会使进程退出；后台探测恢复后 readiness

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -230,6 +230,9 @@ Notifications API 需要 HTTPS，或 `http://localhost` 等受信任的本地来
 | `-s3-secret-key` | `OWLMAIL_S3_SECRET_KEY` | - | 可选静态秘密密钥 |
 | `-s3-session-token` | `OWLMAIL_S3_SESSION_TOKEN` | - | 可选静态凭据会话令牌 |
 | `-s3-use-path-style` | `OWLMAIL_S3_USE_PATH_STYLE` | false | 为兼容服务使用路径式存储桶寻址 |
+| `-s3-startup-check` | `OWLMAIL_S3_STARTUP_CHECK` | false | 首次只读 S3 存储桶探测失败时终止启动 |
+| `-s3-health-check-interval` | `OWLMAIL_S3_HEALTH_CHECK_INTERVAL` | 30s | 后台刷新 S3 readiness 的间隔 |
+| `-s3-health-check-timeout` | `OWLMAIL_S3_HEALTH_CHECK_TIMEOUT` | 5s | 单次 S3 readiness 探测超时 |
 | `-web-user` | `MAILDEV_WEB_USER` / `OWLMAIL_WEB_USER` | - | HTTP Basic Auth 用户名 |
 | `-web-password` | `MAILDEV_WEB_PASS` / `OWLMAIL_WEB_PASSWORD` | - | HTTP Basic Auth 密码 |
 | `-https` | `MAILDEV_HTTPS` / `OWLMAIL_HTTPS_ENABLED` | false | 启用 HTTPS |
@@ -309,6 +312,8 @@ export OWLMAIL_S3_PREFIX=owlmail/attachments
 export OWLMAIL_S3_ACCESS_KEY=replace-me
 export OWLMAIL_S3_SECRET_KEY=replace-me
 export OWLMAIL_S3_USE_PATH_STYLE=true
+# 可选：首次 HeadBucket 失败时终止启动
+export OWLMAIL_S3_STARTUP_CHECK=true
 ./owlmail -mail-directory ./owlmail-data
 ```
 
@@ -317,6 +322,13 @@ export OWLMAIL_S3_USE_PATH_STYLE=true
 `<prefix>/<email-id>/<generated-filename>`；删除邮件和执行保留策略时，会同步删除
 该邮件对应的对象前缀。只有附件上传完成后 SMTP 才会接受本次邮件事务。
 `OWLMAIL_MAIL_MAX_DISK_MB` 只统计本地文件，不包含 S3 对象占用。
+
+OwlMail 使用只读 `HeadBucket` 探测 S3。默认异步执行首次探测，以保持既有启动行为；
+在探测成功前，`GET /readyz` 与 `GET /api/v1/ready` 返回 `503`。设置
+`OWLMAIL_S3_STARTUP_CHECK=true` 后，仅首次探测失败会终止启动。运行期间 S3
+暂时不可用只会让 readiness 失败，不会使进程退出；后台探测恢复后 readiness
+自动恢复。readiness 请求只读取缓存，不会同步等待 S3。`/healthz` 和
+`/api/v1/health` 始终用于进程 liveness。
 
 ## 📡 API 文档
 
@@ -396,7 +408,8 @@ API 的精确等价实现；差异见 [API 参考](./docs/zh-CN/API-Reference.md
 #### 配置和系统
 
 - `GET /config` - 获取配置信息
-- `GET /healthz` - 健康检查
+- `GET /healthz` - 进程存活检查
+- `GET /readyz` - 缓存的依赖 readiness 检查
 - `GET /reloadMailsFromDirectory` - 重新加载邮件目录
 - `GET /socket.io` - WebSocket 连接（标准 WebSocket，非 Socket.IO）
 
@@ -444,7 +457,8 @@ OwlMail 提供了更规范的 RESTful API 设计：
 - `GET /api/v1/settings/outgoing` - 获取出站配置
 - `PUT /api/v1/settings/outgoing` - 更新出站配置
 - `PATCH /api/v1/settings/outgoing` - 部分更新出站配置
-- `GET /api/v1/health` - 健康检查
+- `GET /api/v1/health` - 进程存活检查
+- `GET /api/v1/ready` - 缓存的依赖 readiness 检查
 - `GET /api/v1/version` - 版本信息
 - `GET /api/v1/ws` - WebSocket 连接
 

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -504,6 +504,12 @@ func createMailServer(cfg *config.Config) (*mailserver.MailServer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create mail server: %w", err)
 	}
+	if attachmentHealth != nil {
+		if err := server.AddCloser(attachmentHealth); err != nil {
+			_ = server.Close()
+			return nil, fmt.Errorf("register attachment health monitor: %w", err)
+		}
+	}
 	healthOwned = false
 	storagePolicy, err := setupStoragePolicy(cfg)
 	if err != nil {

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -165,6 +165,36 @@ func setupAttachmentStore(cfg *config.Config) (attachmentstore.Store, error) {
 	return store, nil
 }
 
+func setupAttachmentHealth(store attachmentstore.Store, cfg *config.Config) (*attachmentstore.HealthMonitor, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config is nil")
+	}
+	if store == nil {
+		return nil, nil
+	}
+	interval, err := time.ParseDuration(cfg.S3HealthInterval)
+	if err != nil || interval <= 0 {
+		return nil, fmt.Errorf("invalid S3 health check interval")
+	}
+	timeout, err := time.ParseDuration(cfg.S3HealthTimeout)
+	if err != nil || timeout <= 0 {
+		return nil, fmt.Errorf("invalid S3 health check timeout")
+	}
+	monitor, err := attachmentstore.NewHealthMonitor(store, interval, timeout)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.S3StartupCheck {
+		status := monitor.ProbeNow(context.Background())
+		if !status.Ready() {
+			_ = monitor.Close()
+			return nil, fmt.Errorf("S3 startup check failed: %s", status.ErrorCategory)
+		}
+	}
+	monitor.Start(context.Background())
+	return monitor, nil
+}
+
 func setupStoragePolicy(cfg *config.Config) (mailserver.StoragePolicy, error) {
 	if cfg == nil {
 		return mailserver.StoragePolicy{}, fmt.Errorf("config is nil")
@@ -434,6 +464,20 @@ func createMailServer(cfg *config.Config) (*mailserver.MailServer, error) {
 	if err != nil {
 		return nil, err
 	}
+	attachmentHealth, err := setupAttachmentHealth(attachmentStore, cfg)
+	if err != nil {
+		return nil, err
+	}
+	healthOwned := attachmentHealth != nil
+	defer func() {
+		if healthOwned {
+			_ = attachmentHealth.Close()
+		}
+	}()
+	var healthProvider attachmentstore.ReadinessProvider
+	if attachmentHealth != nil {
+		healthProvider = attachmentHealth
+	}
 	maxMessageMB := cfg.SMTPMaxMessageMB
 	if maxMessageMB == 0 {
 		maxMessageMB = config.DefaultSMTPMaxMessageMB
@@ -448,17 +492,19 @@ func createMailServer(cfg *config.Config) (*mailserver.MailServer, error) {
 
 	// Create mail server
 	server, err := mailserver.NewMailServerWithOptions(cfg.SMTPPort, cfg.SMTPHost, cfg.MailDir, mailserver.ServerOptions{
-		OutgoingConfig:  outgoingConfig,
-		AuthConfig:      authConfig,
-		AuthRequireTLS:  cfg.SMTPAuthRequireTLS,
-		TLSConfig:       tlsConfig,
-		UseUUIDForID:    cfg.UseUUIDForEmailID,
-		MaxMessageBytes: int64(maxMessageMB) << 20,
-		AttachmentStore: attachmentStore,
+		OutgoingConfig:   outgoingConfig,
+		AuthConfig:       authConfig,
+		AuthRequireTLS:   cfg.SMTPAuthRequireTLS,
+		TLSConfig:        tlsConfig,
+		UseUUIDForID:     cfg.UseUUIDForEmailID,
+		MaxMessageBytes:  int64(maxMessageMB) << 20,
+		AttachmentStore:  attachmentStore,
+		AttachmentHealth: healthProvider,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create mail server: %w", err)
 	}
+	healthOwned = false
 	storagePolicy, err := setupStoragePolicy(cfg)
 	if err != nil {
 		_ = server.Close()
@@ -469,7 +515,7 @@ func createMailServer(cfg *config.Config) (*mailserver.MailServer, error) {
 		return nil, fmt.Errorf("configure storage policy: %w", err)
 	}
 	if attachmentStore != nil {
-		common.Log("S3 attachment storage enabled for bucket %s with prefix %s", cfg.S3Bucket, cfg.S3Prefix)
+		common.Log("S3 attachment storage enabled for bucket %s with prefix %s (startup check: %t)", cfg.S3Bucket, cfg.S3Prefix, cfg.S3StartupCheck)
 	}
 
 	// Register event handlers

--- a/cmd/owlmail/main_test.go
+++ b/cmd/owlmail/main_test.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -15,6 +18,7 @@ import (
 
 	"github.com/emersion/go-message/mail"
 	"github.com/soulteary/cli-kit/testutil"
+	"github.com/soulteary/owlmail/internal/attachmentstore"
 	"github.com/soulteary/owlmail/internal/common"
 	"github.com/soulteary/owlmail/internal/config"
 	"github.com/soulteary/owlmail/internal/mailserver"
@@ -960,6 +964,57 @@ func TestSetupAttachmentStore(t *testing.T) {
 	if err != nil || store == nil {
 		t.Fatalf("enabled setupAttachmentStore() = %#v, %v", store, err)
 	}
+}
+
+type healthTestStore struct {
+	healthErr error
+}
+
+func (store *healthTestStore) Put(context.Context, string, string, string, io.Reader, int64) error {
+	return nil
+}
+func (store *healthTestStore) Open(context.Context, string, string) (*attachmentstore.Object, error) {
+	return nil, errors.New("not implemented")
+}
+func (store *healthTestStore) DeleteEmail(context.Context, string) error { return nil }
+func (store *healthTestStore) CheckHealth(context.Context) error         { return store.healthErr }
+
+func TestSetupAttachmentHealthStrictAndCompatibleModes(t *testing.T) {
+	if _, err := setupAttachmentHealth(nil, nil); err == nil {
+		t.Fatal("nil config should fail")
+	}
+	cfg := config.DefaultConfig()
+	if monitor, err := setupAttachmentHealth(nil, cfg); err != nil || monitor != nil {
+		t.Fatalf("disabled health setup = %#v, %v", monitor, err)
+	}
+
+	store := &healthTestStore{healthErr: errors.New("https://access:secret@example.test?token=private")}
+	monitor, err := setupAttachmentHealth(store, cfg)
+	if err != nil {
+		t.Fatalf("default non-strict setup failed: %v", err)
+	}
+	if monitor == nil {
+		t.Fatal("default non-strict setup did not create a monitor")
+	}
+	_ = monitor.Close()
+
+	cfg.S3StartupCheck = true
+	_, err = setupAttachmentHealth(store, cfg)
+	if err == nil || !strings.Contains(err.Error(), "unknown") {
+		t.Fatalf("strict setup error = %v", err)
+	}
+	for _, secret := range []string{"access", "secret", "example.test", "private"} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("strict startup error leaked %q: %v", secret, err)
+		}
+	}
+
+	store.healthErr = nil
+	monitor, err = setupAttachmentHealth(store, cfg)
+	if err != nil || monitor == nil {
+		t.Fatalf("successful strict setup = %#v, %v", monitor, err)
+	}
+	_ = monitor.Close()
 }
 
 func TestCreateMailServerRejectsNegativeMessageLimit(t *testing.T) {

--- a/docs/en/API-Reference.md
+++ b/docs/en/API-Reference.md
@@ -147,8 +147,30 @@ reported in process logs after the HTTP response.
 | `PUT /api/v1/settings/outgoing` | replace outgoing SMTP settings |
 | `PATCH /api/v1/settings/outgoing` | update selected outgoing SMTP fields |
 | `GET /api/v1/health` | unauthenticated liveness check |
+| `GET /api/v1/ready` | unauthenticated cached dependency readiness check |
 | `GET /api/v1/version` | build/version information |
 | `GET /api/v1/ws` | native WebSocket endpoint |
+
+The liveness response is independent of remote storage. Readiness returns
+HTTP `200` only when every enabled dependency is ready and HTTP `503` while the
+cached S3 probe is checking or failing:
+
+```json
+{
+  "status": "unready",
+  "checks": {
+    "attachment_store": {
+      "status": "unready",
+      "error_category": "permission",
+      "checked_at": "2026-09-02T05:45:00Z"
+    }
+  }
+}
+```
+
+The response never includes raw SDK errors, endpoints, access keys, secret
+keys, or session tokens. A readiness request reads a background-refreshed cache
+and does not synchronously contact S3.
 
 A release build returns version provenance similar to:
 
@@ -226,6 +248,7 @@ for existing OwlMail integrations. Prefer `/api/v1` for new code.
 | `PUT /config/outgoing` | `PUT /api/v1/settings/outgoing` |
 | `PATCH /config/outgoing` | `PATCH /api/v1/settings/outgoing` |
 | `GET /healthz` | `GET /api/v1/health` |
+| `GET /readyz` | `GET /api/v1/ready` |
 | `GET /reloadMailsFromDirectory` | reload the configured mail directory |
 
 ## WebSocket protocol

--- a/docs/en/Operations.md
+++ b/docs/en/Operations.md
@@ -122,7 +122,9 @@ uses `/healthz` for this reason.
 
 `GET /readyz` and `GET /api/v1/ready` are readiness checks. With local
 attachment storage they return ready immediately. With S3 enabled, OwlMail
-runs a read-only `HeadBucket` probe in the background, caches the latest result,
+runs a read-only `HeadBucket` probe in the background. If a least-privilege
+policy rejects the bucket-wide operation, it falls back to `ListObjectsV2`
+scoped to the attachment prefix and `MaxKeys=1`. OwlMail caches the latest result
 and refreshes it every 30 seconds by default. Each probe has a five-second
 deadline. An HTTP readiness request only reads that cache; it never performs or
 waits for a remote S3 request.

--- a/docs/en/Operations.md
+++ b/docs/en/Operations.md
@@ -41,7 +41,7 @@ process-specific temporary directory `owlmail-<pid>` while parsed state is held
 in memory. That location is not a durable archive. This profile is intended for
 one developer on a trusted machine.
 
-Readiness check:
+Liveness check:
 
 ```bash
 curl --fail http://localhost:1080/healthz
@@ -112,6 +112,53 @@ endpoint empty for AWS S3. Static credentials are optional: when omitted, the
 AWS SDK default credential chain is used, including environment credentials,
 shared configuration, and workload roles. Use path-style addressing only when
 the selected S3-compatible service requires it.
+
+### Liveness, readiness, and S3 startup policy
+
+`GET /healthz` and `GET /api/v1/health` are process liveness checks. They do
+not depend on S3, so a temporary object-storage outage does not create a
+container restart loop. The image's built-in Docker healthcheck intentionally
+uses `/healthz` for this reason.
+
+`GET /readyz` and `GET /api/v1/ready` are readiness checks. With local
+attachment storage they return ready immediately. With S3 enabled, OwlMail
+runs a read-only `HeadBucket` probe in the background, caches the latest result,
+and refreshes it every 30 seconds by default. Each probe has a five-second
+deadline. An HTTP readiness request only reads that cache; it never performs or
+waits for a remote S3 request.
+
+```bash
+OWLMAIL_S3_STARTUP_CHECK=false \
+OWLMAIL_S3_HEALTH_CHECK_INTERVAL=30s \
+OWLMAIL_S3_HEALTH_CHECK_TIMEOUT=5s \
+./owlmail
+```
+
+The default `OWLMAIL_S3_STARTUP_CHECK=false` preserves existing startup
+behavior. Readiness initially reports `checking` and HTTP `503`, then becomes
+ready after a successful probe. Set the option to `true` when deployment should
+fail fast on an invalid bucket, credentials, permissions, or network path. Only
+the initial failure terminates startup; any later outage changes readiness to
+`503` while liveness stays `200`, and the process recovers automatically after
+a successful background probe.
+
+Readiness output contains only the component status, probe timestamp, and one
+of the bounded categories `pending`, `permission`, `credentials`, `not_found`,
+`timeout`, `unavailable`, `unknown`, or `closed`. It never includes an SDK error,
+endpoint, access key, secret key, or session token.
+
+For Kubernetes, route restart and traffic decisions separately:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 1080
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: 1080
+```
 
 OwlMail streams attachments into local staging files, writes a durable rollback
 marker, uploads every object under `<prefix>/<email-id>/`, and only then commits

--- a/docs/zh-CN/API-Reference.md
+++ b/docs/zh-CN/API-Reference.md
@@ -140,6 +140,7 @@ curl -u admin:secret http://localhost:1080/api/v1/emails
 | `PUT /api/v1/settings/outgoing` | 整体替换出站 SMTP 设置 |
 | `PATCH /api/v1/settings/outgoing` | 更新部分出站 SMTP 字段 |
 | `GET /api/v1/health` | 无需鉴权的存活检查 |
+| `GET /api/v1/ready` | 无需鉴权、读取缓存的依赖 readiness 检查 |
 | `GET /api/v1/version` | 构建/版本信息 |
 | `GET /api/v1/ws` | 原生 WebSocket 端点 |
 
@@ -215,6 +216,7 @@ curl -u admin:secret \
 | `PUT /config/outgoing` | `PUT /api/v1/settings/outgoing` |
 | `PATCH /config/outgoing` | `PATCH /api/v1/settings/outgoing` |
 | `GET /healthz` | `GET /api/v1/health` |
+| `GET /readyz` | `GET /api/v1/ready` |
 | `GET /reloadMailsFromDirectory` | 重新加载已配置邮件目录 |
 
 ## WebSocket 协议

--- a/docs/zh-CN/Operations.md
+++ b/docs/zh-CN/Operations.md
@@ -36,7 +36,7 @@ EML 数据，避免再创建一个邮箱规模的内存缓冲区。
 原始邮件和附件写入当前进程专用的临时目录 `owlmail-<pid>`，解析后的状态保存在
 内存中；该目录不是持久归档。该档位适合可信机器上的单开发者场景。
 
-就绪检查：
+存活检查：
 
 ```bash
 curl --fail http://localhost:1080/healthz
@@ -92,6 +92,47 @@ OWLMAIL_S3_USE_PATH_STYLE=true \
 OwlMail 接收附件前，存储桶必须已经存在。endpoint 留空时使用 AWS S3。静态密钥
 可以不配置，此时使用 AWS SDK 默认凭据链，包括环境凭据、共享配置和工作负载角色。
 只有选定的 S3 兼容服务要求时，才开启路径式寻址。
+
+### Liveness、readiness 与 S3 启动策略
+
+`GET /healthz` 与 `GET /api/v1/health` 是进程 liveness 检查，不依赖 S3。
+因此对象存储暂时不可用时不会造成容器反复重启；镜像内置 Docker 健康检查也刻意
+使用 `/healthz`。
+
+`GET /readyz` 与 `GET /api/v1/ready` 是 readiness 检查。本地附件存储会立即
+返回 ready。启用 S3 后，OwlMail 在后台执行只读 `HeadBucket`，缓存最近结果，
+默认每 30 秒刷新一次，单次探测最多等待 5 秒。HTTP readiness 请求只读取缓存，
+不会同步访问或等待 S3。
+
+```bash
+OWLMAIL_S3_STARTUP_CHECK=false \
+OWLMAIL_S3_HEALTH_CHECK_INTERVAL=30s \
+OWLMAIL_S3_HEALTH_CHECK_TIMEOUT=5s \
+./owlmail
+```
+
+默认 `OWLMAIL_S3_STARTUP_CHECK=false`，保持已有启动兼容性：readiness 起初为
+`checking` 并返回 HTTP `503`，首次探测成功后转为 ready。若希望 bucket、凭据、
+权限或网络路径错误立即阻止部署，可将其设置为 `true`。只有首次失败会终止启动；
+运行期间 S3 故障只让 readiness 返回 `503`，liveness 仍为 `200`，后台探测成功后
+自动恢复。
+
+readiness 响应只包含组件状态、探测时间和 `pending`、`permission`、
+`credentials`、`not_found`、`timeout`、`unavailable`、`unknown`、`closed` 之一；
+不会包含 SDK 原始错误、endpoint、access key、secret key 或 session token。
+
+Kubernetes 应分别配置重启判断和流量接入：
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 1080
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: 1080
+```
 
 OwlMail 会把附件流式写入本地暂存文件并写入持久回滚标记，再把全部对象上传至
 `<prefix>/<email-id>/`，最后提交 `.eml` 标记。上传失败会拒绝 SMTP 事务并清理

--- a/docs/zh-CN/Operations.md
+++ b/docs/zh-CN/Operations.md
@@ -100,8 +100,9 @@ OwlMail 接收附件前，存储桶必须已经存在。endpoint 留空时使用
 使用 `/healthz`。
 
 `GET /readyz` 与 `GET /api/v1/ready` 是 readiness 检查。本地附件存储会立即
-返回 ready。启用 S3 后，OwlMail 在后台执行只读 `HeadBucket`，缓存最近结果，
-默认每 30 秒刷新一次，单次探测最多等待 5 秒。HTTP readiness 请求只读取缓存，
+返回 ready。启用 S3 后，OwlMail 在后台优先执行只读 `HeadBucket`；若最小权限策略
+拒绝 bucket 级操作，则回退到附件前缀下 `MaxKeys=1` 的 `ListObjectsV2`。最近结果会
+被缓存，默认每 30 秒刷新一次，单次探测最多等待 5 秒。HTTP readiness 请求只读取缓存，
 不会同步访问或等待 S3。
 
 ```bash

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	_ "github.com/emersion/go-message/charset"
 	"github.com/gofiber/fiber/v3"
@@ -12,6 +13,7 @@ import (
 	"github.com/gofiber/fiber/v3/middleware/cors"
 	"github.com/gorilla/websocket"
 	"github.com/soulteary/health-kit/v2"
+	"github.com/soulteary/owlmail/internal/attachmentstore"
 	"github.com/soulteary/owlmail/internal/mailserver"
 	"github.com/soulteary/owlmail/internal/types"
 	webassets "github.com/soulteary/owlmail/web"
@@ -114,7 +116,7 @@ func (api *API) setupRoutes() {
 
 	// HTTP Basic Auth middleware if configured
 	if authEnabled {
-		app.Use(basicAuthMiddleware(api.authUser, api.authPassword, "/healthz", "/api/v1/health"))
+		app.Use(basicAuthMiddleware(api.authUser, api.authPassword, "/healthz", "/readyz", "/api/v1/health", "/api/v1/ready"))
 	}
 
 	// Static files are embedded in the executable so the UI and help page work
@@ -153,6 +155,7 @@ func (api *API) setupRoutes() {
 		if strings.HasPrefix(path, "/email") ||
 			strings.HasPrefix(path, "/config") ||
 			strings.HasPrefix(path, "/healthz") ||
+			strings.HasPrefix(path, "/readyz") ||
 			strings.HasPrefix(path, "/socket.io") ||
 			strings.HasPrefix(path, "/api/") ||
 			strings.HasPrefix(path, "/style.css") ||
@@ -215,6 +218,7 @@ func (api *API) setupImprovedAPIRoutes(app *fiber.App) {
 
 	// Health check (adaptor for health-kit)
 	v1.Get("/health", adaptor.HTTPHandler(health.LivenessHandler("owlmail")))
+	v1.Get("/ready", api.readiness)
 	// Version info (adaptor for version-kit)
 	v1.Get("/version", adaptor.HTTPHandler(version.Handler()))
 	// WebSocket (adaptor for gorilla/websocket Upgrade)
@@ -290,7 +294,42 @@ func (api *API) setupMailDevCompatibleRoutes(app *fiber.App) {
 
 	// Health check route (MailDev compatible)
 	app.Get("/healthz", adaptor.HTTPHandler(health.LivenessHandler("owlmail")))
+	app.Get("/readyz", api.readiness)
 
 	// Reload mails from directory route (MailDev compatible)
 	app.Get("/reloadMailsFromDirectory", api.reloadMailsFromDirectory)
+}
+
+type readinessCheck struct {
+	Status        string                              `json:"status"`
+	ErrorCategory attachmentstore.HealthErrorCategory `json:"error_category,omitempty"`
+	CheckedAt     string                              `json:"checked_at,omitempty"`
+}
+
+type readinessResponse struct {
+	Status string                    `json:"status"`
+	Checks map[string]readinessCheck `json:"checks"`
+}
+
+func (api *API) readiness(c fiber.Ctx) error {
+	response := readinessResponse{
+		Status: "ready",
+		Checks: map[string]readinessCheck{
+			"attachment_store": {Status: "disabled"},
+		},
+	}
+	status, enabled := api.mailServer.GetAttachmentHealth()
+	if !enabled {
+		return c.Status(http.StatusOK).JSON(response)
+	}
+	check := readinessCheck{Status: string(status.State), ErrorCategory: status.ErrorCategory}
+	if !status.CheckedAt.IsZero() {
+		check.CheckedAt = status.CheckedAt.Format(time.RFC3339Nano)
+	}
+	response.Checks["attachment_store"] = check
+	if !status.Ready() {
+		response.Status = "unready"
+		return c.Status(http.StatusServiceUnavailable).JSON(response)
+	}
+	return c.Status(http.StatusOK).JSON(response)
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/soulteary/owlmail/internal/attachmentstore"
 	"github.com/soulteary/owlmail/internal/mailserver"
 	"github.com/soulteary/owlmail/internal/types"
 )
@@ -124,6 +125,53 @@ func TestAPIHealthCheck(t *testing.T) {
 	}
 	if response["service"] != "owlmail" {
 		t.Errorf("Expected service 'owlmail', got '%v'", response["service"])
+	}
+}
+
+type staticReadinessProvider struct {
+	status attachmentstore.HealthStatus
+}
+
+func (provider staticReadinessProvider) Snapshot() attachmentstore.HealthStatus {
+	return provider.status
+}
+
+func TestAPIReadinessUsesCachedStoreHealthWithoutAffectingLiveness(t *testing.T) {
+	server, err := mailserver.NewMailServerWithOptions(1025, "localhost", t.TempDir(), mailserver.ServerOptions{
+		AttachmentHealth: staticReadinessProvider{status: attachmentstore.HealthStatus{
+			State: attachmentstore.HealthUnready, ErrorCategory: attachmentstore.HealthErrorPermission,
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	api := NewAPI(server, 1080, "localhost")
+
+	for _, path := range []string{"/readyz", "/api/v1/ready"} {
+		req, _ := http.NewRequest(http.MethodGet, path, nil)
+		resp, requestErr := api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
+		if requestErr != nil {
+			t.Fatal(requestErr)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			t.Fatalf("%s status = %d, body = %s", path, resp.StatusCode, body)
+		}
+		if !strings.Contains(string(body), `"error_category":"permission"`) || strings.Contains(string(body), "secret") || strings.Contains(string(body), "endpoint") || strings.Contains(string(body), "token") {
+			t.Fatalf("unsafe or incomplete readiness response: %s", body)
+		}
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "/healthz", nil)
+	resp, err := api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("liveness status = %d", resp.StatusCode)
 	}
 }
 

--- a/internal/attachmentstore/health.go
+++ b/internal/attachmentstore/health.go
@@ -1,0 +1,221 @@
+package attachmentstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"time"
+)
+
+// HealthState is the cached availability state of an attachment store.
+type HealthState string
+
+const (
+	HealthChecking HealthState = "checking"
+	HealthReady    HealthState = "ready"
+	HealthUnready  HealthState = "unready"
+	HealthClosed   HealthState = "closed"
+)
+
+// HealthErrorCategory is a safe, bounded classification for probe failures.
+// Raw SDK errors are deliberately kept out of readiness responses.
+type HealthErrorCategory string
+
+const (
+	HealthErrorNone        HealthErrorCategory = ""
+	HealthErrorPending     HealthErrorCategory = "pending"
+	HealthErrorPermission  HealthErrorCategory = "permission"
+	HealthErrorCredentials HealthErrorCategory = "credentials"
+	HealthErrorNotFound    HealthErrorCategory = "not_found"
+	HealthErrorTimeout     HealthErrorCategory = "timeout"
+	HealthErrorUnavailable HealthErrorCategory = "unavailable"
+	HealthErrorUnknown     HealthErrorCategory = "unknown"
+	HealthErrorClosed      HealthErrorCategory = "closed"
+)
+
+// HealthStatus is safe to expose through operational readiness endpoints.
+type HealthStatus struct {
+	State         HealthState         `json:"status"`
+	ErrorCategory HealthErrorCategory `json:"error_category,omitempty"`
+	CheckedAt     time.Time           `json:"checked_at,omitempty"`
+}
+
+// Ready reports whether the most recent cached probe succeeded.
+func (status HealthStatus) Ready() bool {
+	return status.State == HealthReady
+}
+
+// ReadinessProvider supplies cached health without performing remote I/O.
+type ReadinessProvider interface {
+	Snapshot() HealthStatus
+}
+
+// HealthMonitor probes a Store in the background and caches the most recent
+// result. Snapshot never performs remote I/O.
+type HealthMonitor struct {
+	store    Store
+	interval time.Duration
+	timeout  time.Duration
+
+	mu      sync.RWMutex
+	status  HealthStatus
+	started bool
+	closed  bool
+	cancel  context.CancelFunc
+	done    chan struct{}
+	probeMu sync.Mutex
+}
+
+// NewHealthMonitor builds a stopped monitor. Start begins the initial
+// asynchronous probe; ProbeNow can be used first for strict startup checks.
+func NewHealthMonitor(store Store, interval, timeout time.Duration) (*HealthMonitor, error) {
+	if store == nil {
+		return nil, fmt.Errorf("attachment store cannot be nil")
+	}
+	if interval <= 0 {
+		return nil, fmt.Errorf("attachment health interval must be positive")
+	}
+	if timeout <= 0 {
+		return nil, fmt.Errorf("attachment health timeout must be positive")
+	}
+	return &HealthMonitor{
+		store: store, interval: interval, timeout: timeout,
+		status: HealthStatus{State: HealthChecking, ErrorCategory: HealthErrorPending},
+		done:   make(chan struct{}),
+	}, nil
+}
+
+// Start begins background probes. It is safe to call more than once.
+func (monitor *HealthMonitor) Start(parent context.Context) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	monitor.mu.Lock()
+	if monitor.started || monitor.closed {
+		monitor.mu.Unlock()
+		return
+	}
+	ctx, cancel := context.WithCancel(parent)
+	monitor.started = true
+	monitor.cancel = cancel
+	monitor.mu.Unlock()
+	go monitor.run(ctx)
+}
+
+func (monitor *HealthMonitor) run(ctx context.Context) {
+	defer close(monitor.done)
+	monitor.probe(ctx)
+	ticker := time.NewTicker(monitor.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			monitor.probe(ctx)
+		}
+	}
+}
+
+// ProbeNow performs one bounded probe and updates the cache. Startup code uses
+// this method only when the explicit strict-startup option is enabled.
+func (monitor *HealthMonitor) ProbeNow(parent context.Context) HealthStatus {
+	if parent == nil {
+		parent = context.Background()
+	}
+	return monitor.probe(parent)
+}
+
+func (monitor *HealthMonitor) probe(parent context.Context) HealthStatus {
+	monitor.probeMu.Lock()
+	defer monitor.probeMu.Unlock()
+
+	ctx, cancel := context.WithTimeout(parent, monitor.timeout)
+	err := monitor.store.CheckHealth(ctx)
+	cancel()
+	status := HealthStatus{State: HealthReady, CheckedAt: time.Now().UTC()}
+	if err != nil {
+		status.State = HealthUnready
+		status.ErrorCategory = classifyHealthError(err)
+	}
+	monitor.mu.Lock()
+	if !monitor.closed {
+		monitor.status = status
+	}
+	monitor.mu.Unlock()
+	return status
+}
+
+// Snapshot returns the most recent cached result without remote I/O.
+func (monitor *HealthMonitor) Snapshot() HealthStatus {
+	monitor.mu.RLock()
+	defer monitor.mu.RUnlock()
+	return monitor.status
+}
+
+// Close cancels an in-flight probe and stops future probes.
+func (monitor *HealthMonitor) Close() error {
+	monitor.mu.Lock()
+	if monitor.closed {
+		monitor.mu.Unlock()
+		return nil
+	}
+	monitor.closed = true
+	cancel := monitor.cancel
+	started := monitor.started
+	monitor.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if started {
+		<-monitor.done
+	}
+	monitor.mu.Lock()
+	monitor.status = HealthStatus{
+		State: HealthClosed, ErrorCategory: HealthErrorClosed, CheckedAt: time.Now().UTC(),
+	}
+	monitor.mu.Unlock()
+	return nil
+}
+
+type codedError interface {
+	ErrorCode() string
+}
+
+func classifyHealthError(err error) HealthErrorCategory {
+	if err == nil {
+		return HealthErrorNone
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return HealthErrorTimeout
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		if netErr.Timeout() {
+			return HealthErrorTimeout
+		}
+		return HealthErrorUnavailable
+	}
+	var apiErr codedError
+	if errors.As(err, &apiErr) {
+		switch strings.ToLower(apiErr.ErrorCode()) {
+		case "accessdenied", "forbidden", "allaccessdisabled":
+			return HealthErrorPermission
+		case "invalidaccesskeyid", "signaturedoesnotmatch", "expiredtoken", "invalidtoken", "tokenrefreshrequired", "requesttimetoolskewed":
+			return HealthErrorCredentials
+		case "nosuchbucket", "notfound":
+			return HealthErrorNotFound
+		case "requesttimeout", "requesttimeoutexception":
+			return HealthErrorTimeout
+		case "internalerror", "serviceunavailable", "slowdown":
+			return HealthErrorUnavailable
+		}
+	}
+	if errors.Is(err, context.Canceled) {
+		return HealthErrorUnavailable
+	}
+	return HealthErrorUnknown
+}

--- a/internal/attachmentstore/s3.go
+++ b/internal/attachmentstore/s3.go
@@ -26,10 +26,21 @@ type S3Config struct {
 }
 
 type s3Client interface {
+	HeadBucket(context.Context, *s3.HeadBucketInput, ...func(*s3.Options)) (*s3.HeadBucketOutput, error)
 	PutObject(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error)
 	GetObject(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error)
 	ListObjectsV2(context.Context, *s3.ListObjectsV2Input, ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
 	DeleteObject(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+}
+
+// CheckHealth verifies that the configured credentials can address the bucket.
+// HeadBucket is read-only and does not create, mutate, or enumerate objects.
+func (store *S3Store) CheckHealth(ctx context.Context) error {
+	_, err := store.client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: aws.String(store.bucket)})
+	if err != nil {
+		return fmt.Errorf("check S3 bucket: %w", err)
+	}
+	return nil
 }
 
 // S3Store stores attachments as <prefix>/<email-id>/<generated-filename>.

--- a/internal/attachmentstore/s3.go
+++ b/internal/attachmentstore/s3.go
@@ -34,11 +34,25 @@ type s3Client interface {
 }
 
 // CheckHealth verifies that the configured credentials can address the bucket.
-// HeadBucket is read-only and does not create, mutate, or enumerate objects.
+// HeadBucket is preferred. A bounded prefix-scoped ListObjectsV2 fallback
+// supports least-privilege policies that deny bucket-wide HeadBucket while
+// permitting OwlMail's actual attachment prefix.
 func (store *S3Store) CheckHealth(ctx context.Context) error {
 	_, err := store.client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: aws.String(store.bucket)})
-	if err != nil {
-		return fmt.Errorf("check S3 bucket: %w", err)
+	if err == nil {
+		return nil
+	}
+	prefix := store.prefix
+	if prefix != "" {
+		prefix += "/"
+	}
+	_, fallbackErr := store.client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+		Bucket:  aws.String(store.bucket),
+		Prefix:  aws.String(prefix),
+		MaxKeys: aws.Int32(1),
+	})
+	if fallbackErr != nil {
+		return fmt.Errorf("check S3 attachment prefix: %w", fallbackErr)
 	}
 	return nil
 }

--- a/internal/attachmentstore/s3_test.go
+++ b/internal/attachmentstore/s3_test.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"io"
 	"sort"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -20,6 +22,7 @@ type fakeS3Client struct {
 	getErr       error
 	listErr      error
 	deleteErr    error
+	headBucket   func(context.Context) error
 }
 
 func newFakeS3Client() *fakeS3Client {
@@ -27,6 +30,15 @@ func newFakeS3Client() *fakeS3Client {
 		objects:      make(map[string][]byte),
 		contentTypes: make(map[string]string),
 	}
+}
+
+func (client *fakeS3Client) HeadBucket(ctx context.Context, _ *s3.HeadBucketInput, _ ...func(*s3.Options)) (*s3.HeadBucketOutput, error) {
+	if client.headBucket != nil {
+		if err := client.headBucket(ctx); err != nil {
+			return nil, err
+		}
+	}
+	return &s3.HeadBucketOutput{}, nil
 }
 
 func (client *fakeS3Client) PutObject(_ context.Context, input *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
@@ -184,4 +196,117 @@ func TestNewS3ValidatesRequiredConfiguration(t *testing.T) {
 	if _, err := NewS3(ctx, S3Config{Region: "us-east-1", Bucket: "bucket", AccessKeyID: "access", SecretAccessKey: "secret"}); err != nil {
 		t.Fatalf("NewS3() valid static configuration error = %v", err)
 	}
+}
+
+type fakeS3APIError struct {
+	code string
+	text string
+}
+
+func (err fakeS3APIError) Error() string     { return err.text }
+func (err fakeS3APIError) ErrorCode() string { return err.code }
+
+func TestS3HealthProbeSuccessAndPermissionFailure(t *testing.T) {
+	client := newFakeS3Client()
+	store := newS3Store(client, "mail-bucket", "attachments")
+	monitor, err := NewHealthMonitor(store, time.Minute, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if status := monitor.ProbeNow(context.Background()); !status.Ready() || status.ErrorCategory != HealthErrorNone {
+		t.Fatalf("successful health status = %#v", status)
+	}
+	client.headBucket = func(context.Context) error {
+		return fakeS3APIError{code: "AccessDenied", text: "secret endpoint and token must not escape"}
+	}
+	status := monitor.ProbeNow(context.Background())
+	if status.Ready() || status.ErrorCategory != HealthErrorPermission {
+		t.Fatalf("permission health status = %#v", status)
+	}
+}
+
+func TestS3HealthProbeTimeout(t *testing.T) {
+	client := newFakeS3Client()
+	client.headBucket = func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	monitor, err := NewHealthMonitor(newS3Store(client, "bucket", ""), time.Minute, 10*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	status := monitor.ProbeNow(context.Background())
+	if status.Ready() || status.ErrorCategory != HealthErrorTimeout {
+		t.Fatalf("timeout health status = %#v", status)
+	}
+}
+
+func TestS3HealthMonitorRecovers(t *testing.T) {
+	client := newFakeS3Client()
+	var unavailable atomic.Bool
+	unavailable.Store(true)
+	client.headBucket = func(context.Context) error {
+		if unavailable.Load() {
+			return fakeS3APIError{code: "ServiceUnavailable", text: "temporary outage"}
+		}
+		return nil
+	}
+	monitor, err := NewHealthMonitor(newS3Store(client, "bucket", ""), 5*time.Millisecond, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	monitor.Start(context.Background())
+	defer func() { _ = monitor.Close() }()
+	waitForHealthState(t, monitor, HealthUnready)
+	unavailable.Store(false)
+	waitForHealthState(t, monitor, HealthReady)
+}
+
+func TestS3HealthMonitorCloseCancelsProbeAndStopsRefresh(t *testing.T) {
+	client := newFakeS3Client()
+	entered := make(chan struct{}, 1)
+	var calls atomic.Int64
+	client.headBucket = func(ctx context.Context) error {
+		calls.Add(1)
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	monitor, err := NewHealthMonitor(newS3Store(client, "bucket", ""), 5*time.Millisecond, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	monitor.Start(context.Background())
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("background health probe did not start")
+	}
+	if err := monitor.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if status := monitor.Snapshot(); status.State != HealthClosed || status.ErrorCategory != HealthErrorClosed {
+		t.Fatalf("closed health status = %#v", status)
+	}
+	count := calls.Load()
+	time.Sleep(20 * time.Millisecond)
+	if calls.Load() != count {
+		t.Fatal("health probes continued after Close")
+	}
+}
+
+func waitForHealthState(t *testing.T, monitor *HealthMonitor, want HealthState) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if monitor.Snapshot().State == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("health state = %q, want %q", monitor.Snapshot().State, want)
 }

--- a/internal/attachmentstore/s3_test.go
+++ b/internal/attachmentstore/s3_test.go
@@ -23,6 +23,7 @@ type fakeS3Client struct {
 	listErr      error
 	deleteErr    error
 	headBucket   func(context.Context) error
+	listObjects  func(context.Context, *s3.ListObjectsV2Input) error
 }
 
 func newFakeS3Client() *fakeS3Client {
@@ -69,7 +70,15 @@ func (client *fakeS3Client) GetObject(_ context.Context, input *s3.GetObjectInpu
 	}, nil
 }
 
-func (client *fakeS3Client) ListObjectsV2(_ context.Context, input *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+func (client *fakeS3Client) ListObjectsV2(ctx context.Context, input *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if client.listObjects != nil {
+		if err := client.listObjects(ctx, input); err != nil {
+			return nil, err
+		}
+	}
 	if client.listErr != nil {
 		return nil, client.listErr
 	}
@@ -229,14 +238,42 @@ func TestS3HealthProbeSuccessAndSafeErrorCategories(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client.headBucket = func(context.Context) error {
-				return fakeS3APIError{code: test.code, text: "secret endpoint and token must not escape"}
+			probeErr := fakeS3APIError{code: test.code, text: "secret endpoint and token must not escape"}
+			client.headBucket = func(context.Context) error { return probeErr }
+			client.listObjects = func(context.Context, *s3.ListObjectsV2Input) error {
+				return probeErr
 			}
 			status := monitor.ProbeNow(context.Background())
 			if status.Ready() || status.ErrorCategory != test.want {
 				t.Fatalf("health status = %#v, want category %q", status, test.want)
 			}
 		})
+	}
+}
+
+func TestS3HealthProbeFallsBackToBoundedPrefixCheck(t *testing.T) {
+	client := newFakeS3Client()
+	client.headBucket = func(context.Context) error {
+		return fakeS3APIError{code: "AccessDenied", text: "bucket-wide check denied"}
+	}
+	client.listObjects = func(_ context.Context, input *s3.ListObjectsV2Input) error {
+		if got := aws.ToString(input.Bucket); got != "mail-bucket" {
+			t.Fatalf("fallback bucket = %q", got)
+		}
+		if got := aws.ToString(input.Prefix); got != "owlmail/attachments/" {
+			t.Fatalf("fallback prefix = %q", got)
+		}
+		if got := aws.ToInt32(input.MaxKeys); got != 1 {
+			t.Fatalf("fallback MaxKeys = %d", got)
+		}
+		return nil
+	}
+	monitor, err := NewHealthMonitor(newS3Store(client, "mail-bucket", "owlmail/attachments"), time.Minute, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status := monitor.ProbeNow(context.Background()); !status.Ready() {
+		t.Fatalf("prefix-scoped fallback status = %#v", status)
 	}
 }
 
@@ -261,6 +298,12 @@ func TestS3HealthMonitorRecovers(t *testing.T) {
 	var unavailable atomic.Bool
 	unavailable.Store(true)
 	client.headBucket = func(context.Context) error {
+		if unavailable.Load() {
+			return fakeS3APIError{code: "ServiceUnavailable", text: "temporary outage"}
+		}
+		return nil
+	}
+	client.listObjects = func(context.Context, *s3.ListObjectsV2Input) error {
 		if unavailable.Load() {
 			return fakeS3APIError{code: "ServiceUnavailable", text: "temporary outage"}
 		}

--- a/internal/attachmentstore/s3_test.go
+++ b/internal/attachmentstore/s3_test.go
@@ -206,7 +206,7 @@ type fakeS3APIError struct {
 func (err fakeS3APIError) Error() string     { return err.text }
 func (err fakeS3APIError) ErrorCode() string { return err.code }
 
-func TestS3HealthProbeSuccessAndPermissionFailure(t *testing.T) {
+func TestS3HealthProbeSuccessAndSafeErrorCategories(t *testing.T) {
 	client := newFakeS3Client()
 	store := newS3Store(client, "mail-bucket", "attachments")
 	monitor, err := NewHealthMonitor(store, time.Minute, time.Second)
@@ -217,12 +217,26 @@ func TestS3HealthProbeSuccessAndPermissionFailure(t *testing.T) {
 	if status := monitor.ProbeNow(context.Background()); !status.Ready() || status.ErrorCategory != HealthErrorNone {
 		t.Fatalf("successful health status = %#v", status)
 	}
-	client.headBucket = func(context.Context) error {
-		return fakeS3APIError{code: "AccessDenied", text: "secret endpoint and token must not escape"}
+	tests := []struct {
+		name string
+		code string
+		want HealthErrorCategory
+	}{
+		{name: "permission", code: "AccessDenied", want: HealthErrorPermission},
+		{name: "credentials", code: "InvalidAccessKeyId", want: HealthErrorCredentials},
+		{name: "missing bucket", code: "NoSuchBucket", want: HealthErrorNotFound},
+		{name: "network service", code: "ServiceUnavailable", want: HealthErrorUnavailable},
 	}
-	status := monitor.ProbeNow(context.Background())
-	if status.Ready() || status.ErrorCategory != HealthErrorPermission {
-		t.Fatalf("permission health status = %#v", status)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client.headBucket = func(context.Context) error {
+				return fakeS3APIError{code: test.code, text: "secret endpoint and token must not escape"}
+			}
+			status := monitor.ProbeNow(context.Background())
+			if status.Ready() || status.ErrorCategory != test.want {
+				t.Fatalf("health status = %#v, want category %q", status, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/attachmentstore/store.go
+++ b/internal/attachmentstore/store.go
@@ -19,4 +19,5 @@ type Store interface {
 	Put(ctx context.Context, emailID, filename, contentType string, body io.Reader, size int64) error
 	Open(ctx context.Context, emailID, filename string) (*Object, error)
 	DeleteEmail(ctx context.Context, emailID string) error
+	CheckHealth(ctx context.Context) error
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,8 @@ const DefaultSMTPMaxMessageMB = 100
 
 const DefaultS3Region = "us-east-1"
 const DefaultS3Prefix = "owlmail/attachments"
+const DefaultS3HealthCheckInterval = "30s"
+const DefaultS3HealthCheckTimeout = "5s"
 
 // DefaultWebhookMaxConcurrency is the recommended concurrent email delivery
 // limit. Zero remains available as an explicit unlimited mode.
@@ -259,6 +261,9 @@ type Config struct {
 	S3SecretAccessKey string
 	S3SessionToken    string
 	S3UsePathStyle    bool
+	S3StartupCheck    bool
+	S3HealthInterval  string
+	S3HealthTimeout   string
 
 	// Webhook forwarding configuration
 	WebhookConfig          string
@@ -312,6 +317,9 @@ func DefaultConfig() *Config {
 		S3SecretAccessKey:      "",
 		S3SessionToken:         "",
 		S3UsePathStyle:         false,
+		S3StartupCheck:         false,
+		S3HealthInterval:       DefaultS3HealthCheckInterval,
+		S3HealthTimeout:        DefaultS3HealthCheckTimeout,
 		WebhookConfig:          "",
 		WebhookMaxConcurrency:  DefaultWebhookMaxConcurrency,
 		WebhookRedisURL:        "",
@@ -362,6 +370,9 @@ type FlagRefs struct {
 	S3SecretAccessKey      *string
 	S3SessionToken         *string
 	S3UsePathStyle         *bool
+	S3StartupCheck         *bool
+	S3HealthInterval       *string
+	S3HealthTimeout        *string
 	WebhookConfig          *string
 	WebhookMaxConcurrency  *int
 	WebhookRedisURL        *string
@@ -414,6 +425,9 @@ func DefineFlags(fs *flag.FlagSet) *FlagRefs {
 		S3SecretAccessKey:      fs.String("s3-secret-key", cfg.S3SecretAccessKey, "S3 static secret key (optional)"),
 		S3SessionToken:         fs.String("s3-session-token", cfg.S3SessionToken, "S3 static credential session token (optional)"),
 		S3UsePathStyle:         fs.Bool("s3-use-path-style", cfg.S3UsePathStyle, "Use path-style S3 bucket addressing"),
+		S3StartupCheck:         fs.Bool("s3-startup-check", cfg.S3StartupCheck, "Fail startup when the initial S3 bucket check fails"),
+		S3HealthInterval:       fs.String("s3-health-check-interval", cfg.S3HealthInterval, "Background S3 health-check interval"),
+		S3HealthTimeout:        fs.String("s3-health-check-timeout", cfg.S3HealthTimeout, "Timeout for each S3 health check"),
 		WebhookConfig:          fs.String("webhook-config", cfg.WebhookConfig, "JSON file path for webhook forwarding targets"),
 		WebhookMaxConcurrency:  fs.Int("webhook-max-concurrency", cfg.WebhookMaxConcurrency, "Maximum concurrent webhook deliveries (0 = unlimited)"),
 		WebhookRedisURL:        fs.String("webhook-redis-url", cfg.WebhookRedisURL, "Redis URL for durable webhook delivery"),
@@ -475,6 +489,9 @@ func ResolveConfig(fs *flag.FlagSet, refs *FlagRefs) *Config {
 		S3SecretAccessKey:      resolveStringWithFlag(fs, "s3-secret-key", "OWLMAIL_S3_SECRET_KEY", *refs.S3SecretAccessKey),
 		S3SessionToken:         resolveStringWithFlag(fs, "s3-session-token", "OWLMAIL_S3_SESSION_TOKEN", *refs.S3SessionToken),
 		S3UsePathStyle:         resolveBoolWithFlag(fs, "s3-use-path-style", "OWLMAIL_S3_USE_PATH_STYLE", *refs.S3UsePathStyle),
+		S3StartupCheck:         resolveBoolWithFlag(fs, "s3-startup-check", "OWLMAIL_S3_STARTUP_CHECK", *refs.S3StartupCheck),
+		S3HealthInterval:       resolveStringWithFlag(fs, "s3-health-check-interval", "OWLMAIL_S3_HEALTH_CHECK_INTERVAL", *refs.S3HealthInterval),
+		S3HealthTimeout:        resolveStringWithFlag(fs, "s3-health-check-timeout", "OWLMAIL_S3_HEALTH_CHECK_TIMEOUT", *refs.S3HealthTimeout),
 		WebhookConfig:          resolveStringWithFlag(fs, "webhook-config", "OWLMAIL_WEBHOOK_CONFIG", *refs.WebhookConfig),
 		WebhookMaxConcurrency:  resolveIntWithFlag(fs, "webhook-max-concurrency", "OWLMAIL_WEBHOOK_MAX_CONCURRENCY", *refs.WebhookMaxConcurrency),
 		WebhookRedisURL:        resolveStringWithFlag(fs, "webhook-redis-url", "OWLMAIL_WEBHOOK_REDIS_URL", *refs.WebhookRedisURL),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -280,7 +280,7 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.UseUUIDForEmailID != false {
 		t.Errorf("DefaultConfig().UseUUIDForEmailID = %v, want %v", cfg.UseUUIDForEmailID, false)
 	}
-	if cfg.S3Enabled || cfg.S3Endpoint != "" || cfg.S3Bucket != "" || cfg.S3Region != DefaultS3Region || cfg.S3Prefix != DefaultS3Prefix || cfg.S3UsePathStyle {
+	if cfg.S3Enabled || cfg.S3Endpoint != "" || cfg.S3Bucket != "" || cfg.S3Region != DefaultS3Region || cfg.S3Prefix != DefaultS3Prefix || cfg.S3UsePathStyle || cfg.S3StartupCheck || cfg.S3HealthInterval != DefaultS3HealthCheckInterval || cfg.S3HealthTimeout != DefaultS3HealthCheckTimeout {
 		t.Errorf("unexpected default S3 attachment config: %#v", cfg)
 	}
 	if cfg.WebhookConfig != "" {
@@ -337,12 +337,15 @@ func TestSMTPAndS3ConfigResolution(t *testing.T) {
 			"-s3-secret-key", "secret",
 			"-s3-session-token", "token",
 			"-s3-use-path-style",
+			"-s3-startup-check",
+			"-s3-health-check-interval", "15s",
+			"-s3-health-check-timeout", "2s",
 		})
 		if err != nil {
 			t.Fatalf("Parse() error = %v", err)
 		}
 		cfg := ResolveConfig(fs, refs)
-		if cfg.SMTPMaxMessageMB != 256 || !cfg.S3Enabled || cfg.S3Endpoint != "http://minio:9000" || cfg.S3Region != "test-region-1" || cfg.S3Bucket != "owlmail-test" || cfg.S3Prefix != "mail/attachments" || cfg.S3AccessKeyID != "access" || cfg.S3SecretAccessKey != "secret" || cfg.S3SessionToken != "token" || !cfg.S3UsePathStyle {
+		if cfg.SMTPMaxMessageMB != 256 || !cfg.S3Enabled || cfg.S3Endpoint != "http://minio:9000" || cfg.S3Region != "test-region-1" || cfg.S3Bucket != "owlmail-test" || cfg.S3Prefix != "mail/attachments" || cfg.S3AccessKeyID != "access" || cfg.S3SecretAccessKey != "secret" || cfg.S3SessionToken != "token" || !cfg.S3UsePathStyle || !cfg.S3StartupCheck || cfg.S3HealthInterval != "15s" || cfg.S3HealthTimeout != "2s" {
 			t.Fatalf("unexpected resolved CLI config: %#v", cfg)
 		}
 	})
@@ -358,6 +361,9 @@ func TestSMTPAndS3ConfigResolution(t *testing.T) {
 		t.Setenv("OWLMAIL_S3_SECRET_KEY", "env-secret")
 		t.Setenv("OWLMAIL_S3_SESSION_TOKEN", "env-token")
 		t.Setenv("OWLMAIL_S3_USE_PATH_STYLE", "true")
+		t.Setenv("OWLMAIL_S3_STARTUP_CHECK", "true")
+		t.Setenv("OWLMAIL_S3_HEALTH_CHECK_INTERVAL", "20s")
+		t.Setenv("OWLMAIL_S3_HEALTH_CHECK_TIMEOUT", "3s")
 
 		fs := flag.NewFlagSet("smtp-s3-env", flag.ContinueOnError)
 		refs := DefineFlags(fs)
@@ -365,7 +371,7 @@ func TestSMTPAndS3ConfigResolution(t *testing.T) {
 			t.Fatalf("Parse() error = %v", err)
 		}
 		cfg := ResolveConfig(fs, refs)
-		if cfg.SMTPMaxMessageMB != 512 || !cfg.S3Enabled || cfg.S3Endpoint != "https://objects.example.test" || cfg.S3Region != "region-2" || cfg.S3Bucket != "mail-bucket" || cfg.S3Prefix != "tenant/owlmail" || cfg.S3AccessKeyID != "env-access" || cfg.S3SecretAccessKey != "env-secret" || cfg.S3SessionToken != "env-token" || !cfg.S3UsePathStyle {
+		if cfg.SMTPMaxMessageMB != 512 || !cfg.S3Enabled || cfg.S3Endpoint != "https://objects.example.test" || cfg.S3Region != "region-2" || cfg.S3Bucket != "mail-bucket" || cfg.S3Prefix != "tenant/owlmail" || cfg.S3AccessKeyID != "env-access" || cfg.S3SecretAccessKey != "env-secret" || cfg.S3SessionToken != "env-token" || !cfg.S3UsePathStyle || !cfg.S3StartupCheck || cfg.S3HealthInterval != "20s" || cfg.S3HealthTimeout != "3s" {
 			t.Fatalf("unexpected resolved environment config: %#v", cfg)
 		}
 	})

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -99,6 +99,12 @@ func ValidateConfig(cfg *Config) error {
 			}
 		}
 	}
+	if healthInterval, err := time.ParseDuration(cfg.S3HealthInterval); err != nil || healthInterval <= 0 {
+		return fmt.Errorf("S3 health check interval must be a positive duration")
+	}
+	if healthTimeout, err := time.ParseDuration(cfg.S3HealthTimeout); err != nil || healthTimeout <= 0 {
+		return fmt.Errorf("S3 health check timeout must be a positive duration")
+	}
 
 	// Validate auto relay rules file path if specified
 	if cfg.AutoRelayRules != "" {

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -98,12 +98,12 @@ func ValidateConfig(cfg *Config) error {
 				return fmt.Errorf("S3 endpoint must be an HTTP or HTTPS URL without credentials, query, or fragment")
 			}
 		}
-	}
-	if healthInterval, err := time.ParseDuration(cfg.S3HealthInterval); err != nil || healthInterval <= 0 {
-		return fmt.Errorf("S3 health check interval must be a positive duration")
-	}
-	if healthTimeout, err := time.ParseDuration(cfg.S3HealthTimeout); err != nil || healthTimeout <= 0 {
-		return fmt.Errorf("S3 health check timeout must be a positive duration")
+		if healthInterval, err := time.ParseDuration(cfg.S3HealthInterval); err != nil || healthInterval <= 0 {
+			return fmt.Errorf("S3 health check interval must be a positive duration")
+		}
+		if healthTimeout, err := time.ParseDuration(cfg.S3HealthTimeout); err != nil || healthTimeout <= 0 {
+			return fmt.Errorf("S3 health check timeout must be a positive duration")
+		}
 	}
 
 	// Validate auto relay rules file path if specified

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -334,6 +334,16 @@ func TestValidateConfig(t *testing.T) {
 		if err := ValidateConfig(cfg); err != nil {
 			t.Fatalf("valid S3 attachment config error = %v", err)
 		}
+
+		cfg.S3HealthInterval = "never"
+		if err := ValidateConfig(cfg); err == nil {
+			t.Error("invalid S3 health interval should fail")
+		}
+		cfg.S3HealthInterval = DefaultS3HealthCheckInterval
+		cfg.S3HealthTimeout = "0s"
+		if err := ValidateConfig(cfg); err == nil {
+			t.Error("non-positive S3 health timeout should fail")
+		}
 	})
 
 	t.Run("valid full config", func(t *testing.T) {

--- a/internal/mailserver/attachment_storage_test.go
+++ b/internal/mailserver/attachment_storage_test.go
@@ -49,6 +49,8 @@ func (store *memoryAttachmentStore) Put(ctx context.Context, emailID, filename, 
 	return nil
 }
 
+func (store *memoryAttachmentStore) CheckHealth(context.Context) error { return nil }
+
 func (store *memoryAttachmentStore) Open(ctx context.Context, emailID, filename string) (*attachmentstore.Object, error) {
 	if store.blockOpen {
 		<-ctx.Done()

--- a/internal/mailserver/attachment_stream_test.go
+++ b/internal/mailserver/attachment_stream_test.go
@@ -355,6 +355,8 @@ type failSecondPutStore struct {
 	err   error
 }
 
+func (store *failSecondPutStore) CheckHealth(context.Context) error { return nil }
+
 func (store *failSecondPutStore) Put(ctx context.Context, emailID, filename, contentType string, body io.Reader, size int64) error {
 	store.calls++
 	if store.calls == 2 {

--- a/internal/mailserver/config.go
+++ b/internal/mailserver/config.go
@@ -96,9 +96,6 @@ func NewMailServerWithOptions(port int, host, mailDir string, options ServerOpti
 		tlsConfig:               options.TLSConfig,
 		useUUIDForID:            options.UseUUIDForID,
 	}
-	if closer, ok := options.AttachmentHealth.(interface{ Close() error }); ok {
-		ms.closers = append(ms.closers, closer)
-	}
 
 	// Setup outgoing mail if config provided
 	if options.OutgoingConfig != nil {

--- a/internal/mailserver/config.go
+++ b/internal/mailserver/config.go
@@ -84,6 +84,7 @@ func NewMailServerWithOptions(port int, host, mailDir string, options ServerOpti
 		host:                    host,
 		maxMessageBytes:         maxMessageBytes,
 		attachmentStore:         options.AttachmentStore,
+		attachmentHealth:        options.AttachmentHealth,
 		attachmentUploadTimeout: defaultAttachmentUploadTimeout,
 		attachmentOpenTimeout:   defaultAttachmentOpenTimeout,
 		attachmentDeleteTimeout: defaultAttachmentDeleteTimeout,
@@ -94,6 +95,9 @@ func NewMailServerWithOptions(port int, host, mailDir string, options ServerOpti
 		authRequireTLS:          options.AuthRequireTLS,
 		tlsConfig:               options.TLSConfig,
 		useUUIDForID:            options.UseUUIDForID,
+	}
+	if closer, ok := options.AttachmentHealth.(interface{ Close() error }); ok {
+		ms.closers = append(ms.closers, closer)
 	}
 
 	// Setup outgoing mail if config provided

--- a/internal/mailserver/types.go
+++ b/internal/mailserver/types.go
@@ -52,13 +52,14 @@ type TLSConfig struct {
 // ServerOptions contains optional runtime integrations and SMTP behavior.
 // Zero MaxMessageBytes selects DefaultMaxMessageBytes.
 type ServerOptions struct {
-	OutgoingConfig  *outgoing.OutgoingConfig
-	AuthConfig      *SMTPAuthConfig
-	AuthRequireTLS  bool
-	TLSConfig       *TLSConfig
-	UseUUIDForID    bool
-	MaxMessageBytes int64
-	AttachmentStore attachmentstore.Store
+	OutgoingConfig   *outgoing.OutgoingConfig
+	AuthConfig       *SMTPAuthConfig
+	AuthRequireTLS   bool
+	TLSConfig        *TLSConfig
+	UseUUIDForID     bool
+	MaxMessageBytes  int64
+	AttachmentStore  attachmentstore.Store
+	AttachmentHealth attachmentstore.ReadinessProvider
 }
 
 // AttachmentReader describes an attachment opened for HTTP streaming.
@@ -86,6 +87,7 @@ type MailServer struct {
 	host                    string
 	maxMessageBytes         int64
 	attachmentStore         attachmentstore.Store
+	attachmentHealth        attachmentstore.ReadinessProvider
 	attachmentUploadTimeout time.Duration
 	attachmentOpenTimeout   time.Duration
 	attachmentDeleteTimeout time.Duration
@@ -143,6 +145,15 @@ func (ms *MailServer) GetMaxMessageBytes() int64 {
 // GetMailDir returns the mail directory path
 func (ms *MailServer) GetMailDir() string {
 	return ms.mailDir
+}
+
+// GetAttachmentHealth returns the latest cached attachment-store readiness.
+// A nil provider means external attachment storage is disabled.
+func (ms *MailServer) GetAttachmentHealth() (attachmentstore.HealthStatus, bool) {
+	if ms.attachmentHealth == nil {
+		return attachmentstore.HealthStatus{}, false
+	}
+	return ms.attachmentHealth.Snapshot(), true
 }
 
 // GetAuthConfig returns the SMTP authentication configuration

--- a/web/help.html
+++ b/web/help.html
@@ -92,6 +92,7 @@ SMTP_SECURE=false</code></pre>
                                 <tr><td>Web listener</td><td><code>-web</code>, <code>-web-ip</code></td><td><code>OWLMAIL_WEB_PORT</code>, <code>OWLMAIL_WEB_HOST</code></td><td><code>1080</code>, <code>localhost</code></td></tr>
                                 <tr><td>Persistent mail</td><td><code>-mail-directory</code></td><td><code>OWLMAIL_MAIL_DIR</code></td><td>Process-specific temporary directory</td></tr>
                                 <tr><td>Attachment storage</td><td><code>-s3-enabled</code> and S3 options</td><td><code>OWLMAIL_S3_ENABLED</code> and S3 variables</td><td>Local mail directory</td></tr>
+                                <tr><td>S3 readiness</td><td><code>-s3-startup-check</code>, interval and timeout options</td><td><code>OWLMAIL_S3_STARTUP_CHECK</code> and health-check variables</td><td>Async checks every <code>30s</code>, <code>5s</code> timeout</td></tr>
                                 <tr><td>Web authentication</td><td><code>-web-user</code>, <code>-web-password</code></td><td><code>OWLMAIL_WEB_USER</code>, <code>OWLMAIL_WEB_PASSWORD</code></td><td>Disabled; partial credentials are completed safely</td></tr>
                                 <tr><td>SMTP authentication</td><td><code>-smtp-user</code>, <code>-smtp-password</code></td><td><code>OWLMAIL_SMTP_USER</code>, <code>OWLMAIL_SMTP_PASSWORD</code></td><td>NO AUTH; set both to require PLAIN/LOGIN</td></tr>
                                 <tr><td>Require TLS for SMTP AUTH</td><td><code>-smtp-auth-require-tls</code></td><td><code>OWLMAIL_SMTP_AUTH_REQUIRE_TLS</code></td><td>Disabled; requires SMTP TLS when enabled</td></tr>
@@ -143,7 +144,8 @@ SMTP_SECURE=false</code></pre>
                         <div><code>GET /api/v1/emails/:id</code><span>Read a message</span></div>
                         <div><code>GET /api/v1/emails/:id/raw</code><span>Download the original message</span></div>
                         <div><code>DELETE /api/v1/emails/:id</code><span>Delete a message</span></div>
-                        <div><code>GET /api/v1/health</code><span>Health check</span></div>
+                        <div><code>GET /api/v1/health</code><span>Process liveness</span></div>
+                        <div><code>GET /api/v1/ready</code><span>Cached dependency readiness</span></div>
                         <div><code>GET /api/v1/version</code><span>Build/version information</span></div>
                         <div><code>GET /api/v1/ws</code><span>Live WebSocket events</span></div>
                     </div>
@@ -228,6 +230,7 @@ SMTP_SECURE=false</code></pre>
                                 <tr><td>Web 监听</td><td><code>-web</code>、<code>-web-ip</code></td><td><code>OWLMAIL_WEB_PORT</code>、<code>OWLMAIL_WEB_HOST</code></td><td><code>1080</code>、<code>localhost</code></td></tr>
                                 <tr><td>邮件持久化</td><td><code>-mail-directory</code></td><td><code>OWLMAIL_MAIL_DIR</code></td><td>当前进程专用临时目录</td></tr>
                                 <tr><td>附件存储</td><td><code>-s3-enabled</code> 及 S3 参数</td><td><code>OWLMAIL_S3_ENABLED</code> 及 S3 变量</td><td>本地邮件目录</td></tr>
+                                <tr><td>S3 readiness</td><td><code>-s3-startup-check</code>、间隔和超时参数</td><td><code>OWLMAIL_S3_STARTUP_CHECK</code> 及健康探测变量</td><td>默认异步每 <code>30s</code> 探测，超时 <code>5s</code></td></tr>
                                 <tr><td>Web 认证</td><td><code>-web-user</code>、<code>-web-password</code></td><td><code>OWLMAIL_WEB_USER</code>、<code>OWLMAIL_WEB_PASSWORD</code></td><td>关闭；单项凭据会安全补全</td></tr>
                                 <tr><td>SMTP 鉴权</td><td><code>-smtp-user</code>、<code>-smtp-password</code></td><td><code>OWLMAIL_SMTP_USER</code>、<code>OWLMAIL_SMTP_PASSWORD</code></td><td>默认 NO AUTH；同时设置两项后强制 PLAIN/LOGIN</td></tr>
                                 <tr><td>SMTP AUTH 强制 TLS</td><td><code>-smtp-auth-require-tls</code></td><td><code>OWLMAIL_SMTP_AUTH_REQUIRE_TLS</code></td><td>默认关闭；开启时要求 SMTP TLS</td></tr>
@@ -279,7 +282,8 @@ SMTP_SECURE=false</code></pre>
                         <div><code>GET /api/v1/emails/:id</code><span>读取单封邮件</span></div>
                         <div><code>GET /api/v1/emails/:id/raw</code><span>下载原始邮件</span></div>
                         <div><code>DELETE /api/v1/emails/:id</code><span>删除单封邮件</span></div>
-                        <div><code>GET /api/v1/health</code><span>健康检查</span></div>
+                        <div><code>GET /api/v1/health</code><span>进程存活检查</span></div>
+                        <div><code>GET /api/v1/ready</code><span>缓存的依赖 readiness</span></div>
                         <div><code>GET /api/v1/version</code><span>构建和版本信息</span></div>
                         <div><code>GET /api/v1/ws</code><span>实时 WebSocket 事件</span></div>
                     </div>


### PR DESCRIPTION
## Summary

- add a testable attachment-store health probe that prefers S3 `HeadBucket` and falls back to a bounded, prefix-scoped `ListObjectsV2` check for least-privilege policies
- cache bounded background probe results and expose separate public `/readyz` and `/api/v1/ready` endpoints while preserving `/healthz` and `/api/v1/health` as liveness checks
- add opt-in strict startup validation with a compatibility-preserving default, safe error categories, automatic recovery, and shutdown cancellation
- document configuration, probe semantics, Kubernetes usage, and operational troubleshooting

## Safety and compatibility

- `OWLMAIL_S3_STARTUP_CHECK` defaults to `false`
- readiness requests never perform synchronous S3 I/O
- transient S3 failures do not terminate a running process
- API and strict-startup failures expose only bounded categories, never raw SDK errors, endpoints, access keys, secrets, or session tokens
- the Docker healthcheck remains a liveness probe to avoid restart loops

## Tests

- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run --timeout=5m`
- `bun test ./tests/web ./tests/docs`
- `bun build ./web/*.js --target=browser`

Fake S3 coverage includes success, missing bucket, invalid credentials, permission denial, service/network failure, timeout, prefix-policy fallback, recovery, and cancellation/stop on close.

## Review follow-up

- addressed the prefix-scoped S3 policy finding in `2a4ac0a`; the review thread is resolved