### PR TITLE
feat(smtp): add configurable DATA concurrency limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to OwlMail are documented in this file. The format follows
 
 ### Added
 
+- A configurable per-process SMTP DATA concurrency limit shared by ordinary
+  SMTP, STARTTLS, and SMTPS. The default of eight protects MIME parsing,
+  transactional staging, attachment hashing, and S3 uploads; `0` preserves an
+  explicit unlimited mode, while capacity returns retryable `451 4.3.2` after
+  safely draining the rejected message without creating storage artifacts.
 - An optional, default-off read-only MCP server using the official Go SDK's
   Streamable HTTP transport. It exposes compact list/search, detached email,
   lossless base64-encoded bounded raw source, and attachment-metadata tools;

--- a/README.de.md
+++ b/README.de.md
@@ -197,6 +197,7 @@ docker buildx build \
 | `-smtp` | `MAILDEV_SMTP_PORT` / `OWLMAIL_SMTP_PORT` | 1025 | SMTP-Port |
 | `-ip` | `MAILDEV_IP` / `OWLMAIL_SMTP_HOST` | localhost | SMTP-Host |
 | `-smtp-max-message-mb` | `OWLMAIL_SMTP_MAX_MESSAGE_MB` | 100 | Maximale Größe eingehender Nachrichten in MiB |
+| `-smtp-max-concurrency` | `OWLMAIL_SMTP_MAX_CONCURRENCY` | 8 | Gleichzeitige DATA-Transaktionen pro Prozess über SMTP, STARTTLS und SMTPS; `0` ist unbegrenzt; bei vollem Limit folgt ein wiederholbarer Fehler `451 4.3.2` |
 | `-web` | `MAILDEV_WEB_PORT` / `OWLMAIL_WEB_PORT` | 1080 | Web-API-Port |
 | `-web-ip` | `MAILDEV_WEB_IP` / `OWLMAIL_WEB_HOST` | localhost | Web-API-Host |
 | `-base-pathname` | `MAILDEV_BASE_PATHNAME` / `OWLMAIL_BASE_PATHNAME` | - | URL-Pfadpräfix wie `/owlmail`; standardmäßig wird der Root-Pfad verwendet |

--- a/README.fr.md
+++ b/README.fr.md
@@ -198,6 +198,7 @@ docker buildx build \
 | `-smtp` | `MAILDEV_SMTP_PORT` / `OWLMAIL_SMTP_PORT` | 1025 | SMTP port |
 | `-ip` | `MAILDEV_IP` / `OWLMAIL_SMTP_HOST` | localhost | SMTP host |
 | `-smtp-max-message-mb` | `OWLMAIL_SMTP_MAX_MESSAGE_MB` | 100 | Taille maximale des messages entrants en MiB |
+| `-smtp-max-concurrency` | `OWLMAIL_SMTP_MAX_CONCURRENCY` | 8 | Transactions DATA simultanées par processus pour SMTP, STARTTLS et SMTPS ; `0` signifie illimité ; la saturation renvoie l’erreur temporaire `451 4.3.2` |
 | `-web` | `MAILDEV_WEB_PORT` / `OWLMAIL_WEB_PORT` | 1080 | Web API port |
 | `-web-ip` | `MAILDEV_WEB_IP` / `OWLMAIL_WEB_HOST` | localhost | Web API host |
 | `-base-pathname` | `MAILDEV_BASE_PATHNAME` / `OWLMAIL_BASE_PATHNAME` | - | Préfixe de chemin URL tel que `/owlmail`; la racine reste la valeur par défaut |

--- a/README.it.md
+++ b/README.it.md
@@ -197,6 +197,7 @@ docker buildx build \
 | `-smtp` | `MAILDEV_SMTP_PORT` / `OWLMAIL_SMTP_PORT` | 1025 | Porta SMTP |
 | `-ip` | `MAILDEV_IP` / `OWLMAIL_SMTP_HOST` | localhost | Host SMTP |
 | `-smtp-max-message-mb` | `OWLMAIL_SMTP_MAX_MESSAGE_MB` | 100 | Dimensione massima dei messaggi in ingresso in MiB |
+| `-smtp-max-concurrency` | `OWLMAIL_SMTP_MAX_CONCURRENCY` | 8 | Transazioni DATA simultanee per processo tra SMTP, STARTTLS e SMTPS; `0` indica nessun limite; a capacità piena restituisce l’errore temporaneo `451 4.3.2` |
 | `-web` | `MAILDEV_WEB_PORT` / `OWLMAIL_WEB_PORT` | 1080 | Porta API Web |
 | `-web-ip` | `MAILDEV_WEB_IP` / `OWLMAIL_WEB_HOST` | localhost | Host API Web |
 | `-base-pathname` | `MAILDEV_BASE_PATHNAME` / `OWLMAIL_BASE_PATHNAME` | - | Prefisso del percorso URL come `/owlmail`; la radice resta predefinita |

--- a/README.ja.md
+++ b/README.ja.md
@@ -197,6 +197,7 @@ docker buildx build \
 | `-smtp` | `MAILDEV_SMTP_PORT` / `OWLMAIL_SMTP_PORT` | 1025 | SMTP port |
 | `-ip` | `MAILDEV_IP` / `OWLMAIL_SMTP_HOST` | localhost | SMTP host |
 | `-smtp-max-message-mb` | `OWLMAIL_SMTP_MAX_MESSAGE_MB` | 100 | 受信メッセージの最大サイズ（MiB） |
+| `-smtp-max-concurrency` | `OWLMAIL_SMTP_MAX_CONCURRENCY` | 8 | SMTP・STARTTLS・SMTPS 全体でのプロセス単位の同時 DATA トランザクション数。`0` は無制限。上限時は再試行可能な `451 4.3.2` を返す |
 | `-web` | `MAILDEV_WEB_PORT` / `OWLMAIL_WEB_PORT` | 1080 | Web API port |
 | `-web-ip` | `MAILDEV_WEB_IP` / `OWLMAIL_WEB_HOST` | localhost | Web API host |
 | `-base-pathname` | `MAILDEV_BASE_PATHNAME` / `OWLMAIL_BASE_PATHNAME` | - | `/owlmail` などの URL パス接頭辞。既定はルートパス |

--- a/README.ko.md
+++ b/README.ko.md
@@ -197,6 +197,7 @@ docker buildx build \
 | `-smtp` | `MAILDEV_SMTP_PORT` / `OWLMAIL_SMTP_PORT` | 1025 | SMTP port |
 | `-ip` | `MAILDEV_IP` / `OWLMAIL_SMTP_HOST` | localhost | SMTP host |
 | `-smtp-max-message-mb` | `OWLMAIL_SMTP_MAX_MESSAGE_MB` | 100 | 수신 메시지 최대 크기(MiB) |
+| `-smtp-max-concurrency` | `OWLMAIL_SMTP_MAX_CONCURRENCY` | 8 | SMTP, STARTTLS, SMTPS 전체에서 프로세스별 동시 DATA 트랜잭션 수; `0`은 무제한; 한도 도달 시 재시도 가능한 `451 4.3.2` 반환 |
 | `-web` | `MAILDEV_WEB_PORT` / `OWLMAIL_WEB_PORT` | 1080 | Web API port |
 | `-web-ip` | `MAILDEV_WEB_IP` / `OWLMAIL_WEB_HOST` | localhost | Web API host |
 | `-base-pathname` | `MAILDEV_BASE_PATHNAME` / `OWLMAIL_BASE_PATHNAME` | - | `/owlmail` 같은 URL 경로 접두사. 기본값은 루트 경로 |

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ the message body; clicking one focuses OwlMail and opens the message.
 | `-smtp` | `MAILDEV_SMTP_PORT` / `OWLMAIL_SMTP_PORT` | 1025 | SMTP port |
 | `-ip` | `MAILDEV_IP` / `OWLMAIL_SMTP_HOST` | localhost | SMTP host |
 | `-smtp-max-message-mb` | `OWLMAIL_SMTP_MAX_MESSAGE_MB` | 100 | Maximum inbound message size in MiB |
+| `-smtp-max-concurrency` | `OWLMAIL_SMTP_MAX_CONCURRENCY` | 8 | Concurrent DATA transactions per process across SMTP, STARTTLS, and SMTPS; `0` is unlimited; a full limit returns retryable `451 4.3.2` |
 | `-web` | `MAILDEV_WEB_PORT` / `OWLMAIL_WEB_PORT` | 1080 | Web API port |
 | `-web-ip` | `MAILDEV_WEB_IP` / `OWLMAIL_WEB_HOST` | localhost | Web API host |
 | `-base-pathname` | `MAILDEV_BASE_PATHNAME` / `OWLMAIL_BASE_PATHNAME` | - | URL path prefix such as `/owlmail`; root remains the default |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -214,6 +214,7 @@ Notifications API 需要 HTTPS，或 `http://localhost` 等受信任的本地来
 | `-smtp` | `MAILDEV_SMTP_PORT` / `OWLMAIL_SMTP_PORT` | 1025 | SMTP 端口 |
 | `-ip` | `MAILDEV_IP` / `OWLMAIL_SMTP_HOST` | localhost | SMTP 主机 |
 | `-smtp-max-message-mb` | `OWLMAIL_SMTP_MAX_MESSAGE_MB` | 100 | 单封入站邮件上限，单位 MiB |
+| `-smtp-max-concurrency` | `OWLMAIL_SMTP_MAX_CONCURRENCY` | 8 | 每进程跨 SMTP、STARTTLS 与 SMTPS 的并发 DATA 事务数；`0` 表示不限制；达到上限返回可重试的 `451 4.3.2` |
 | `-web` | `MAILDEV_WEB_PORT` / `OWLMAIL_WEB_PORT` | 1080 | Web API 端口 |
 | `-web-ip` | `MAILDEV_WEB_IP` / `OWLMAIL_WEB_HOST` | localhost | Web API 主机 |
 | `-base-pathname` | `MAILDEV_BASE_PATHNAME` / `OWLMAIL_BASE_PATHNAME` | - | URL 子路径前缀，例如 `/owlmail`；默认仍为根路径 |

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -538,6 +538,9 @@ func createMailServer(cfg *config.Config) (*mailserver.MailServer, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("config is nil")
 	}
+	if cfg.SMTPMaxConcurrency < 0 {
+		return nil, fmt.Errorf("SMTP max concurrency must be a non-negative integer")
+	}
 
 	// Validate and compile webhook configuration before starting server resources.
 	webhookDispatcher, err := setupWebhookDispatcher(cfg)
@@ -594,14 +597,15 @@ func createMailServer(cfg *config.Config) (*mailserver.MailServer, error) {
 
 	// Create mail server
 	server, err := mailserver.NewMailServerWithOptions(cfg.SMTPPort, cfg.SMTPHost, cfg.MailDir, mailserver.ServerOptions{
-		OutgoingConfig:   outgoingConfig,
-		AuthConfig:       authConfig,
-		AuthRequireTLS:   cfg.SMTPAuthRequireTLS,
-		TLSConfig:        tlsConfig,
-		UseUUIDForID:     cfg.UseUUIDForEmailID,
-		MaxMessageBytes:  int64(maxMessageMB) << 20,
-		AttachmentStore:  attachmentStore,
-		AttachmentHealth: healthProvider,
+		OutgoingConfig:     outgoingConfig,
+		AuthConfig:         authConfig,
+		AuthRequireTLS:     cfg.SMTPAuthRequireTLS,
+		TLSConfig:          tlsConfig,
+		UseUUIDForID:       cfg.UseUUIDForEmailID,
+		MaxMessageBytes:    int64(maxMessageMB) << 20,
+		MaxDataConcurrency: cfg.SMTPMaxConcurrency,
+		AttachmentStore:    attachmentStore,
+		AttachmentHealth:   healthProvider,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create mail server: %w", err)

--- a/cmd/owlmail/main_test.go
+++ b/cmd/owlmail/main_test.go
@@ -867,6 +867,9 @@ func TestCreateMailServer(t *testing.T) {
 	if got, want := server.GetMaxMessageBytes(), int64(64<<20); got != want {
 		t.Fatalf("MaxMessageBytes = %d, want %d", got, want)
 	}
+	if got := server.GetMaxDataConcurrency(); got != 0 {
+		t.Fatalf("MaxDataConcurrency = %d, want unlimited", got)
+	}
 	defer func() {
 		if server != nil {
 			if err := server.Close(); err != nil {
@@ -1067,6 +1070,15 @@ func TestCreateMailServerRejectsNegativeMessageLimit(t *testing.T) {
 	cfg.SMTPMaxMessageMB = -1
 	if _, err := createMailServer(cfg); err == nil || !strings.Contains(err.Error(), "greater than zero") {
 		t.Fatalf("createMailServer() error = %v, want invalid message-size error", err)
+	}
+}
+
+func TestCreateMailServerRejectsNegativeDataConcurrency(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.MailDir = t.TempDir()
+	cfg.SMTPMaxConcurrency = -1
+	if _, err := createMailServer(cfg); err == nil || !strings.Contains(err.Error(), "non-negative integer") {
+		t.Fatalf("createMailServer() error = %v", err)
 	}
 }
 

--- a/docs/en/API-Reference.md
+++ b/docs/en/API-Reference.md
@@ -205,6 +205,12 @@ enabled; it does not change anonymous delivery in NO AUTH mode. This startup
 policy is not writable through the settings API. See
 [Operations](./Operations.md#smtp-ingress-limits-and-authentication-modes).
 
+Inbound DATA processing is limited to eight concurrent transactions per process
+by default across SMTP, STARTTLS, and SMTPS. Set `OWLMAIL_SMTP_MAX_CONCURRENCY`
+or `-smtp-max-concurrency`; `0` means unlimited. At capacity the SMTP client
+receives retryable `451 4.3.2`, not an HTTP API error. This process-level startup
+setting is not exposed or modified by the settings API.
+
 ```bash
 curl -u admin:secret \
   -H 'Content-Type: application/json' \

--- a/docs/en/Operations.md
+++ b/docs/en/Operations.md
@@ -455,6 +455,22 @@ The SMTP and SMTPS servers accept at most 100 MiB per message by default. Set
 to change the limit. The recipient limit remains 50 and read/write timeouts
 remain 10 seconds.
 
+OwlMail also allows eight concurrent SMTP message-body transactions per process
+by default. Configure the limit with `-smtp-max-concurrency` or
+`OWLMAIL_SMTP_MAX_CONCURRENCY`; `0` explicitly restores unlimited concurrency.
+One limiter is owned by the mail server and shared by ordinary SMTP, STARTTLS,
+and direct SMTPS. Each replica applies its own limit; this is not a cluster-wide
+or distributed quota.
+
+A slot is acquired non-blockingly when the SMTP library enters its DATA handler
+and is held through raw EML staging, MIME and body processing, attachment
+streaming and digest calculation, S3 upload, and atomic commit or rollback. It
+does not limit connections, sessions, AUTH, MAIL FROM, or RCPT TO. When all
+slots are occupied, OwlMail drains the submitted message body without storing
+it and returns `451 4.3.2 temporary resource limit reached; try again later`.
+That temporary status tells compliant SMTP clients to retry; rejected messages
+leave no EML, attachment, index, or S3 object behind.
+
 Omitting both `-smtp-user` and `-smtp-password` selects NO AUTH mode. It accepts
 mail without authentication and accepts arbitrary PLAIN/LOGIN credentials so
 test clients that require credential fields can connect without OwlMail-side

--- a/docs/zh-CN/API-Reference.md
+++ b/docs/zh-CN/API-Reference.md
@@ -173,6 +173,11 @@ SMTPS 连接上执行，并要求启用 SMTP TLS；NO AUTH 模式下的匿名投
 启动策略不能通过设置 API 修改。详见
 [运维与排障](./Operations.md#smtp-入口限制与鉴权模式)。
 
+入站 DATA 处理默认限制为每进程 8 个并发事务，普通 SMTP、STARTTLS 与 SMTPS
+共用上限。可通过 `OWLMAIL_SMTP_MAX_CONCURRENCY` 或 `-smtp-max-concurrency`
+设置；`0` 表示不限制。达到上限时 SMTP 客户端收到可重试的 `451 4.3.2`，而不是
+HTTP API 错误。该进程级启动配置不会由设置 API 返回或修改。
+
 ```bash
 curl -u admin:secret \
   -H 'Content-Type: application/json' \

--- a/docs/zh-CN/Operations.md
+++ b/docs/zh-CN/Operations.md
@@ -393,6 +393,19 @@ SMTP 与 SMTPS 默认单封邮件上限为 100 MiB。可通过 `-smtp-max-messag
 `OWLMAIL_SMTP_MAX_MESSAGE_MB` 设置为其他正整数 MiB。收件人上限仍为 50，读写
 超时仍为 10 秒。
 
+OwlMail 默认还会把每个进程同时处理的 SMTP 邮件正文事务限制为 8 个。可通过
+`-smtp-max-concurrency` 或 `OWLMAIL_SMTP_MAX_CONCURRENCY` 调整；显式设置为
+`0` 会恢复不限制并发的原有行为。普通 SMTP、STARTTLS 与直接 SMTPS 共用邮件
+服务器持有的同一个 limiter。多副本部署中每个实例独立执行上限，这不是集群级或
+分布式配额。
+
+SMTP 库进入 DATA handler 时会以非阻塞方式获取名额，名额覆盖原始 EML 暂存、
+MIME 与正文处理、附件流式写入和摘要计算、S3 上传，以及原子提交或失败回滚。
+该上限不限制 TCP 连接、SMTP session、AUTH、MAIL FROM 或 RCPT TO。名额已满时，
+OwlMail 会安全排空但不存储本次邮件正文，并返回
+`451 4.3.2 temporary resource limit reached; try again later`。该临时状态允许合规
+SMTP 客户端重试；被拒绝的事务不会留下 EML、附件、索引记录或 S3 对象。
+
 同时省略 `-smtp-user` 与 `-smtp-password` 时使用 NO AUTH 模式：允许不认证直接
 投递，也接受任意 PLAIN/LOGIN 凭据，便于必须填写凭据的测试客户端零配置接入。
 同时设置两项后强制 SMTP AUTH；未认证事务返回 `530 5.7.0`，错误凭据返回

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ package config
 
 import (
 	"flag"
+	"strconv"
 
 	"github.com/soulteary/cli-kit/env"
 	"github.com/soulteary/cli-kit/flagutil"
@@ -17,6 +18,11 @@ const DefaultMailCleanupInterval = "1h"
 // DefaultSMTPMaxMessageMB raises the historical 1 MiB limit while retaining a
 // bounded default suitable for development and test environments.
 const DefaultSMTPMaxMessageMB = 100
+
+// DefaultSMTPMaxConcurrency bounds concurrent high-resource SMTP DATA
+// transactions within one OwlMail process. Zero remains an explicit unlimited
+// mode for deployments that need the historical behavior.
+const DefaultSMTPMaxConcurrency = 8
 
 const DefaultS3Region = "us-east-1"
 const DefaultS3Prefix = "owlmail/attachments"
@@ -212,6 +218,7 @@ type Config struct {
 	SMTPPort            int
 	SMTPHost            string
 	SMTPMaxMessageMB    int
+	SMTPMaxConcurrency  int
 	MailDir             string
 	MailRetentionDays   int
 	MailMaxMessages     int
@@ -289,6 +296,7 @@ func DefaultConfig() *Config {
 		SMTPPort:               1025,
 		SMTPHost:               "localhost",
 		SMTPMaxMessageMB:       DefaultSMTPMaxMessageMB,
+		SMTPMaxConcurrency:     DefaultSMTPMaxConcurrency,
 		MailDir:                "",
 		MailRetentionDays:      0,
 		MailMaxMessages:        0,
@@ -347,6 +355,7 @@ type FlagRefs struct {
 	SMTPPort               *int
 	SMTPHost               *string
 	SMTPMaxMessageMB       *int
+	SMTPMaxConcurrency     *int
 	MailDir                *string
 	MailRetentionDays      *int
 	MailMaxMessages        *int
@@ -406,6 +415,7 @@ func DefineFlags(fs *flag.FlagSet) *FlagRefs {
 		SMTPPort:               fs.Int("smtp", cfg.SMTPPort, "SMTP port to catch emails"),
 		SMTPHost:               fs.String("ip", cfg.SMTPHost, "IP address to bind SMTP service to"),
 		SMTPMaxMessageMB:       fs.Int("smtp-max-message-mb", cfg.SMTPMaxMessageMB, "Maximum inbound message size in MiB"),
+		SMTPMaxConcurrency:     fs.Int("smtp-max-concurrency", cfg.SMTPMaxConcurrency, "Maximum concurrent SMTP DATA transactions per process (0 = unlimited)"),
 		MailDir:                fs.String("mail-directory", cfg.MailDir, "Directory for persisting mails"),
 		MailRetentionDays:      fs.Int("mail-retention-days", cfg.MailRetentionDays, "Delete mail older than this many days (0 = unlimited)"),
 		MailMaxMessages:        fs.Int("mail-max-messages", cfg.MailMaxMessages, "Maximum stored message count (0 = unlimited)"),
@@ -466,6 +476,7 @@ func ResolveConfig(fs *flag.FlagSet, refs *FlagRefs) *Config {
 		SMTPPort:            resolveIntWithFlag(fs, "smtp", "OWLMAIL_SMTP_PORT", *refs.SMTPPort),
 		SMTPHost:            resolveStringWithFlag(fs, "ip", "OWLMAIL_SMTP_HOST", *refs.SMTPHost),
 		SMTPMaxMessageMB:    resolveIntWithFlag(fs, "smtp-max-message-mb", "OWLMAIL_SMTP_MAX_MESSAGE_MB", *refs.SMTPMaxMessageMB),
+		SMTPMaxConcurrency:  resolveSMTPMaxConcurrencyWithFlag(fs, *refs.SMTPMaxConcurrency),
 		MailDir:             resolveStringWithFlag(fs, "mail-directory", "OWLMAIL_MAIL_DIR", *refs.MailDir),
 		MailRetentionDays:   resolveIntWithFlag(fs, "mail-retention-days", "OWLMAIL_MAIL_RETENTION_DAYS", *refs.MailRetentionDays),
 		MailMaxMessages:     resolveIntWithFlag(fs, "mail-max-messages", "OWLMAIL_MAIL_MAX_MESSAGES", *refs.MailMaxMessages),
@@ -524,6 +535,28 @@ func ResolveConfig(fs *flag.FlagSet, refs *FlagRefs) *Config {
 		WebhookRedisPrefix:     resolveStringWithFlag(fs, "webhook-redis-prefix", "OWLMAIL_WEBHOOK_REDIS_PREFIX", *refs.WebhookRedisPrefix),
 		WebhookShutdownTimeout: resolveStringWithFlag(fs, "webhook-shutdown-timeout", "OWLMAIL_WEBHOOK_SHUTDOWN_TIMEOUT", *refs.WebhookShutdownTimeout),
 	}
+}
+
+// resolveSMTPMaxConcurrencyWithFlag keeps the established CLI-over-environment
+// priority while rejecting malformed environment values. ResolveConfig cannot
+// return an error without breaking its public API, so malformed values use the
+// invalid sentinel -1 and are rejected by validation and server construction.
+func resolveSMTPMaxConcurrencyWithFlag(fs *flag.FlagSet, flagValue int) int {
+	if flagutil.HasFlag(fs, "smtp-max-concurrency") {
+		return flagValue
+	}
+	if !env.Has("OWLMAIL_SMTP_MAX_CONCURRENCY") {
+		return flagValue
+	}
+	raw := env.Get("OWLMAIL_SMTP_MAX_CONCURRENCY", "")
+	if raw == "" {
+		return flagValue
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return -1
+	}
+	return value
 }
 
 // ParseFlags is a convenience function that defines flags, parses arguments, and resolves config.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"flag"
+	"strings"
 	"testing"
 
 	"github.com/soulteary/cli-kit/testutil"
@@ -286,6 +287,9 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.SMTPMaxMessageMB != DefaultSMTPMaxMessageMB {
 		t.Errorf("DefaultConfig().SMTPMaxMessageMB = %d, want %d", cfg.SMTPMaxMessageMB, DefaultSMTPMaxMessageMB)
 	}
+	if cfg.SMTPMaxConcurrency != DefaultSMTPMaxConcurrency {
+		t.Errorf("DefaultConfig().SMTPMaxConcurrency = %d, want %d", cfg.SMTPMaxConcurrency, DefaultSMTPMaxConcurrency)
+	}
 	if cfg.WebPort != 1080 {
 		t.Errorf("DefaultConfig().WebPort = %d, want %d", cfg.WebPort, 1080)
 	}
@@ -325,6 +329,73 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.WebhookRedisURL != "" || cfg.WebhookRedisPrefix != "owlmail:webhooks" || cfg.WebhookShutdownTimeout != "15s" {
 		t.Errorf("unexpected default webhook queue config: %#v", cfg)
 	}
+}
+
+func TestSMTPMaxConcurrencyResolution(t *testing.T) {
+	t.Run("environment", func(t *testing.T) {
+		t.Setenv("OWLMAIL_SMTP_MAX_CONCURRENCY", "3")
+		fs := flag.NewFlagSet("smtp-concurrency-env", flag.ContinueOnError)
+		refs := DefineFlags(fs)
+		if err := fs.Parse(nil); err != nil {
+			t.Fatal(err)
+		}
+		cfg := ResolveConfig(fs, refs)
+		if cfg.SMTPMaxConcurrency != 3 {
+			t.Fatalf("SMTPMaxConcurrency = %d, want 3", cfg.SMTPMaxConcurrency)
+		}
+	})
+
+	t.Run("zero is unlimited", func(t *testing.T) {
+		t.Setenv("OWLMAIL_SMTP_MAX_CONCURRENCY", "0")
+		fs := flag.NewFlagSet("smtp-concurrency-zero", flag.ContinueOnError)
+		refs := DefineFlags(fs)
+		if err := fs.Parse(nil); err != nil {
+			t.Fatal(err)
+		}
+		cfg := ResolveConfig(fs, refs)
+		if cfg.SMTPMaxConcurrency != 0 {
+			t.Fatalf("SMTPMaxConcurrency = %d, want 0", cfg.SMTPMaxConcurrency)
+		}
+		if err := ValidateConfig(cfg); err != nil {
+			t.Fatalf("unlimited config failed validation: %v", err)
+		}
+	})
+
+	t.Run("CLI overrides invalid environment", func(t *testing.T) {
+		t.Setenv("OWLMAIL_SMTP_MAX_CONCURRENCY", "not-a-number")
+		fs := flag.NewFlagSet("smtp-concurrency-cli", flag.ContinueOnError)
+		refs := DefineFlags(fs)
+		if err := fs.Parse([]string{"-smtp-max-concurrency", "5"}); err != nil {
+			t.Fatal(err)
+		}
+		cfg := ResolveConfig(fs, refs)
+		if cfg.SMTPMaxConcurrency != 5 {
+			t.Fatalf("SMTPMaxConcurrency = %d, want 5", cfg.SMTPMaxConcurrency)
+		}
+	})
+
+	for _, value := range []string{"-1", "invalid", "8.5"} {
+		t.Run("reject "+value, func(t *testing.T) {
+			t.Setenv("OWLMAIL_SMTP_MAX_CONCURRENCY", value)
+			fs := flag.NewFlagSet("smtp-concurrency-invalid", flag.ContinueOnError)
+			refs := DefineFlags(fs)
+			if err := fs.Parse(nil); err != nil {
+				t.Fatal(err)
+			}
+			cfg := ResolveConfig(fs, refs)
+			if err := ValidateConfig(cfg); err == nil || !strings.Contains(err.Error(), "non-negative integer") {
+				t.Fatalf("ValidateConfig() error = %v", err)
+			}
+		})
+	}
+
+	t.Run("invalid CLI string", func(t *testing.T) {
+		fs := flag.NewFlagSet("smtp-concurrency-invalid-cli", flag.ContinueOnError)
+		_ = DefineFlags(fs)
+		if err := fs.Parse([]string{"-smtp-max-concurrency", "invalid"}); err == nil {
+			t.Fatal("invalid CLI integer was accepted")
+		}
+	})
 }
 
 func TestSMTPAuthRequireTLSResolution(t *testing.T) {

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -38,6 +38,9 @@ func ValidateConfig(cfg *Config) error {
 	if int64(cfg.SMTPMaxMessageMB) > maxMessageMB {
 		return fmt.Errorf("SMTP max message size is too large")
 	}
+	if cfg.SMTPMaxConcurrency < 0 {
+		return fmt.Errorf("SMTP max concurrency must be a non-negative integer")
+	}
 	if (cfg.SMTPUser == "") != (cfg.SMTPPassword == "") {
 		return fmt.Errorf("SMTP username and password must be configured together")
 	}

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -137,6 +137,14 @@ func TestValidateConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("invalid SMTP max concurrency", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.SMTPMaxConcurrency = -1
+		if err := ValidateConfig(cfg); err == nil || !strings.Contains(err.Error(), "non-negative integer") {
+			t.Fatalf("ValidateConfig() error = %v", err)
+		}
+	})
+
 	t.Run("invalid Web port", func(t *testing.T) {
 		cfg := DefaultConfig()
 		cfg.WebPort = 70000

--- a/internal/mailserver/config.go
+++ b/internal/mailserver/config.go
@@ -42,6 +42,9 @@ func NewMailServerWithFullConfig(port int, host, mailDir string, outgoingConfig 
 // NewMailServerWithOptions creates a mail server with optional external
 // attachment storage and a configurable SMTP message-size limit.
 func NewMailServerWithOptions(port int, host, mailDir string, options ServerOptions) (*MailServer, error) {
+	if options.MaxDataConcurrency < 0 {
+		return nil, fmt.Errorf("SMTP DATA max concurrency must be zero or greater")
+	}
 	if options.AuthRequireTLS && (options.TLSConfig == nil || !options.TLSConfig.Enabled) {
 		return nil, fmt.Errorf("SMTP AUTH cannot require TLS without an enabled TLS configuration")
 	}
@@ -83,6 +86,8 @@ func NewMailServerWithOptions(port int, host, mailDir string, options ServerOpti
 		port:                    port,
 		host:                    host,
 		maxMessageBytes:         maxMessageBytes,
+		maxDataConcurrency:      options.MaxDataConcurrency,
+		dataLimiter:             newDataLimiter(options.MaxDataConcurrency),
 		attachmentStore:         options.AttachmentStore,
 		attachmentHealth:        options.AttachmentHealth,
 		attachmentUploadTimeout: defaultAttachmentUploadTimeout,

--- a/internal/mailserver/data_limiter.go
+++ b/internal/mailserver/data_limiter.go
@@ -1,0 +1,56 @@
+package mailserver
+
+import "github.com/emersion/go-smtp"
+
+var errSMTPDataConcurrencyLimit = &smtp.SMTPError{
+	Code:         451,
+	EnhancedCode: smtp.EnhancedCode{4, 3, 2},
+	Message:      "temporary resource limit reached; try again later",
+}
+
+// dataLimiter is owned by one MailServer and therefore shared by its ordinary
+// SMTP, STARTTLS, and SMTPS sessions. A nil limiter is the explicit unlimited
+// mode. Acquisition is intentionally non-blocking so clients receive a
+// retryable SMTP response instead of waiting indefinitely.
+type dataLimiter struct {
+	slots chan struct{}
+}
+
+func newDataLimiter(maxConcurrency int) *dataLimiter {
+	if maxConcurrency == 0 {
+		return nil
+	}
+	return &dataLimiter{slots: make(chan struct{}, maxConcurrency)}
+}
+
+func (limiter *dataLimiter) tryAcquire() bool {
+	if limiter == nil {
+		return true
+	}
+	select {
+	case limiter.slots <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func (limiter *dataLimiter) release() {
+	if limiter != nil {
+		<-limiter.slots
+	}
+}
+
+func (ms *MailServer) tryAcquireDataSlot() bool {
+	return ms.dataLimiter.tryAcquire()
+}
+
+func (ms *MailServer) releaseDataSlot() {
+	// Keep the slot held while a deterministic test hook accounts for the
+	// completed transaction. The deferred release still prevents a hook panic
+	// from leaking capacity.
+	defer ms.dataLimiter.release()
+	if ms.beforeDataRelease != nil {
+		ms.beforeDataRelease()
+	}
+}

--- a/internal/mailserver/data_limiter_test.go
+++ b/internal/mailserver/data_limiter_test.go
@@ -1,0 +1,521 @@
+package mailserver
+
+import (
+	"bytes"
+	"crypto/tls"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/emersion/go-smtp"
+)
+
+type gatedDataReader struct {
+	reader  io.Reader
+	entered chan struct{}
+	release <-chan struct{}
+	once    sync.Once
+}
+
+func (reader *gatedDataReader) Read(buffer []byte) (int, error) {
+	reader.once.Do(func() { close(reader.entered) })
+	<-reader.release
+	return reader.reader.Read(buffer)
+}
+
+func newDataTestSession(server *MailServer) *Session {
+	return &Session{
+		mailServer:    server,
+		from:          "sender@example.test",
+		to:            []string{"recipient@example.test"},
+		authenticated: true,
+	}
+}
+
+func assertDataLimitError(t *testing.T, err error) {
+	t.Helper()
+	var smtpErr *smtp.SMTPError
+	if !errors.As(err, &smtpErr) {
+		t.Fatalf("DATA error = %v, want SMTP error", err)
+	}
+	if smtpErr.Code != 451 || smtpErr.EnhancedCode != (smtp.EnhancedCode{4, 3, 2}) {
+		t.Fatalf("DATA status = %d %v, want 451 4.3.2", smtpErr.Code, smtpErr.EnhancedCode)
+	}
+	if smtpErr.Message != "temporary resource limit reached; try again later" {
+		t.Fatalf("DATA message = %q", smtpErr.Message)
+	}
+}
+
+func TestDataConcurrencyRejectsImmediatelyAndRecovers(t *testing.T) {
+	server, err := NewMailServerWithOptions(1025, "localhost", t.TempDir(), ServerOptions{MaxDataConcurrency: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	releaseFirst := make(chan struct{})
+	firstEntered := make(chan struct{})
+	firstResult := make(chan error, 1)
+	go func() {
+		firstResult <- newDataTestSession(server).Data(&gatedDataReader{
+			reader:  bytes.NewReader(validMessage("first")),
+			entered: firstEntered,
+			release: releaseFirst,
+		})
+	}()
+	<-firstEntered
+
+	secondErr := newDataTestSession(server).Data(bytes.NewReader(validMessage("rejected")))
+	assertDataLimitError(t, secondErr)
+	if got := len(server.dataLimiter.slots); got != 1 {
+		t.Fatalf("occupied DATA slots = %d, want 1", got)
+	}
+
+	close(releaseFirst)
+	if err := <-firstResult; err != nil {
+		t.Fatalf("first DATA failed: %v", err)
+	}
+	if got := len(server.dataLimiter.slots); got != 0 {
+		t.Fatalf("occupied DATA slots after completion = %d, want 0", got)
+	}
+	if err := newDataTestSession(server).Data(bytes.NewReader(validMessage("after release"))); err != nil {
+		t.Fatalf("DATA after release failed: %v", err)
+	}
+	if got := len(server.GetAllEmail()); got != 2 {
+		t.Fatalf("stored messages = %d, want 2", got)
+	}
+}
+
+func TestDataConcurrencyNeverExceedsLimit(t *testing.T) {
+	const (
+		limit = 3
+		total = 24
+	)
+	server, err := NewMailServerWithOptions(1025, "localhost", t.TempDir(), ServerOptions{MaxDataConcurrency: limit})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	var active atomic.Int32
+	var peak atomic.Int32
+	entered := make(chan struct{}, limit)
+	server.afterDataAcquire = func() {
+		current := active.Add(1)
+		for {
+			previous := peak.Load()
+			if current <= previous || peak.CompareAndSwap(previous, current) {
+				entered <- struct{}{}
+				return
+			}
+		}
+	}
+	server.beforeDataRelease = func() { active.Add(-1) }
+
+	release := make(chan struct{})
+	results := make(chan error, total)
+	for index := 0; index < total; index++ {
+		go func() {
+			results <- newDataTestSession(server).Data(&gatedDataReader{
+				reader:  bytes.NewReader(validMessage("pressure")),
+				entered: make(chan struct{}),
+				release: release,
+			})
+		}()
+	}
+	for index := 0; index < limit; index++ {
+		<-entered
+	}
+	for index := 0; index < total-limit; index++ {
+		assertDataLimitError(t, <-results)
+	}
+	close(release)
+	for index := 0; index < limit; index++ {
+		if err := <-results; err != nil {
+			t.Fatalf("accepted DATA failed: %v", err)
+		}
+	}
+	if got := peak.Load(); got != limit {
+		t.Fatalf("peak DATA concurrency = %d, want %d", got, limit)
+	}
+	if got := active.Load(); got != 0 {
+		t.Fatalf("active DATA count after completion = %d, want 0", got)
+	}
+}
+
+func TestUnlimitedDataConcurrency(t *testing.T) {
+	const total = 8
+	server, err := NewMailServerWithOptions(1025, "localhost", t.TempDir(), ServerOptions{MaxDataConcurrency: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	if server.dataLimiter != nil {
+		t.Fatal("unlimited mode created a limiter")
+	}
+
+	release := make(chan struct{})
+	entered := make(chan struct{}, total)
+	server.afterDataAcquire = func() { entered <- struct{}{} }
+	results := make(chan error, total)
+	for index := 0; index < total; index++ {
+		go func() {
+			results <- newDataTestSession(server).Data(&gatedDataReader{
+				reader:  bytes.NewReader(validMessage("unlimited")),
+				entered: make(chan struct{}),
+				release: release,
+			})
+		}()
+	}
+	for index := 0; index < total; index++ {
+		<-entered
+	}
+	close(release)
+	for index := 0; index < total; index++ {
+		if err := <-results; err != nil {
+			t.Fatalf("unlimited DATA failed: %v", err)
+		}
+	}
+}
+
+func TestDataSlotReleasedAfterTransactionFailures(t *testing.T) {
+	readFailure := errors.New("injected DATA read failure")
+	brokenMIME := []byte("From: from@example.test\r\nTo: recipient@example.test\r\n" +
+		"Content-Type: multipart/mixed; boundary=broken\r\n\r\n" +
+		"--broken\r\nContent-Type: application/octet-stream\r\n" +
+		"Content-Transfer-Encoding: base64\r\n" +
+		"Content-Disposition: attachment; filename=broken.bin\r\n\r\n%%%\r\n--broken--\r\n")
+
+	tests := []struct {
+		name      string
+		message   func() io.Reader
+		configure func(*MailServer) func()
+	}{
+		{
+			name: "message reader",
+			message: func() io.Reader {
+				return io.MultiReader(bytes.NewReader([]byte("From: sender@example.test\r\n\r\n")), errorReader{err: readFailure})
+			},
+			configure: func(*MailServer) func() { return func() {} },
+		},
+		{
+			name:      "MIME parsing",
+			message:   func() io.Reader { return bytes.NewReader(brokenMIME) },
+			configure: func(*MailServer) func() { return func() {} },
+		},
+		{
+			name:    "attachment staging write",
+			message: func() io.Reader { return bytes.NewReader(multipartMessage()) },
+			configure: func(server *MailServer) func() {
+				server.beforeAttachmentWrite = func(string) error { return errors.New("injected staging failure") }
+				return func() { server.beforeAttachmentWrite = nil }
+			},
+		},
+		{
+			name:    "atomic commit",
+			message: func() io.Reader { return bytes.NewReader(validMessage("commit failure")) },
+			configure: func(server *MailServer) func() {
+				server.beforeStoreCommit = func(*Email) error { return errors.New("injected commit failure") }
+				return func() { server.beforeStoreCommit = nil }
+			},
+		},
+		{
+			name:    "S3 upload and rollback",
+			message: func() io.Reader { return bytes.NewReader(multipartMessage()) },
+			configure: func(server *MailServer) func() {
+				remote := newMemoryAttachmentStore()
+				remote.putErr = errors.New("injected S3 failure")
+				server.attachmentStore = remote
+				return func() { remote.putErr = nil }
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server, err := NewMailServerWithOptions(1025, "localhost", t.TempDir(), ServerOptions{MaxDataConcurrency: 1})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = server.Close() }()
+			recover := test.configure(server)
+			if err := newDataTestSession(server).Data(test.message()); err == nil {
+				t.Fatal("failing DATA transaction succeeded")
+			}
+			if got := len(server.dataLimiter.slots); got != 0 {
+				t.Fatalf("DATA failure retained %d slot(s)", got)
+			}
+			recover()
+			if err := newDataTestSession(server).Data(bytes.NewReader(validMessage("recovered"))); err != nil {
+				t.Fatalf("DATA after failure did not recover: %v", err)
+			}
+		})
+	}
+}
+
+func TestRejectedDataCreatesNoLocalOrRemoteArtifacts(t *testing.T) {
+	directory := t.TempDir()
+	remote := newMemoryAttachmentStore()
+	server, err := NewMailServerWithOptions(1025, "localhost", directory, ServerOptions{
+		MaxDataConcurrency: 1,
+		AttachmentStore:    remote,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	if !server.dataLimiter.tryAcquire() {
+		t.Fatal("failed to occupy the only DATA slot")
+	}
+	defer server.dataLimiter.release()
+
+	err = newDataTestSession(server).Data(bytes.NewReader(multipartMessage()))
+	assertDataLimitError(t, err)
+	if got := len(server.GetAllEmail()); got != 0 {
+		t.Fatalf("rejected DATA created %d index record(s)", got)
+	}
+	if artifacts := dataArtifactPaths(t, directory); len(artifacts) != 0 {
+		t.Fatalf("rejected DATA left local artifacts: %v", artifacts)
+	}
+	if len(remote.objects) != 0 {
+		t.Fatalf("rejected DATA left S3 objects: %v", remote.objects)
+	}
+}
+
+type errorReader struct {
+	err error
+}
+
+func (reader errorReader) Read([]byte) (int, error) { return 0, reader.err }
+
+func startDataProtocolServers(t *testing.T, server *MailServer) (plainAddress, smtpsAddress string) {
+	t.Helper()
+	plainListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		_ = plainListener.Close()
+		t.Fatal(err)
+	}
+	done := make(chan error, 2)
+	go func() { done <- server.smtpServer.Serve(plainListener) }()
+	go func() { done <- server.smtpsServer.Serve(tls.NewListener(tlsListener, server.smtpsServer.TLSConfig)) }()
+	t.Cleanup(func() {
+		_ = server.Close()
+		for index := 0; index < 2; index++ {
+			<-done
+		}
+	})
+	return plainListener.Addr().String(), tlsListener.Addr().String()
+}
+
+func beginData(t *testing.T, client *smtp.Client, from string) io.WriteCloser {
+	t.Helper()
+	if err := client.Mail(from, nil); err != nil {
+		t.Fatalf("MAIL FROM failed: %v", err)
+	}
+	if err := client.Rcpt("recipient@example.test", nil); err != nil {
+		t.Fatalf("RCPT TO failed: %v", err)
+	}
+	writer, err := client.Data()
+	if err != nil {
+		t.Fatalf("DATA command failed: %v", err)
+	}
+	return writer
+}
+
+func finishData(writer io.WriteCloser, subject string) error {
+	_, writeErr := writer.Write(validMessage(subject))
+	return errors.Join(writeErr, writer.Close())
+}
+
+func dataArtifactPaths(t *testing.T, root string) []string {
+	t.Helper()
+	var paths []string
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == root {
+			return nil
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		paths = append(paths, relative)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func TestSMTPTransportsShareDataLimitAndRejectedBodyIsDrained(t *testing.T) {
+	directory := t.TempDir()
+	server, err := NewMailServerWithOptions(1025, "127.0.0.1", directory, ServerOptions{
+		TLSConfig:          &TLSConfig{Enabled: true},
+		MaxDataConcurrency: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plainAddress, smtpsAddress := startDataProtocolServers(t, server)
+
+	holderEntered := make(chan struct{})
+	releaseHolder := make(chan struct{})
+	var blockFirst sync.Once
+	server.afterDataAcquire = func() {
+		blockFirst.Do(func() {
+			close(holderEntered)
+			<-releaseHolder
+		})
+	}
+
+	plainClient, err := smtp.Dial(plainAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = plainClient.Close() }()
+	holderResult := make(chan error, 1)
+	holder := beginData(t, plainClient, "plain-holder@example.test")
+	go func() { holderResult <- finishData(holder, "plain holder") }()
+	<-holderEntered
+
+	startTLSClient, err := smtp.DialStartTLS(plainAddress, insecureSMTPTestTLSConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = startTLSClient.Close() }()
+	startTLSWriter := beginData(t, startTLSClient, "starttls-rejected@example.test")
+	assertDataLimitError(t, finishData(startTLSWriter, "STARTTLS rejected"))
+
+	smtpsClient, err := smtp.DialTLS(smtpsAddress, insecureSMTPTestTLSConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = smtpsClient.Close() }()
+	smtpsWriter := beginData(t, smtpsClient, "smtps-rejected@example.test")
+	assertDataLimitError(t, finishData(smtpsWriter, "SMTPS rejected"))
+
+	if artifacts := dataArtifactPaths(t, directory); len(artifacts) != 0 {
+		t.Fatalf("rejected DATA left artifacts: %v", artifacts)
+	}
+	close(releaseHolder)
+	if err := <-holderResult; err != nil {
+		t.Fatalf("plain holder failed: %v", err)
+	}
+
+	// Both rejected connections remain protocol-synchronized after go-smtp
+	// drains their message bodies, so they can deliver the next transaction.
+	if err := finishData(beginData(t, startTLSClient, "starttls-retry@example.test"), "STARTTLS retry"); err != nil {
+		t.Fatalf("STARTTLS connection reuse failed: %v", err)
+	}
+	if err := finishData(beginData(t, smtpsClient, "smtps-retry@example.test"), "SMTPS retry"); err != nil {
+		t.Fatalf("SMTPS connection reuse failed: %v", err)
+	}
+	if got := len(server.GetAllEmail()); got != 3 {
+		t.Fatalf("stored messages = %d, want 3", got)
+	}
+}
+
+func TestMessageSizeFailureReleasesDataSlot(t *testing.T) {
+	server, err := NewMailServerWithOptions(1025, "127.0.0.1", t.TempDir(), ServerOptions{
+		MaxMessageBytes:    512,
+		MaxDataConcurrency: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- server.smtpServer.Serve(listener) }()
+	defer func() {
+		_ = server.Close()
+		<-done
+	}()
+
+	client, err := smtp.Dial(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = client.Close() }()
+	oversized := beginData(t, client, "oversized@example.test")
+	if _, err := io.WriteString(oversized, "From: sender@example.test\r\nTo: recipient@example.test\r\n\r\n"+strings.Repeat("x", 1024)); err != nil {
+		t.Fatal(err)
+	}
+	if err := oversized.Close(); err == nil {
+		t.Fatal("oversized DATA succeeded")
+	}
+	if got := len(server.dataLimiter.slots); got != 0 {
+		t.Fatalf("oversized DATA retained %d slot(s)", got)
+	}
+	if err := finishData(beginData(t, client, "after-size@example.test"), "after size failure"); err != nil {
+		t.Fatalf("DATA after size failure failed: %v", err)
+	}
+}
+
+func TestClientAbortAndServerCloseReleaseDataSlot(t *testing.T) {
+	for _, closeServer := range []bool{false, true} {
+		name := "client abort"
+		if closeServer {
+			name = "server close"
+		}
+		t.Run(name, func(t *testing.T) {
+			directory := t.TempDir()
+			server, err := NewMailServerWithOptions(1025, "127.0.0.1", directory, ServerOptions{MaxDataConcurrency: 1})
+			if err != nil {
+				t.Fatal(err)
+			}
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			done := make(chan error, 1)
+			go func() { done <- server.smtpServer.Serve(listener) }()
+			acquired := make(chan struct{})
+			released := make(chan struct{})
+			server.afterDataAcquire = func() { close(acquired) }
+			server.beforeDataRelease = func() { close(released) }
+
+			client, err := smtp.Dial(listener.Addr().String())
+			if err != nil {
+				t.Fatal(err)
+			}
+			writer := beginData(t, client, "interrupted@example.test")
+			if _, err := io.WriteString(writer, "From: sender@example.test\r\n\r\npartial"); err != nil {
+				t.Fatal(err)
+			}
+			<-acquired
+			if closeServer {
+				_ = server.Close()
+			} else {
+				_ = client.Close()
+			}
+			<-released
+			if got := len(server.dataLimiter.slots); got != 0 {
+				t.Fatalf("interrupted DATA retained %d slot(s)", got)
+			}
+			if artifacts := dataArtifactPaths(t, directory); len(artifacts) != 0 {
+				t.Fatalf("interrupted DATA left artifacts: %v", artifacts)
+			}
+			_ = client.Close()
+			_ = server.Close()
+			<-done
+		})
+	}
+}

--- a/internal/mailserver/lifecycle.go
+++ b/internal/mailserver/lifecycle.go
@@ -53,6 +53,11 @@ func (ms *MailServer) Listen() error {
 	if ms.tlsConfig != nil && ms.tlsConfig.Enabled {
 		common.Log("SMTP TLS/STARTTLS enabled")
 	}
+	if ms.maxDataConcurrency == 0 {
+		common.Log("SMTP DATA concurrency is unlimited")
+	} else {
+		common.Log("SMTP DATA concurrency limit: %d per process", ms.maxDataConcurrency)
+	}
 	return ms.smtpServer.ListenAndServe()
 }
 

--- a/internal/mailserver/mailserver_config_test.go
+++ b/internal/mailserver/mailserver_config_test.go
@@ -73,6 +73,20 @@ func TestNewMailServerWithCustomMessageLimit(t *testing.T) {
 	}
 }
 
+func TestNewMailServerWithDataConcurrencyLimit(t *testing.T) {
+	server, err := NewMailServerWithOptions(1025, "localhost", t.TempDir(), ServerOptions{MaxDataConcurrency: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	if got := server.GetMaxDataConcurrency(); got != 4 {
+		t.Fatalf("GetMaxDataConcurrency() = %d, want 4", got)
+	}
+	if _, err := NewMailServerWithOptions(1025, "localhost", t.TempDir(), ServerOptions{MaxDataConcurrency: -1}); err == nil {
+		t.Fatal("negative DATA concurrency was accepted")
+	}
+}
+
 func TestNewMailServerRejectsAuthRequireTLSWithoutTLS(t *testing.T) {
 	for _, tlsConfig := range []*TLSConfig{nil, {Enabled: false}} {
 		_, err := NewMailServerWithOptions(1025, "localhost", t.TempDir(), ServerOptions{

--- a/internal/mailserver/session.go
+++ b/internal/mailserver/session.go
@@ -63,6 +63,13 @@ func (s *Session) Data(r io.Reader) error {
 	if err := s.requireAuthentication(); err != nil {
 		return err
 	}
+	if !s.mailServer.tryAcquireDataSlot() {
+		return errSMTPDataConcurrencyLimit
+	}
+	defer s.mailServer.releaseDataSlot()
+	if s.mailServer.afterDataAcquire != nil {
+		s.mailServer.afterDataAcquire()
+	}
 	id := makeID(s.mailServer.useUUIDForID)
 	return s.mailServer.storeIncomingEmail(id, r, s)
 }

--- a/internal/mailserver/types.go
+++ b/internal/mailserver/types.go
@@ -50,16 +50,18 @@ type TLSConfig struct {
 }
 
 // ServerOptions contains optional runtime integrations and SMTP behavior.
-// Zero MaxMessageBytes selects DefaultMaxMessageBytes.
+// Zero MaxMessageBytes selects DefaultMaxMessageBytes. Zero
+// MaxDataConcurrency leaves SMTP DATA concurrency unlimited.
 type ServerOptions struct {
-	OutgoingConfig   *outgoing.OutgoingConfig
-	AuthConfig       *SMTPAuthConfig
-	AuthRequireTLS   bool
-	TLSConfig        *TLSConfig
-	UseUUIDForID     bool
-	MaxMessageBytes  int64
-	AttachmentStore  attachmentstore.Store
-	AttachmentHealth attachmentstore.ReadinessProvider
+	OutgoingConfig     *outgoing.OutgoingConfig
+	AuthConfig         *SMTPAuthConfig
+	AuthRequireTLS     bool
+	TLSConfig          *TLSConfig
+	UseUUIDForID       bool
+	MaxMessageBytes    int64
+	MaxDataConcurrency int
+	AttachmentStore    attachmentstore.Store
+	AttachmentHealth   attachmentstore.ReadinessProvider
 }
 
 // AttachmentReader describes an attachment opened for HTTP streaming.
@@ -86,6 +88,8 @@ type MailServer struct {
 	port                    int
 	host                    string
 	maxMessageBytes         int64
+	maxDataConcurrency      int
+	dataLimiter             *dataLimiter
 	attachmentStore         attachmentstore.Store
 	attachmentHealth        attachmentstore.ReadinessProvider
 	attachmentUploadTimeout time.Duration
@@ -125,6 +129,11 @@ type MailServer struct {
 	beforeEmailRollback        func(string) error
 	beforeEmailDelete          func(string) error
 	syncAcceptedFenceDirectory func(string) error
+
+	// DATA hooks are nil in production and provide deterministic synchronization
+	// for concurrency and shutdown tests.
+	afterDataAcquire  func()
+	beforeDataRelease func()
 }
 
 // GetHost returns the SMTP server host
@@ -140,6 +149,12 @@ func (ms *MailServer) GetPort() int {
 // GetMaxMessageBytes returns the configured inbound SMTP message-size limit.
 func (ms *MailServer) GetMaxMessageBytes() int64 {
 	return ms.maxMessageBytes
+}
+
+// GetMaxDataConcurrency returns the per-process SMTP DATA transaction limit.
+// Zero means unlimited.
+func (ms *MailServer) GetMaxDataConcurrency() int {
+	return ms.maxDataConcurrency
 }
 
 // GetMailDir returns the mail directory path

--- a/tests/docs/markdown.test.js
+++ b/tests/docs/markdown.test.js
@@ -299,6 +299,8 @@ test("security-sensitive SMTP authentication modes remain explicit", () => {
     "smtp-max-message-mb",
     "50 recipients",
     "50 个收件人",
+    "OWLMAIL_SMTP_MAX_CONCURRENCY",
+    "451 4.3.2",
   ]) {
     assert.ok(help.includes(marker), `web/help.html is missing SMTP ingress marker ${marker}`);
   }

--- a/web/help.html
+++ b/web/help.html
@@ -91,6 +91,7 @@ SMTP_SECURE=false</code></pre>
                             <tbody>
                                 <tr><td>SMTP listener</td><td><code>-smtp</code>, <code>-ip</code></td><td><code>OWLMAIL_SMTP_PORT</code>, <code>OWLMAIL_SMTP_HOST</code></td><td><code>1025</code>, <code>localhost</code></td></tr>
                                 <tr><td>SMTP message limit</td><td><code>-smtp-max-message-mb</code></td><td><code>OWLMAIL_SMTP_MAX_MESSAGE_MB</code></td><td><code>100</code> MiB</td></tr>
+                                <tr><td>SMTP DATA concurrency</td><td><code>-smtp-max-concurrency</code></td><td><code>OWLMAIL_SMTP_MAX_CONCURRENCY</code></td><td><code>8</code> per process; <code>0</code> is unlimited</td></tr>
                                 <tr><td>Web listener</td><td><code>-web</code>, <code>-web-ip</code></td><td><code>OWLMAIL_WEB_PORT</code>, <code>OWLMAIL_WEB_HOST</code></td><td><code>1080</code>, <code>localhost</code></td></tr>
                                 <tr><td>Persistent mail</td><td><code>-mail-directory</code></td><td><code>OWLMAIL_MAIL_DIR</code></td><td>Process-specific temporary directory</td></tr>
                                 <tr><td>Attachment storage</td><td><code>-s3-enabled</code> and S3 options</td><td><code>OWLMAIL_S3_ENABLED</code> and S3 variables</td><td>Local mail directory</td></tr>
@@ -107,7 +108,7 @@ SMTP_SECURE=false</code></pre>
                     </div>
                     <h3>Web authentication defaults</h3>
                     <p>With only a username, OwlMail generates a random 32-character password and prints it once to stderr at startup. With only a password, the username defaults to <code>admin</code>. Supplying neither value disables authentication; supplying both uses them unchanged. Generated passwords change after every restart, so configure both values when credentials must remain stable. Startup fails if the generated password cannot be written to stderr. Use Basic Auth only over localhost or HTTPS.</p>
-                    <aside class="note"><strong>SMTP authentication modes:</strong> omitting both credentials selects NO AUTH, which permits unauthenticated delivery and accepts arbitrary PLAIN/LOGIN credentials for test clients. Setting both requires valid AUTH; setting only one fails startup. PLAIN/LOGIN is permitted without TLS for development compatibility by default. Enable <code>-smtp-auth-require-tls</code> with SMTP TLS to reject AUTH on cleartext connections while allowing it after STARTTLS and over SMTPS; anonymous NO AUTH delivery is unchanged, and missing TLS makes startup fail. Each SMTP/SMTPS connection uses 10-second read and write timeouts; a message is limited to 100 MiB by default (configurable with <code>-smtp-max-message-mb</code>) and 50 recipients.</aside>
+                    <aside class="note"><strong>SMTP authentication and capacity:</strong> omitting both credentials selects NO AUTH, which permits unauthenticated delivery and accepts arbitrary PLAIN/LOGIN credentials for test clients. Setting both requires valid AUTH; setting only one fails startup. PLAIN/LOGIN is permitted without TLS for development compatibility by default. Enable <code>-smtp-auth-require-tls</code> with SMTP TLS to reject AUTH on cleartext connections while allowing it after STARTTLS and over SMTPS; anonymous NO AUTH delivery is unchanged, and missing TLS makes startup fail. Each SMTP/SMTPS connection uses 10-second read and write timeouts; a message is limited to 100 MiB by default (configurable with <code>-smtp-max-message-mb</code>) and 50 recipients. One per-process limit of eight active DATA transactions is shared by SMTP, STARTTLS, and SMTPS; <code>0</code> is unlimited. Each replica enforces its own limit. At capacity the client receives retryable <code>451 4.3.2 temporary resource limit reached; try again later</code>.</aside>
                     <h3>Persistent Docker example</h3>
                     <pre><code>docker run -d --name owlmail \
   -p 1025:1025 -p 1080:1080 \
@@ -229,6 +230,7 @@ SMTP_SECURE=false</code></pre>
                             <tbody>
                                 <tr><td>SMTP 监听</td><td><code>-smtp</code>、<code>-ip</code></td><td><code>OWLMAIL_SMTP_PORT</code>、<code>OWLMAIL_SMTP_HOST</code></td><td><code>1025</code>、<code>localhost</code></td></tr>
                                 <tr><td>SMTP 邮件上限</td><td><code>-smtp-max-message-mb</code></td><td><code>OWLMAIL_SMTP_MAX_MESSAGE_MB</code></td><td><code>100</code> MiB</td></tr>
+                                <tr><td>SMTP DATA 并发</td><td><code>-smtp-max-concurrency</code></td><td><code>OWLMAIL_SMTP_MAX_CONCURRENCY</code></td><td>每进程 <code>8</code>；<code>0</code> 表示不限制</td></tr>
                                 <tr><td>Web 监听</td><td><code>-web</code>、<code>-web-ip</code></td><td><code>OWLMAIL_WEB_PORT</code>、<code>OWLMAIL_WEB_HOST</code></td><td><code>1080</code>、<code>localhost</code></td></tr>
                                 <tr><td>邮件持久化</td><td><code>-mail-directory</code></td><td><code>OWLMAIL_MAIL_DIR</code></td><td>当前进程专用临时目录</td></tr>
                                 <tr><td>附件存储</td><td><code>-s3-enabled</code> 及 S3 参数</td><td><code>OWLMAIL_S3_ENABLED</code> 及 S3 变量</td><td>本地邮件目录</td></tr>
@@ -245,7 +247,7 @@ SMTP_SECURE=false</code></pre>
                     </div>
                     <h3>Web 认证默认策略</h3>
                     <p>只配置用户名时，OwlMail 会生成 32 字符随机密码，并在启动时向 stderr 输出一次；只配置密码时，用户名默认为 <code>admin</code>。两项均不配置表示关闭认证，两项均配置则原样使用。自动密码会在每次重启后变化，需要稳定凭据时应同时配置两项；如果无法将自动生成的密码写入 stderr，OwlMail 会启动失败。Basic Auth 只应在 localhost 或 HTTPS 上使用。</p>
-                    <aside class="note"><strong>SMTP 鉴权模式：</strong>两项凭据都省略时使用 NO AUTH，允许不认证投递，也接受测试客户端提交的任意 PLAIN/LOGIN 凭据；同时设置两项后强制验证，只设置一项会启动失败。为兼容开发环境，默认允许在未启用 TLS 时使用 PLAIN/LOGIN。启用 SMTP TLS 并设置 <code>-smtp-auth-require-tls</code> 后，明文连接会拒绝 AUTH，STARTTLS 后及 SMTPS 仍可正常认证；NO AUTH 匿名投递不变，缺少 TLS 配置会启动失败。每个 SMTP/SMTPS 连接的读写超时均为 10 秒；单封邮件默认最大 100 MiB（可用 <code>-smtp-max-message-mb</code> 调整），最多 50 个收件人。</aside>
+                    <aside class="note"><strong>SMTP 鉴权与容量：</strong>两项凭据都省略时使用 NO AUTH，允许不认证投递，也接受测试客户端提交的任意 PLAIN/LOGIN 凭据；同时设置两项后强制验证，只设置一项会启动失败。为兼容开发环境，默认允许在未启用 TLS 时使用 PLAIN/LOGIN。启用 SMTP TLS 并设置 <code>-smtp-auth-require-tls</code> 后，明文连接会拒绝 AUTH，STARTTLS 后及 SMTPS 仍可正常认证；NO AUTH 匿名投递不变，缺少 TLS 配置会启动失败。每个 SMTP/SMTPS 连接的读写超时均为 10 秒；单封邮件默认最大 100 MiB（可用 <code>-smtp-max-message-mb</code> 调整），最多 50 个收件人。普通 SMTP、STARTTLS 与 SMTPS 共用每进程 8 个活动 DATA 事务的默认上限；<code>0</code> 表示不限制，多副本各自执行上限。达到上限时客户端收到可重试的 <code>451 4.3.2 temporary resource limit reached; try again later</code>。</aside>
                     <h3>Docker 持久化示例</h3>
                     <pre><code>docker run -d --name owlmail \
   -p 1025:1025 -p 1080:1080 \


### PR DESCRIPTION
## Summary

- add `-smtp-max-concurrency` / `OWLMAIL_SMTP_MAX_CONCURRENCY`
- default to `8` active message-body transactions per process
- keep `0` as the explicit unlimited compatibility mode
- reject negative and malformed values during startup
- return retryable `451 4.3.2 temporary resource limit reached; try again later` when capacity is full

## Limiter ownership and scope

The limiter is owned by one `MailServer` instance. Ordinary SMTP, STARTTLS, and direct SMTPS sessions all use backends pointing to that same instance, so they share one process-wide limit. Each OwlMail replica enforces its own independent limit; this is not a cluster-global or distributed limiter.

The non-blocking slot acquisition happens at the start of `Session.Data`, before an email ID is generated or any EML/attachment staging is created. go-smtp invokes that entry point for DATA and BDAT/CHUNKING message processing. The slot covers raw EML staging, MIME/body parsing, attachment streaming plus size/SHA-256 calculation, optional S3 upload, and final atomic commit or rollback.

It does not limit TCP connections, SMTP sessions, AUTH, MAIL FROM, RCPT TO, REST, WebSocket, Web UI, or webhook delivery.

## Capacity response and cleanup

When no slot is available, the backend immediately returns an `smtp.SMTPError` with `451 4.3.2`. go-smtp drains the submitted DATA body before writing the final response and resets the transaction, preserving protocol synchronization and connection reuse without storing the rejected message.

A structured `defer` releases the slot after every accepted invocation, including:

- successful commit
- message read or MIME parse failure
- maximum-message-size failure
- raw/staging/attachment write failure
- atomic metadata or in-memory commit failure
- S3 upload failure and rollback
- client interruption
- server shutdown

Rejected transactions enter no storage code and therefore create no EML, temporary file, attachment directory, index record, or S3 object.

## Compatibility

Existing NO AUTH, SMTP AUTH, `smtp-auth-require-tls`, STARTTLS, SMTPS, message-size limits, transactional persistence/recovery, local and S3 attachment storage, webhook concurrency, and HTTP/WebSocket/UI behavior are unchanged.

## Verification

- `go test -race ./...`
- `go vet ./...`
- `go build ./cmd/owlmail`
- `golangci-lint run --timeout=5m`
- `bun test tests/docs/markdown.test.js tests/web/*.test.js` (70 passed)
- `git diff --check`
- `gofmt -s -l .` (no output)

Tests use deterministic gates/hooks rather than timing sleeps for the new concurrency behavior. They cover bounded pressure, unlimited mode, shared SMTP/STARTTLS/SMTPS capacity, retryable protocol responses and connection reuse, size/parse/storage/S3 failures, interruption/shutdown, and artifact cleanup.