### PR TITLE
feat(cli): add sendmail-compatible SMTP client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to OwlMail are documented in this file. The format follows
 
 ### Added
 
+- A sendmail-compatible `owlmail sendmail` subcommand for PHP, cron, and
+  legacy programs. It submits stdin through the normal SMTP boundary, supports
+  `-t`, `-f`, `-i`/`-oi`, explicit recipients, AUTH, STARTTLS, and SMTPS,
+  removes Bcc fields, negotiates SMTPUTF8, and returns stable sysexits-style
+  statuses for usage, message-data, permanent SMTP, local I/O, and temporary
+  SMTP failures.
 - A configurable per-process SMTP DATA concurrency limit shared by ordinary
   SMTP, STARTTLS, and SMTPS. The default of eight protects MIME parsing,
   transactional staging, attachment hashing, and S3 uploads; `0` preserves an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ All notable changes to OwlMail are documented in this file. The format follows
 - A sendmail-compatible `owlmail sendmail` subcommand for PHP, cron, and
   legacy programs. It submits stdin through the normal SMTP boundary, supports
   `-t`, `-f`, `-i`/`-oi`, explicit recipients, AUTH, STARTTLS, and SMTPS,
-  removes Bcc fields, negotiates SMTPUTF8, and returns stable sysexits-style
+  removes Bcc and Resent-Bcc fields, negotiates SMTPUTF8, bounds the whole
+  SMTP submission with a configurable timeout, and returns stable sysexits-style
   statuses for usage, message-data, permanent SMTP, local I/O, and temporary
   SMTP failures.
 - A configurable per-process SMTP DATA concurrency limit shared by ordinary

--- a/README.de.md
+++ b/README.de.md
@@ -54,6 +54,7 @@ Sie vor der Migration von API- oder Socket.IO-Clients die dokumentierten Untersc
 - 🆕 **Verbesserte RESTful API** - Standardisierteres API-Design (`/api/v1/*`)
 - 🆕 **Integrierte Hilfe** - Lokaler zweisprachiger Leitfaden im Posteingang oder unter `/help`
 - 🆕 **Webhook-Konfigurator** - Eingebetteter lokaler Editor unter `/webhooks` zum Erstellen, Importieren, Prüfen, Kopieren und Herunterladen von Weiterleitungsregeln
+- 🆕 **Sendmail-kompatible CLI** - [`owlmail sendmail`](./docs/de/Sendmail.md) übergibt PHP-, Cron- und Altprogramm-Nachrichten über die normale SMTP-Grenze
 
 ### Kompatibilität
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -55,6 +55,7 @@ client API ou Socket.IO.
 - 🆕 **Improved RESTful API** - More standardized API design (`/api/v1/*`)
 - 🆕 **Aide intégrée** - Guide local bilingue depuis la boîte de réception ou `/help`
 - 🆕 **Configurateur Webhook** - Éditeur local intégré sous `/webhooks` pour créer, importer, valider, copier et télécharger les règles de transfert
+- 🆕 **CLI compatible sendmail** - [`owlmail sendmail`](./docs/fr/Sendmail.md) soumet les messages PHP, Cron et historiques via la frontière SMTP normale
 
 ### Compatibility
 

--- a/README.it.md
+++ b/README.it.md
@@ -54,6 +54,7 @@ prima di migrare client API o Socket.IO.
 - 🆕 **API RESTful Migliorata** - Design API più standardizzato (`/api/v1/*`)
 - 🆕 **Guida integrata** - Guida locale bilingue dalla casella di posta o su `/help`
 - 🆕 **Configuratore Webhook** - Editor locale integrato in `/webhooks` per creare, importare, validare, copiare e scaricare le regole di inoltro
+- 🆕 **CLI compatibile con sendmail** - [`owlmail sendmail`](./docs/it/Sendmail.md) consegna i messaggi di PHP, Cron e programmi legacy tramite il normale confine SMTP
 
 ### Compatibilità
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -54,6 +54,7 @@ API レスポンスと WebSocket プロトコルは独自です。API や Socket
 - 🆕 **Improved RESTful API** - More standardized API design (`/api/v1/*`)
 - 🆕 **内蔵ヘルプ** - 受信トレイまたは `/help` から開けるローカル二言語ガイド
 - 🆕 **Webhook 設定ツール** - `/webhooks` で転送ルールの作成、インポート、検証、コピー、ダウンロードができる組み込みローカルエディター
+- 🆕 **sendmail 互換 CLI** - [`owlmail sendmail`](./docs/ja/Sendmail.md) は PHP、Cron、従来プログラムのメールを通常の SMTP 境界経由で送信
 
 ### Compatibility
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -54,6 +54,7 @@ WebSocket 프로토콜은 OwlMail 고유 형식입니다. API 또는 Socket.IO �
 - 🆕 **Improved RESTful API** - More standardized API design (`/api/v1/*`)
 - 🆕 **내장 도움말** - 받은 편지함 또는 `/help`에서 여는 로컬 이중 언어 가이드
 - 🆕 **Webhook 구성 도구** - `/webhooks`에서 전달 규칙을 생성, 가져오기, 검증, 복사 및 다운로드하는 내장 로컬 편집기
+- 🆕 **sendmail 호환 CLI** - [`owlmail sendmail`](./docs/ko/Sendmail.md)은 PHP, Cron 및 기존 프로그램의 메일을 일반 SMTP 경계를 통해 전달
 
 ### Compatibility
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ boundary before migrating API or Socket.IO clients.
 - 🆕 **Improved RESTful API** - More standardized API design (`/api/v1/*`)
 - 🆕 **Built-in Help** - Local bilingual guide available from the inbox or at `/help`
 - 🆕 **Webhook Configurator** - Embedded local editor at `/webhooks` for building, importing, validating, copying, and downloading forwarding rules
+- 🆕 **Sendmail-compatible CLI** - [`owlmail sendmail`](./docs/en/Sendmail.md) lets PHP, cron, and legacy programs submit through the normal SMTP security and capacity boundary
 
 ### Compatibility
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -55,6 +55,7 @@ OwlMail 是面向开发和测试环境的 SMTP 服务器与 Web 界面，支持�
 - 🆕 **改进的 RESTful API** - 更规范的 API 设计（`/api/v1/*`）
 - 🆕 **内置帮助** - 可从收件箱或 `/help` 打开本地中英文指南
 - 🆕 **Webhook 配置器** - 在 `/webhooks` 使用内置本地编辑器生成、导入、校验、复制和下载转发规则
+- 🆕 **Sendmail 兼容 CLI** - [`owlmail sendmail`](./docs/zh-CN/Sendmail.md) 让 PHP、Cron 和传统程序通过正常 SMTP 安全与容量边界投递
 
 ### 兼容性
 

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/soulteary/owlmail/internal/mailserver"
 	"github.com/soulteary/owlmail/internal/mcpserver"
 	"github.com/soulteary/owlmail/internal/outgoing"
+	"github.com/soulteary/owlmail/internal/sendmail"
 	webhooknotify "github.com/soulteary/owlmail/internal/webhook"
 )
 
@@ -695,6 +696,9 @@ func startServers(server *mailserver.MailServer, cfg *config.Config) error {
 }
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "sendmail" {
+		os.Exit(sendmail.Run(os.Args[2:], os.Stdin, os.Stdout, os.Stderr))
+	}
 	if len(os.Args) > 1 && os.Args[1] == "migrate-attachments" {
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		err := runAttachmentMigration(ctx, os.Args[2:], os.Stdout, os.Stderr)

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Select your preferred language:
 - [OwlMail 0.6.0 Release Notes](./en/Release-0.6.0.md)
 - [API Reference](./en/API-Reference.md)
 - [Operations and Troubleshooting](./en/Operations.md)
+- [Sendmail-compatible CLI](./en/Sendmail.md)
 - [Release Process](./en/Releasing.md)
 - [OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper](./en/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [API Refactoring Record (historical)](./en/internal/API_Refactoring_Record.md)
@@ -44,6 +45,7 @@ Select your preferred language:
 - [OwlMail 0.6.0 发布说明](./zh-CN/Release-0.6.0.md)
 - [API 参考](./zh-CN/API-Reference.md)
 - [运维与排障](./zh-CN/Operations.md)
+- [Sendmail 兼容 CLI](./zh-CN/Sendmail.md)
 - [发布流程](./zh-CN/Releasing.md)
 - [OwlMail × MailDev - 功能与 API 完整对比与迁移白皮书](./zh-CN/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [API 重构记录（历史资料）](./zh-CN/internal/API_Refactoring_Record.md)
@@ -61,6 +63,7 @@ Select your preferred language:
 - [OwlMail × MailDev - Vollständiger Funktions- und API-Vergleich sowie Migrations-Whitepaper](./de/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [API-Refactoring-Aufzeichnung](./de/internal/API_Refactoring_Record.md)
 - Gemeinsame Referenzen: [0.6.0 Release Notes (English)](./en/Release-0.6.0.md), [API (English)](./en/API-Reference.md), [Operations (English)](./en/Operations.md), [Webhook (English)](./en/Webhook-Forwarding.md)
+- [Sendmail-kompatible CLI](./de/Sendmail.md)
 
 ---
 
@@ -73,6 +76,7 @@ Select your preferred language:
 - [OwlMail × MailDev : Livre blanc complet sur les fonctionnalités, l'API et la migration](./fr/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [Enregistrement de la refactorisation de l'API](./fr/internal/API_Refactoring_Record.md)
 - Références partagées : [Notes de version 0.6.0 (English)](./en/Release-0.6.0.md), [API (English)](./en/API-Reference.md), [Operations (English)](./en/Operations.md), [Webhook (English)](./en/Webhook-Forwarding.md)
+- [CLI compatible sendmail](./fr/Sendmail.md)
 
 ---
 
@@ -85,6 +89,7 @@ Select your preferred language:
 - [OwlMail × MailDev: Libro bianco completo su funzionalità, API e migrazione](./it/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [Registro della Refactorizzazione dell'API](./it/internal/API_Refactoring_Record.md)
 - Riferimenti condivisi: [Note di rilascio 0.6.0 (English)](./en/Release-0.6.0.md), [API (English)](./en/API-Reference.md), [Operations (English)](./en/Operations.md), [Webhook (English)](./en/Webhook-Forwarding.md)
+- [CLI compatibile con sendmail](./it/Sendmail.md)
 
 ---
 
@@ -97,6 +102,7 @@ Select your preferred language:
 - [OwlMail × MailDev: 完全な機能と API の比較および移行ホワイトペーパー](./ja/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [API リファクタリング記録](./ja/internal/API_Refactoring_Record.md)
 - 共通リファレンス：[0.6.0 リリースノート (English)](./en/Release-0.6.0.md)、[API (English)](./en/API-Reference.md)、[Operations (English)](./en/Operations.md)、[Webhook (English)](./en/Webhook-Forwarding.md)
+- [sendmail 互換 CLI](./ja/Sendmail.md)
 
 ---
 
@@ -109,6 +115,7 @@ Select your preferred language:
 - [OwlMail × MailDev: 전체 기능 및 API 비교 및 마이그레이션 화이트페이퍼](./ko/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 - [API 리팩토링 기록](./ko/internal/API_Refactoring_Record.md)
 - 공통 참조: [0.6.0 릴리스 노트 (English)](./en/Release-0.6.0.md), [API (English)](./en/API-Reference.md), [Operations (English)](./en/Operations.md), [Webhook (English)](./en/Webhook-Forwarding.md)
+- [sendmail 호환 CLI](./ko/Sendmail.md)
 
 ---
 

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -24,6 +24,8 @@ in eigenen Verzeichnissen organisiert.
     dokumentierte MailDev-Unterschiede.
 - **[Betrieb und Fehlerbehebung](../en/Operations.md)** (English, [中文](../zh-CN/Operations.md))
   - Bereitstellungsprofile, Persistenz, Sicherheit, TLS, Kapazität und Diagnose.
+- **[Sendmail-kompatible CLI](./Sendmail.md)**
+  - PHP `sendmail_path`, Cron, SMTP/TLS/AUTH und stabile Statuswerte.
 - **[Webhook-Weiterleitung](../en/Webhook-Forwarding.md)** (English, [中文](../zh-CN/Webhook-Forwarding.md))
   - Filter, benutzerdefinierte Payloads, HMAC-Signaturen, Wiederholungen und
     die Integration mit `soulteary/webhook`.

--- a/docs/de/Sendmail.md
+++ b/docs/de/Sendmail.md
@@ -1,0 +1,50 @@
+# Sendmail-kompatible CLI
+
+`owlmail sendmail` liest eine RFC-5322-Nachricht von stdin und übergibt sie über
+den normalen OwlMail-SMTP-Listener. AUTH, TLS, Größen-, Empfänger- und
+DATA-Parallelitätsgrenzen werden dadurch nicht umgangen.
+
+```bash
+owlmail sendmail -t -i < message.eml
+```
+
+`-t` liest `To`, `Cc` und `Bcc`; explizite Empfänger werden ergänzt. Vor DATA
+werden alle Bcc-Felder einschließlich Fortsetzungszeilen entfernt. `-f ADDRESS`
+und `-fADDRESS` setzen den Envelope-Absender, `-f '<>'` den leeren Reverse Path.
+`-i`, `-oi` und `--` werden unterstützt. CRLF, Dot-Stuffing sowie RFC-2047- und
+UTF-8-Header werden korrekt behandelt; bei Bedarf wird SMTPUTF8 verwendet.
+
+## PHP
+
+```ini
+sendmail_path = "/usr/local/bin/owlmail sendmail -t -i"
+```
+
+```yaml
+environment:
+  OWLMAIL_SENDMAIL_HOST: owlmail
+  OWLMAIL_SENDMAIL_PORT: "1025"
+```
+
+## Konfiguration
+
+| Option | Umgebungsvariable | Standard |
+|---|---|---:|
+| `--host` | `OWLMAIL_SENDMAIL_HOST` | `127.0.0.1` |
+| `--port` | `OWLMAIL_SENDMAIL_PORT` | `1025` |
+| `--starttls` | `OWLMAIL_SENDMAIL_STARTTLS` | `false` |
+| `--smtps` | `OWLMAIL_SENDMAIL_SMTPS` | `false` |
+| `--username` | `OWLMAIL_SENDMAIL_USERNAME` | - |
+| `--password` | `OWLMAIL_SENDMAIL_PASSWORD` | - |
+
+STARTTLS und SMTPS schließen sich aus. Kennungen müssen gemeinsam gesetzt
+werden; das Passwort sollte aus der Umgebung kommen. TLS-Zertifikate werden
+gegen den System-Truststore und den Hostnamen geprüft. Es gibt keinen unsicheren
+Schalter zum Überspringen der Prüfung.
+
+Stabile Statuswerte: `0` Erfolg, `64` Argumentfehler, `65` Nachrichtendaten,
+`69` permanenter SMTP-Fehler, `74` lokaler I/O-Fehler und `75` temporärer
+SMTP-/Netzwerkfehler. Kennwort, Nachrichtentext und vollständiger AUTH-Dialog
+werden nicht protokolliert. Die vollständige Referenz steht auf
+[Englisch](../en/Sendmail.md) und [Chinesisch](../zh-CN/Sendmail.md).
+

--- a/docs/de/Sendmail.md
+++ b/docs/de/Sendmail.md
@@ -8,8 +8,8 @@ DATA-Parallelitätsgrenzen werden dadurch nicht umgangen.
 owlmail sendmail -t -i < message.eml
 ```
 
-`-t` liest `To`, `Cc` und `Bcc`; explizite Empfänger werden ergänzt. Vor DATA
-werden alle Bcc-Felder einschließlich Fortsetzungszeilen entfernt. `-f ADDRESS`
+`-t` liest `To`, `Cc`, `Bcc` und die `Resent-*`-Felder; explizite Empfänger werden ergänzt. Vor DATA
+werden alle Bcc- und Resent-Bcc-Felder einschließlich Fortsetzungszeilen entfernt. `-f ADDRESS`
 und `-fADDRESS` setzen den Envelope-Absender, `-f '<>'` den leeren Reverse Path.
 `-i`, `-oi` und `--` werden unterstützt. CRLF, Dot-Stuffing sowie RFC-2047- und
 UTF-8-Header werden korrekt behandelt; bei Bedarf wird SMTPUTF8 verwendet.
@@ -36,6 +36,7 @@ environment:
 | `--smtps` | `OWLMAIL_SENDMAIL_SMTPS` | `false` |
 | `--username` | `OWLMAIL_SENDMAIL_USERNAME` | - |
 | `--password` | `OWLMAIL_SENDMAIL_PASSWORD` | - |
+| `--timeout` | `OWLMAIL_SENDMAIL_TIMEOUT` | `30s` |
 
 STARTTLS und SMTPS schließen sich aus. Kennungen müssen gemeinsam gesetzt
 werden; das Passwort sollte aus der Umgebung kommen. TLS-Zertifikate werden
@@ -47,4 +48,3 @@ Stabile Statuswerte: `0` Erfolg, `64` Argumentfehler, `65` Nachrichtendaten,
 SMTP-/Netzwerkfehler. Kennwort, Nachrichtentext und vollständiger AUTH-Dialog
 werden nicht protokolliert. Die vollständige Referenz steht auf
 [Englisch](../en/Sendmail.md) und [Chinesisch](../zh-CN/Sendmail.md).
-

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -35,6 +35,11 @@ Welcome to the OwlMail documentation directory. This directory contains technica
     webhook capacity, backup/upgrade, shutdown boundaries, and failure diagnosis.
   - **Other languages**: [简体中文](../zh-CN/Operations.md)
 
+- **[Sendmail-compatible CLI](./Sendmail.md)**
+  - PHP `sendmail_path`, cron and legacy-program usage, SMTP/TLS/AUTH options,
+    envelope handling, stable exit statuses, and safety boundaries.
+  - **Other languages**: [简体中文](../zh-CN/Sendmail.md) | [Deutsch](../de/Sendmail.md) | [Français](../fr/Sendmail.md) | [Italiano](../it/Sendmail.md) | [日本語](../ja/Sendmail.md) | [한국어](../ko/Sendmail.md)
+
 - **[Webhook Forwarding](./Webhook-Forwarding.md)**
   - Use the embedded `/webhooks` configurator, or configure filtering, custom
     payload templates, HMAC signatures, retries, and integration with `soulteary/webhook` manually.

--- a/docs/en/Sendmail.md
+++ b/docs/en/Sendmail.md
@@ -1,0 +1,119 @@
+# Sendmail-compatible CLI
+
+`owlmail sendmail` gives PHP, cron jobs, and legacy applications a
+sendmail-style process interface while delivering through OwlMail's normal
+SMTP listener. It does not write to the mailbox directly. SMTP AUTH, TLS
+policy, the message-size limit, recipient limit, and DATA concurrency limit
+are therefore enforced by the server exactly as they are for any other SMTP
+client.
+
+## Basic use
+
+Pass recipients explicitly:
+
+```bash
+printf 'From: app@example.test\nSubject: Job finished\n\nDone.\n' |
+  owlmail sendmail operator@example.test
+```
+
+Or extract envelope recipients from `To`, `Cc`, and `Bcc`:
+
+```bash
+owlmail sendmail -t -i < message.eml
+```
+
+Explicit recipients and recipients found with `-t` are combined. Every `Bcc`
+field, including folded continuation lines, is removed before DATA is sent.
+`-i` and `-oi` are accepted for compatibility; the SMTP client always performs
+CRLF normalization and dot-stuffing. Use `-f '<>'` for an empty envelope sender.
+RFC 2047 and UTF-8 headers remain intact, and SMTPUTF8 is negotiated when raw
+UTF-8 headers or internationalized envelope addresses require it.
+
+## PHP `sendmail_path`
+
+Install the OwlMail binary in the PHP container or host, then add this to
+`php.ini`:
+
+```ini
+sendmail_path = "/usr/local/bin/owlmail sendmail -t -i"
+```
+
+Point the inherited process environment at the OwlMail service. For a Compose
+service named `owlmail`:
+
+```yaml
+environment:
+  OWLMAIL_SENDMAIL_HOST: owlmail
+  OWLMAIL_SENDMAIL_PORT: "1025"
+```
+
+PHP's `mail()` function can now submit through the same SMTP boundary:
+
+```php
+<?php
+mail('developer@example.test', 'OwlMail test', 'It works!', [
+    'From' => 'php@example.test',
+]);
+```
+
+## SMTP configuration
+
+Command-line options override environment variables.
+
+| Option | Environment variable | Default | Purpose |
+|---|---|---:|---|
+| `--host` | `OWLMAIL_SENDMAIL_HOST` | `127.0.0.1` | OwlMail SMTP host |
+| `--port` | `OWLMAIL_SENDMAIL_PORT` | `1025` | OwlMail SMTP port |
+| `--starttls` | `OWLMAIL_SENDMAIL_STARTTLS` | `false` | Require an advertised STARTTLS upgrade |
+| `--smtps` | `OWLMAIL_SENDMAIL_SMTPS` | `false` | Use implicit TLS from connection start |
+| `--username` | `OWLMAIL_SENDMAIL_USERNAME` | - | PLAIN AUTH username |
+| `--password` | `OWLMAIL_SENDMAIL_PASSWORD` | - | PLAIN AUTH password |
+
+`--smtp-host`, `--smtp-ip`, and `--smtp-port` are accepted aliases. STARTTLS
+and SMTPS are mutually exclusive. Credentials must be provided together;
+prefer `OWLMAIL_SENDMAIL_PASSWORD` over a command-line password so the secret
+does not appear in a process listing.
+
+For a TLS-required OwlMail listener:
+
+```bash
+export OWLMAIL_SENDMAIL_HOST=owlmail.example.test
+export OWLMAIL_SENDMAIL_PORT=1025
+export OWLMAIL_SENDMAIL_STARTTLS=true
+export OWLMAIL_SENDMAIL_USERNAME=app
+export OWLMAIL_SENDMAIL_PASSWORD='replace-me'
+owlmail sendmail -t < message.eml
+```
+
+SMTPS normally uses port 465 and `OWLMAIL_SENDMAIL_SMTPS=true`. Certificates
+are verified against the operating system trust store and the configured host
+name. Install a private CA in that trust store when OwlMail uses a private
+certificate; the command intentionally has no insecure-skip-verification mode.
+
+## Compatible arguments
+
+- `-t`: add addresses from all `To`, `Cc`, and `Bcc` fields.
+- `-f ADDRESS` or `-fADDRESS`: select the envelope sender. `-f '<>'` selects
+  the null reverse path.
+- `-i` and `-oi`: accepted no-op compatibility forms.
+- `--`: stop option parsing so a later value is always treated as a recipient.
+
+Unknown sendmail flags fail instead of being silently ignored.
+
+## Exit status
+
+The stable values follow `sysexits(3)` conventions:
+
+| Status | Meaning |
+|---:|---|
+| `0` | Server accepted DATA |
+| `64` | Invalid option or client configuration |
+| `65` | Invalid RFC 5322 header data or no recipients found with `-t` |
+| `69` | Permanent SMTP failure, including a 5xx reply |
+| `74` | Local stdin/read failure |
+| `75` | Temporary SMTP 4xx reply or network failure; retry is appropriate |
+
+Once the server returns `250` after DATA, a later QUIT failure still returns
+success so callers do not resend an already accepted message. Diagnostics
+never include the password, message body, or full authentication exchange.
+

--- a/docs/en/Sendmail.md
+++ b/docs/en/Sendmail.md
@@ -16,14 +16,15 @@ printf 'From: app@example.test\nSubject: Job finished\n\nDone.\n' |
   owlmail sendmail operator@example.test
 ```
 
-Or extract envelope recipients from `To`, `Cc`, and `Bcc`:
+Or extract envelope recipients from `To`, `Cc`, `Bcc`, and their `Resent-*`
+counterparts:
 
 ```bash
 owlmail sendmail -t -i < message.eml
 ```
 
 Explicit recipients and recipients found with `-t` are combined. Every `Bcc`
-field, including folded continuation lines, is removed before DATA is sent.
+and `Resent-Bcc` field, including folded continuation lines, is removed before DATA is sent.
 `-i` and `-oi` are accepted for compatibility; the SMTP client always performs
 CRLF normalization and dot-stuffing. Use `-f '<>'` for an empty envelope sender.
 RFC 2047 and UTF-8 headers remain intact, and SMTPUTF8 is negotiated when raw
@@ -68,6 +69,7 @@ Command-line options override environment variables.
 | `--smtps` | `OWLMAIL_SENDMAIL_SMTPS` | `false` | Use implicit TLS from connection start |
 | `--username` | `OWLMAIL_SENDMAIL_USERNAME` | - | PLAIN AUTH username |
 | `--password` | `OWLMAIL_SENDMAIL_PASSWORD` | - | PLAIN AUTH password |
+| `--timeout` | `OWLMAIL_SENDMAIL_TIMEOUT` | `30s` | Whole SMTP submission deadline, including connect and DATA acceptance |
 
 `--smtp-host`, `--smtp-ip`, and `--smtp-port` are accepted aliases. STARTTLS
 and SMTPS are mutually exclusive. Credentials must be provided together;
@@ -92,7 +94,8 @@ certificate; the command intentionally has no insecure-skip-verification mode.
 
 ## Compatible arguments
 
-- `-t`: add addresses from all `To`, `Cc`, and `Bcc` fields.
+- `-t`: add addresses from all `To`, `Cc`, `Bcc`, `Resent-To`, `Resent-Cc`,
+  and `Resent-Bcc` fields.
 - `-f ADDRESS` or `-fADDRESS`: select the envelope sender. `-f '<>'` selects
   the null reverse path.
 - `-i` and `-oi`: accepted no-op compatibility forms.
@@ -116,4 +119,3 @@ The stable values follow `sysexits(3)` conventions:
 Once the server returns `250` after DATA, a later QUIT failure still returns
 success so callers do not resend an already accepted message. Diagnostics
 never include the password, message body, or full authentication exchange.
-

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -24,6 +24,8 @@ langue dans des répertoires distincts.
     différences documentées avec MailDev.
 - **[Exploitation et dépannage](../en/Operations.md)** (English, [中文](../zh-CN/Operations.md))
   - Déploiement, persistance, sécurité, TLS, capacité et diagnostic.
+- **[CLI compatible sendmail](./Sendmail.md)**
+  - PHP `sendmail_path`, Cron, SMTP/TLS/AUTH et codes de sortie stables.
 - **[Transmission Webhook](../en/Webhook-Forwarding.md)** (English, [中文](../zh-CN/Webhook-Forwarding.md))
   - Filtres, charges utiles personnalisées, signatures HMAC, tentatives et
     intégration avec `soulteary/webhook`.

--- a/docs/fr/Sendmail.md
+++ b/docs/fr/Sendmail.md
@@ -1,0 +1,50 @@
+# CLI compatible sendmail
+
+`owlmail sendmail` lit un message RFC 5322 sur stdin et l'envoie au listener
+SMTP normal d'OwlMail. AUTH, TLS, les limites de taille, de destinataires et de
+concurrence DATA restent donc appliqués.
+
+```bash
+owlmail sendmail -t -i < message.eml
+```
+
+`-t` extrait `To`, `Cc` et `Bcc` et les ajoute aux destinataires explicites.
+Tous les champs Bcc et leurs continuations sont retirés avant DATA. `-f ADDRESS`
+ou `-fADDRESS` choisit l'expéditeur d'enveloppe; `-f '<>'` utilise un reverse
+path vide. `-i`, `-oi` et `--` sont acceptés. CRLF, dot-stuffing et les en-têtes
+RFC 2047/UTF-8 sont préservés, avec SMTPUTF8 lorsque nécessaire.
+
+## PHP
+
+```ini
+sendmail_path = "/usr/local/bin/owlmail sendmail -t -i"
+```
+
+```yaml
+environment:
+  OWLMAIL_SENDMAIL_HOST: owlmail
+  OWLMAIL_SENDMAIL_PORT: "1025"
+```
+
+## Configuration
+
+| Option | Variable d'environnement | Défaut |
+|---|---|---:|
+| `--host` | `OWLMAIL_SENDMAIL_HOST` | `127.0.0.1` |
+| `--port` | `OWLMAIL_SENDMAIL_PORT` | `1025` |
+| `--starttls` | `OWLMAIL_SENDMAIL_STARTTLS` | `false` |
+| `--smtps` | `OWLMAIL_SENDMAIL_SMTPS` | `false` |
+| `--username` | `OWLMAIL_SENDMAIL_USERNAME` | - |
+| `--password` | `OWLMAIL_SENDMAIL_PASSWORD` | - |
+
+STARTTLS et SMTPS sont exclusifs. L'identifiant et le mot de passe doivent être
+fournis ensemble; préférez la variable d'environnement pour le secret. Les
+certificats TLS sont vérifiés avec le magasin système et le nom d'hôte; aucune
+option non sûre ne désactive cette vérification.
+
+Codes stables : `0` succès, `64` arguments, `65` données du message, `69` erreur
+SMTP permanente, `74` E/S locale, `75` erreur SMTP temporaire ou réseau. Le mot
+de passe, le corps et l'échange AUTH complet ne sont jamais journalisés. Voir la
+référence complète en [anglais](../en/Sendmail.md) ou en
+[chinois](../zh-CN/Sendmail.md).
+

--- a/docs/fr/Sendmail.md
+++ b/docs/fr/Sendmail.md
@@ -8,8 +8,8 @@ concurrence DATA restent donc appliqués.
 owlmail sendmail -t -i < message.eml
 ```
 
-`-t` extrait `To`, `Cc` et `Bcc` et les ajoute aux destinataires explicites.
-Tous les champs Bcc et leurs continuations sont retirés avant DATA. `-f ADDRESS`
+`-t` extrait `To`, `Cc`, `Bcc` et les champs `Resent-*`, puis les ajoute aux destinataires explicites.
+Tous les champs Bcc/Resent-Bcc et leurs continuations sont retirés avant DATA. `-f ADDRESS`
 ou `-fADDRESS` choisit l'expéditeur d'enveloppe; `-f '<>'` utilise un reverse
 path vide. `-i`, `-oi` et `--` sont acceptés. CRLF, dot-stuffing et les en-têtes
 RFC 2047/UTF-8 sont préservés, avec SMTPUTF8 lorsque nécessaire.
@@ -36,6 +36,7 @@ environment:
 | `--smtps` | `OWLMAIL_SENDMAIL_SMTPS` | `false` |
 | `--username` | `OWLMAIL_SENDMAIL_USERNAME` | - |
 | `--password` | `OWLMAIL_SENDMAIL_PASSWORD` | - |
+| `--timeout` | `OWLMAIL_SENDMAIL_TIMEOUT` | `30s` |
 
 STARTTLS et SMTPS sont exclusifs. L'identifiant et le mot de passe doivent être
 fournis ensemble; préférez la variable d'environnement pour le secret. Les
@@ -47,4 +48,3 @@ SMTP permanente, `74` E/S locale, `75` erreur SMTP temporaire ou réseau. Le mot
 de passe, le corps et l'échange AUTH complet ne sont jamais journalisés. Voir la
 référence complète en [anglais](../en/Sendmail.md) ou en
 [chinois](../zh-CN/Sendmail.md).
-

--- a/docs/it/README.md
+++ b/docs/it/README.md
@@ -24,6 +24,8 @@ lingua in directory separate.
     documentate rispetto a MailDev.
 - **[Operazioni e risoluzione problemi](../en/Operations.md)** (English, [中文](../zh-CN/Operations.md))
   - Distribuzione, persistenza, sicurezza, TLS, capacità e diagnostica.
+- **[CLI compatibile con sendmail](./Sendmail.md)**
+  - PHP `sendmail_path`, Cron, SMTP/TLS/AUTH e codici di uscita stabili.
 - **[Inoltro Webhook](../en/Webhook-Forwarding.md)** (English, [中文](../zh-CN/Webhook-Forwarding.md))
   - Filtri, payload personalizzati, firme HMAC, nuovi tentativi e integrazione
     con `soulteary/webhook`.

--- a/docs/it/Sendmail.md
+++ b/docs/it/Sendmail.md
@@ -8,8 +8,8 @@ concorrenza DATA rimangono quindi attivi.
 owlmail sendmail -t -i < message.eml
 ```
 
-`-t` estrae `To`, `Cc` e `Bcc` e li aggiunge ai destinatari espliciti. Tutti i
-campi Bcc e le continuazioni vengono rimossi prima di DATA. `-f ADDRESS` o
+`-t` estrae `To`, `Cc`, `Bcc` e i campi `Resent-*`, aggiungendoli ai destinatari espliciti. Tutti i
+campi Bcc/Resent-Bcc e le continuazioni vengono rimossi prima di DATA. `-f ADDRESS` o
 `-fADDRESS` imposta il mittente dell'envelope; `-f '<>'` usa il reverse path
 vuoto. Sono supportati `-i`, `-oi` e `--`. CRLF, dot-stuffing e header RFC
 2047/UTF-8 restano corretti, con SMTPUTF8 quando necessario.
@@ -36,6 +36,7 @@ environment:
 | `--smtps` | `OWLMAIL_SENDMAIL_SMTPS` | `false` |
 | `--username` | `OWLMAIL_SENDMAIL_USERNAME` | - |
 | `--password` | `OWLMAIL_SENDMAIL_PASSWORD` | - |
+| `--timeout` | `OWLMAIL_SENDMAIL_TIMEOUT` | `30s` |
 
 STARTTLS e SMTPS sono mutuamente esclusivi. Username e password vanno forniti
 insieme; per il segreto è preferibile la variabile d'ambiente. I certificati TLS
@@ -46,4 +47,3 @@ Codici stabili: `0` successo, `64` argomenti, `65` dati messaggio, `69` errore
 SMTP permanente, `74` I/O locale e `75` errore SMTP temporaneo o di rete.
 Password, corpo e scambio AUTH completo non vengono registrati. Riferimento
 completo in [inglese](../en/Sendmail.md) o [cinese](../zh-CN/Sendmail.md).
-

--- a/docs/it/Sendmail.md
+++ b/docs/it/Sendmail.md
@@ -1,0 +1,49 @@
+# CLI compatibile con sendmail
+
+`owlmail sendmail` legge un messaggio RFC 5322 da stdin e lo consegna al normale
+listener SMTP di OwlMail. AUTH, TLS e i limiti per dimensione, destinatari e
+concorrenza DATA rimangono quindi attivi.
+
+```bash
+owlmail sendmail -t -i < message.eml
+```
+
+`-t` estrae `To`, `Cc` e `Bcc` e li aggiunge ai destinatari espliciti. Tutti i
+campi Bcc e le continuazioni vengono rimossi prima di DATA. `-f ADDRESS` o
+`-fADDRESS` imposta il mittente dell'envelope; `-f '<>'` usa il reverse path
+vuoto. Sono supportati `-i`, `-oi` e `--`. CRLF, dot-stuffing e header RFC
+2047/UTF-8 restano corretti, con SMTPUTF8 quando necessario.
+
+## PHP
+
+```ini
+sendmail_path = "/usr/local/bin/owlmail sendmail -t -i"
+```
+
+```yaml
+environment:
+  OWLMAIL_SENDMAIL_HOST: owlmail
+  OWLMAIL_SENDMAIL_PORT: "1025"
+```
+
+## Configurazione
+
+| Opzione | Variabile d'ambiente | Predefinito |
+|---|---|---:|
+| `--host` | `OWLMAIL_SENDMAIL_HOST` | `127.0.0.1` |
+| `--port` | `OWLMAIL_SENDMAIL_PORT` | `1025` |
+| `--starttls` | `OWLMAIL_SENDMAIL_STARTTLS` | `false` |
+| `--smtps` | `OWLMAIL_SENDMAIL_SMTPS` | `false` |
+| `--username` | `OWLMAIL_SENDMAIL_USERNAME` | - |
+| `--password` | `OWLMAIL_SENDMAIL_PASSWORD` | - |
+
+STARTTLS e SMTPS sono mutuamente esclusivi. Username e password vanno forniti
+insieme; per il segreto è preferibile la variabile d'ambiente. I certificati TLS
+sono verificati con il trust store di sistema e il nome host; non esiste
+un'opzione insicura per saltare la verifica.
+
+Codici stabili: `0` successo, `64` argomenti, `65` dati messaggio, `69` errore
+SMTP permanente, `74` I/O locale e `75` errore SMTP temporaneo o di rete.
+Password, corpo e scambio AUTH completo non vengono registrati. Riferimento
+completo in [inglese](../en/Sendmail.md) o [cinese](../zh-CN/Sendmail.md).
+

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -22,6 +22,8 @@ OwlMail のドキュメントへようこそ。文書は言語別のディレク
   - ルート、認証、レスポンス形式、WebSocket イベント、および MailDev との相違点。
 - **[運用・トラブルシューティング](../en/Operations.md)** (English、[中文](../zh-CN/Operations.md))
   - デプロイ、永続化、セキュリティ、TLS、容量、障害診断。
+- **[sendmail 互換 CLI](./Sendmail.md)**
+  - PHP `sendmail_path`、Cron、SMTP/TLS/AUTH、安定した終了コード。
 - **[Webhook 転送](../en/Webhook-Forwarding.md)** (English、[中文](../zh-CN/Webhook-Forwarding.md))
   - フィルター、カスタムペイロード、HMAC 署名、再試行、`soulteary/webhook` 連携。
 - **[実行可能な Webhook 例](../../examples/webhooks/README.md)** (English、[中文](../../examples/webhooks/README.zh-CN.md))

--- a/docs/ja/Sendmail.md
+++ b/docs/ja/Sendmail.md
@@ -8,8 +8,8 @@ SMTP リスナーへ送信します。AUTH、TLS、サイズ、受信者数、DA
 owlmail sendmail -t -i < message.eml
 ```
 
-`-t` は `To`、`Cc`、`Bcc` を抽出し、明示的な受信者に追加します。DATA の前に
-Bcc と継続行をすべて削除します。`-f ADDRESS` または `-fADDRESS` は envelope
+`-t` は `To`、`Cc`、`Bcc` と `Resent-*` フィールドを抽出し、明示的な受信者に追加します。DATA の前に
+Bcc、Resent-Bcc と継続行をすべて削除します。`-f ADDRESS` または `-fADDRESS` は envelope
 sender を指定し、`-f '<>'` は空の reverse path を指定します。`-i`、`-oi`、
 `--` に対応します。CRLF、dot-stuffing、RFC 2047/UTF-8 ヘッダーを保持し、必要時
 は SMTPUTF8 を使用します。
@@ -36,6 +36,7 @@ environment:
 | `--smtps` | `OWLMAIL_SENDMAIL_SMTPS` | `false` |
 | `--username` | `OWLMAIL_SENDMAIL_USERNAME` | - |
 | `--password` | `OWLMAIL_SENDMAIL_PASSWORD` | - |
+| `--timeout` | `OWLMAIL_SENDMAIL_TIMEOUT` | `30s` |
 
 STARTTLS と SMTPS は同時に指定できません。ユーザー名とパスワードは両方必要で、
 秘密情報は環境変数から渡すことを推奨します。TLS 証明書は OS の信頼ストアとホスト名
@@ -45,4 +46,3 @@ STARTTLS と SMTPS は同時に指定できません。ユーザー名とパス�
 SMTP エラー、`74` ローカル I/O、`75` 一時的 SMTP/ネットワークエラーです。
 パスワード、本文、AUTH の完全な交換は記録しません。完全な説明は
 [英語](../en/Sendmail.md)または[中国語](../zh-CN/Sendmail.md)を参照してください。
-

--- a/docs/ja/Sendmail.md
+++ b/docs/ja/Sendmail.md
@@ -1,0 +1,48 @@
+# sendmail 互換 CLI
+
+`owlmail sendmail` は stdin から RFC 5322 メッセージを読み、OwlMail の通常の
+SMTP リスナーへ送信します。AUTH、TLS、サイズ、受信者数、DATA 同時実行数の
+制限を迂回しません。
+
+```bash
+owlmail sendmail -t -i < message.eml
+```
+
+`-t` は `To`、`Cc`、`Bcc` を抽出し、明示的な受信者に追加します。DATA の前に
+Bcc と継続行をすべて削除します。`-f ADDRESS` または `-fADDRESS` は envelope
+sender を指定し、`-f '<>'` は空の reverse path を指定します。`-i`、`-oi`、
+`--` に対応します。CRLF、dot-stuffing、RFC 2047/UTF-8 ヘッダーを保持し、必要時
+は SMTPUTF8 を使用します。
+
+## PHP
+
+```ini
+sendmail_path = "/usr/local/bin/owlmail sendmail -t -i"
+```
+
+```yaml
+environment:
+  OWLMAIL_SENDMAIL_HOST: owlmail
+  OWLMAIL_SENDMAIL_PORT: "1025"
+```
+
+## 設定
+
+| オプション | 環境変数 | 既定値 |
+|---|---|---:|
+| `--host` | `OWLMAIL_SENDMAIL_HOST` | `127.0.0.1` |
+| `--port` | `OWLMAIL_SENDMAIL_PORT` | `1025` |
+| `--starttls` | `OWLMAIL_SENDMAIL_STARTTLS` | `false` |
+| `--smtps` | `OWLMAIL_SENDMAIL_SMTPS` | `false` |
+| `--username` | `OWLMAIL_SENDMAIL_USERNAME` | - |
+| `--password` | `OWLMAIL_SENDMAIL_PASSWORD` | - |
+
+STARTTLS と SMTPS は同時に指定できません。ユーザー名とパスワードは両方必要で、
+秘密情報は環境変数から渡すことを推奨します。TLS 証明書は OS の信頼ストアとホスト名
+で検証され、検証を無効にする危険なオプションはありません。
+
+安定した終了コードは、`0` 成功、`64` 引数、`65` メッセージデータ、`69` 恒久的
+SMTP エラー、`74` ローカル I/O、`75` 一時的 SMTP/ネットワークエラーです。
+パスワード、本文、AUTH の完全な交換は記録しません。完全な説明は
+[英語](../en/Sendmail.md)または[中国語](../zh-CN/Sendmail.md)を参照してください。
+

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -22,6 +22,8 @@ OwlMail 문서에 오신 것을 환영합니다. 문서는 언어별 디렉터�
   - 경로, 인증, 응답 형식, WebSocket 이벤트 및 MailDev와의 차이점.
 - **[운영 및 문제 해결](../en/Operations.md)** (English, [中文](../zh-CN/Operations.md))
   - 배포, 영속성, 보안, TLS, 용량 및 장애 진단.
+- **[sendmail 호환 CLI](./Sendmail.md)**
+  - PHP `sendmail_path`, Cron, SMTP/TLS/AUTH 및 안정적인 종료 코드.
 - **[Webhook 전달](../en/Webhook-Forwarding.md)** (English, [中文](../zh-CN/Webhook-Forwarding.md))
   - 필터, 사용자 지정 페이로드, HMAC 서명, 재시도 및 `soulteary/webhook` 연동.
 - **[실행 가능한 Webhook 예제](../../examples/webhooks/README.md)** (English, [中文](../../examples/webhooks/README.zh-CN.md))

--- a/docs/ko/Sendmail.md
+++ b/docs/ko/Sendmail.md
@@ -1,0 +1,48 @@
+# sendmail 호환 CLI
+
+`owlmail sendmail`은 stdin에서 RFC 5322 메시지를 읽어 OwlMail의 일반 SMTP
+리스너로 전달합니다. 따라서 AUTH, TLS, 크기, 수신자 수 및 DATA 동시성 제한을
+우회하지 않습니다.
+
+```bash
+owlmail sendmail -t -i < message.eml
+```
+
+`-t`는 `To`, `Cc`, `Bcc`를 추출하여 명시적 수신자에 추가합니다. DATA 전송 전에
+Bcc 필드와 연속 줄을 모두 제거합니다. `-f ADDRESS` 또는 `-fADDRESS`는 envelope
+sender를 설정하고 `-f '<>'`는 빈 reverse path를 사용합니다. `-i`, `-oi`, `--`를
+지원합니다. CRLF, dot-stuffing, RFC 2047/UTF-8 헤더를 보존하며 필요하면 SMTPUTF8을
+사용합니다.
+
+## PHP
+
+```ini
+sendmail_path = "/usr/local/bin/owlmail sendmail -t -i"
+```
+
+```yaml
+environment:
+  OWLMAIL_SENDMAIL_HOST: owlmail
+  OWLMAIL_SENDMAIL_PORT: "1025"
+```
+
+## 설정
+
+| 옵션 | 환경 변수 | 기본값 |
+|---|---|---:|
+| `--host` | `OWLMAIL_SENDMAIL_HOST` | `127.0.0.1` |
+| `--port` | `OWLMAIL_SENDMAIL_PORT` | `1025` |
+| `--starttls` | `OWLMAIL_SENDMAIL_STARTTLS` | `false` |
+| `--smtps` | `OWLMAIL_SENDMAIL_SMTPS` | `false` |
+| `--username` | `OWLMAIL_SENDMAIL_USERNAME` | - |
+| `--password` | `OWLMAIL_SENDMAIL_PASSWORD` | - |
+
+STARTTLS와 SMTPS는 함께 사용할 수 없습니다. 사용자 이름과 암호를 함께 제공해야 하며,
+암호는 환경 변수로 전달하는 것이 좋습니다. TLS 인증서는 시스템 신뢰 저장소와 호스트
+이름으로 검증되며 검증을 건너뛰는 안전하지 않은 옵션은 없습니다.
+
+안정적인 종료 코드는 `0` 성공, `64` 인수, `65` 메시지 데이터, `69` 영구 SMTP 오류,
+`74` 로컬 I/O, `75` 임시 SMTP/네트워크 오류입니다. 암호, 메시지 본문 및 전체 AUTH
+교환은 기록하지 않습니다. 전체 문서는 [영어](../en/Sendmail.md) 또는
+[중국어](../zh-CN/Sendmail.md)를 참조하세요.
+

--- a/docs/ko/Sendmail.md
+++ b/docs/ko/Sendmail.md
@@ -8,8 +8,8 @@
 owlmail sendmail -t -i < message.eml
 ```
 
-`-t`는 `To`, `Cc`, `Bcc`를 추출하여 명시적 수신자에 추가합니다. DATA 전송 전에
-Bcc 필드와 연속 줄을 모두 제거합니다. `-f ADDRESS` 또는 `-fADDRESS`는 envelope
+`-t`는 `To`, `Cc`, `Bcc` 및 `Resent-*` 필드를 추출하여 명시적 수신자에 추가합니다. DATA 전송 전에
+Bcc/Resent-Bcc 필드와 연속 줄을 모두 제거합니다. `-f ADDRESS` 또는 `-fADDRESS`는 envelope
 sender를 설정하고 `-f '<>'`는 빈 reverse path를 사용합니다. `-i`, `-oi`, `--`를
 지원합니다. CRLF, dot-stuffing, RFC 2047/UTF-8 헤더를 보존하며 필요하면 SMTPUTF8을
 사용합니다.
@@ -36,6 +36,7 @@ environment:
 | `--smtps` | `OWLMAIL_SENDMAIL_SMTPS` | `false` |
 | `--username` | `OWLMAIL_SENDMAIL_USERNAME` | - |
 | `--password` | `OWLMAIL_SENDMAIL_PASSWORD` | - |
+| `--timeout` | `OWLMAIL_SENDMAIL_TIMEOUT` | `30s` |
 
 STARTTLS와 SMTPS는 함께 사용할 수 없습니다. 사용자 이름과 암호를 함께 제공해야 하며,
 암호는 환경 변수로 전달하는 것이 좋습니다. TLS 인증서는 시스템 신뢰 저장소와 호스트
@@ -45,4 +46,3 @@ STARTTLS와 SMTPS는 함께 사용할 수 없습니다. 사용자 이름과 암�
 `74` 로컬 I/O, `75` 임시 SMTP/네트워크 오류입니다. 암호, 메시지 본문 및 전체 AUTH
 교환은 기록하지 않습니다. 전체 문서는 [영어](../en/Sendmail.md) 또는
 [중국어](../zh-CN/Sendmail.md)를 참조하세요.
-

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -34,6 +34,11 @@
     备份升级、关闭边界和故障定位。
   - **其他语言**：[English](../en/Operations.md)
 
+- **[Sendmail 兼容 CLI](./Sendmail.md)**
+  - PHP `sendmail_path`、Cron 与传统程序用法，SMTP/TLS/AUTH 配置、信封处理、
+    稳定退出码和安全边界。
+  - **其他语言**：[English](../en/Sendmail.md) | [Deutsch](../de/Sendmail.md) | [Français](../fr/Sendmail.md) | [Italiano](../it/Sendmail.md) | [日本語](../ja/Sendmail.md) | [한국어](../ko/Sendmail.md)
+
 - **[Webhook 消息转发](./Webhook-Forwarding.md)**
   - 使用内置 `/webhooks` 配置器，或手动配置邮件过滤、自定义消息模板、HMAC
     签名、失败重试，以及与 `soulteary/webhook` 的对接。

--- a/docs/zh-CN/Sendmail.md
+++ b/docs/zh-CN/Sendmail.md
@@ -13,13 +13,14 @@ printf 'From: app@example.test\nSubject: Job finished\n\nDone.\n' |
   owlmail sendmail operator@example.test
 ```
 
-也可以从 `To`、`Cc` 和 `Bcc` 提取信封收件人：
+也可以从 `To`、`Cc`、`Bcc` 及对应的 `Resent-*` 字段提取信封收件人：
 
 ```bash
 owlmail sendmail -t -i < message.eml
 ```
 
-显式收件人与 `-t` 提取的收件人会合并。发送 DATA 前会删除所有 `Bcc` 字段及其
+显式收件人与 `-t` 提取的收件人会合并。发送 DATA 前会删除所有 `Bcc`、
+`Resent-Bcc` 字段及其
 折行续行。`-i` 和 `-oi` 作为兼容参数接受；SMTP 客户端始终正确处理 CRLF 和
 dot-stuffing。`-f '<>'` 表示空 envelope sender。RFC 2047 与 UTF-8 头保持原样；
 原始 UTF-8 头或国际化信封地址需要时会协商 SMTPUTF8。
@@ -61,6 +62,7 @@ mail('developer@example.test', 'OwlMail test', 'It works!', [
 | `--smtps` | `OWLMAIL_SENDMAIL_SMTPS` | `false` | 连接建立时直接使用 TLS |
 | `--username` | `OWLMAIL_SENDMAIL_USERNAME` | - | PLAIN AUTH 用户名 |
 | `--password` | `OWLMAIL_SENDMAIL_PASSWORD` | - | PLAIN AUTH 密码 |
+| `--timeout` | `OWLMAIL_SENDMAIL_TIMEOUT` | `30s` | 整次 SMTP 投递时限，包括连接和 DATA 接受 |
 
 同时支持 `--smtp-host`、`--smtp-ip` 和 `--smtp-port` 别名。STARTTLS 与 SMTPS
 互斥，用户名和密码必须同时配置。建议使用 `OWLMAIL_SENDMAIL_PASSWORD`，避免
@@ -83,7 +85,8 @@ SMTPS 通常使用 465 端口，并设置 `OWLMAIL_SENDMAIL_SMTPS=true`。证书
 
 ## 兼容参数
 
-- `-t`：加入所有 `To`、`Cc`、`Bcc` 地址。
+- `-t`：加入所有 `To`、`Cc`、`Bcc`、`Resent-To`、`Resent-Cc`、
+  `Resent-Bcc` 地址。
 - `-f ADDRESS` 或 `-fADDRESS`：设置 envelope sender；`-f '<>'` 使用空反向路径。
 - `-i`、`-oi`：接受但无需额外处理的兼容形式。
 - `--`：结束参数解析，后续值一律作为收件人。
@@ -105,4 +108,3 @@ SMTPS 通常使用 465 端口，并设置 `OWLMAIL_SENDMAIL_SMTPS=true`。证书
 
 服务端在 DATA 后返回 `250` 即构成接受边界；此后的 QUIT 失败仍返回成功，避免调用方
 重复投递。诊断信息不会包含密码、邮件正文或完整认证交换。
-

--- a/docs/zh-CN/Sendmail.md
+++ b/docs/zh-CN/Sendmail.md
@@ -1,0 +1,108 @@
+# Sendmail 兼容 CLI
+
+`owlmail sendmail` 为 PHP、Cron 和传统程序提供 sendmail 风格的进程接口，
+但邮件仍通过 OwlMail 的正常 SMTP 监听器投递，不会直接写入邮箱。因此服务端配置的
+SMTP AUTH、TLS 策略、邮件大小、收件人数和 DATA 并发限制都会正常生效。
+
+## 基本用法
+
+显式指定收件人：
+
+```bash
+printf 'From: app@example.test\nSubject: Job finished\n\nDone.\n' |
+  owlmail sendmail operator@example.test
+```
+
+也可以从 `To`、`Cc` 和 `Bcc` 提取信封收件人：
+
+```bash
+owlmail sendmail -t -i < message.eml
+```
+
+显式收件人与 `-t` 提取的收件人会合并。发送 DATA 前会删除所有 `Bcc` 字段及其
+折行续行。`-i` 和 `-oi` 作为兼容参数接受；SMTP 客户端始终正确处理 CRLF 和
+dot-stuffing。`-f '<>'` 表示空 envelope sender。RFC 2047 与 UTF-8 头保持原样；
+原始 UTF-8 头或国际化信封地址需要时会协商 SMTPUTF8。
+
+## PHP `sendmail_path`
+
+先把 OwlMail 二进制放入 PHP 容器或主机，再在 `php.ini` 中配置：
+
+```ini
+sendmail_path = "/usr/local/bin/owlmail sendmail -t -i"
+```
+
+通过 PHP 进程继承的环境变量指向 OwlMail。假设 Compose 服务名为 `owlmail`：
+
+```yaml
+environment:
+  OWLMAIL_SENDMAIL_HOST: owlmail
+  OWLMAIL_SENDMAIL_PORT: "1025"
+```
+
+此后 PHP `mail()` 也会通过同一 SMTP 安全边界投递：
+
+```php
+<?php
+mail('developer@example.test', 'OwlMail test', 'It works!', [
+    'From' => 'php@example.test',
+]);
+```
+
+## SMTP 配置
+
+命令行参数优先于环境变量。
+
+| 参数 | 环境变量 | 默认值 | 作用 |
+|---|---|---:|---|
+| `--host` | `OWLMAIL_SENDMAIL_HOST` | `127.0.0.1` | OwlMail SMTP 主机 |
+| `--port` | `OWLMAIL_SENDMAIL_PORT` | `1025` | OwlMail SMTP 端口 |
+| `--starttls` | `OWLMAIL_SENDMAIL_STARTTLS` | `false` | 要求服务端声明并完成 STARTTLS 升级 |
+| `--smtps` | `OWLMAIL_SENDMAIL_SMTPS` | `false` | 连接建立时直接使用 TLS |
+| `--username` | `OWLMAIL_SENDMAIL_USERNAME` | - | PLAIN AUTH 用户名 |
+| `--password` | `OWLMAIL_SENDMAIL_PASSWORD` | - | PLAIN AUTH 密码 |
+
+同时支持 `--smtp-host`、`--smtp-ip` 和 `--smtp-port` 别名。STARTTLS 与 SMTPS
+互斥，用户名和密码必须同时配置。建议使用 `OWLMAIL_SENDMAIL_PASSWORD`，避免
+命令行密码出现在进程列表中。
+
+连接要求 TLS 的 OwlMail：
+
+```bash
+export OWLMAIL_SENDMAIL_HOST=owlmail.example.test
+export OWLMAIL_SENDMAIL_PORT=1025
+export OWLMAIL_SENDMAIL_STARTTLS=true
+export OWLMAIL_SENDMAIL_USERNAME=app
+export OWLMAIL_SENDMAIL_PASSWORD='replace-me'
+owlmail sendmail -t < message.eml
+```
+
+SMTPS 通常使用 465 端口，并设置 `OWLMAIL_SENDMAIL_SMTPS=true`。证书会根据操作
+系统信任库和目标主机名进行校验。使用私有证书时，应把私有 CA 安装到该信任库；
+命令有意不提供跳过证书校验的选项。
+
+## 兼容参数
+
+- `-t`：加入所有 `To`、`Cc`、`Bcc` 地址。
+- `-f ADDRESS` 或 `-fADDRESS`：设置 envelope sender；`-f '<>'` 使用空反向路径。
+- `-i`、`-oi`：接受但无需额外处理的兼容形式。
+- `--`：结束参数解析，后续值一律作为收件人。
+
+未知 sendmail 参数会明确失败，不会静默忽略。
+
+## 退出码
+
+以下稳定值遵循 `sysexits(3)` 约定：
+
+| 退出码 | 含义 |
+|---:|---|
+| `0` | 服务端已经接受 DATA |
+| `64` | 参数或客户端配置错误 |
+| `65` | RFC 5322 头无效，或 `-t` 未找到收件人 |
+| `69` | 永久 SMTP 错误，包括 5xx 响应 |
+| `74` | 本地 stdin/读取错误 |
+| `75` | 临时 SMTP 4xx 或网络错误，可以重试 |
+
+服务端在 DATA 后返回 `250` 即构成接受边界；此后的 QUIT 失败仍返回成功，避免调用方
+重复投递。诊断信息不会包含密码、邮件正文或完整认证交换。
+

--- a/internal/mailserver/config.go
+++ b/internal/mailserver/config.go
@@ -134,6 +134,7 @@ func (ms *MailServer) setupSMTPServer() error {
 	s.WriteTimeout = 10 * time.Second
 	s.MaxMessageBytes = ms.maxMessageBytes
 	s.MaxRecipients = 50
+	s.EnableSMTPUTF8 = true
 
 	// Preserve the development-friendly default while allowing deployments to
 	// require an encrypted transport before PLAIN or LOGIN is accepted.
@@ -173,6 +174,7 @@ func (ms *MailServer) setupSMTPServer() error {
 		smtps.WriteTimeout = 10 * time.Second
 		smtps.MaxMessageBytes = ms.maxMessageBytes
 		smtps.MaxRecipients = 50
+		smtps.EnableSMTPUTF8 = true
 
 		smtps.AllowInsecureAuth = !ms.authRequireTLS
 

--- a/internal/mailserver/mailserver_config_test.go
+++ b/internal/mailserver/mailserver_config_test.go
@@ -32,6 +32,9 @@ func TestNewMailServer(t *testing.T) {
 	if server.smtpServer.MaxMessageBytes != DefaultMaxMessageBytes {
 		t.Errorf("default MaxMessageBytes = %d, want %d", server.smtpServer.MaxMessageBytes, DefaultMaxMessageBytes)
 	}
+	if !server.smtpServer.EnableSMTPUTF8 {
+		t.Fatal("SMTP server should advertise SMTPUTF8 for internationalized messages")
+	}
 
 	// Test with custom values
 	server2, err := NewMailServer(2525, "127.0.0.1", tmpDir)
@@ -70,6 +73,9 @@ func TestNewMailServerWithCustomMessageLimit(t *testing.T) {
 	}
 	if server.smtpsServer == nil || server.smtpsServer.MaxMessageBytes != limit {
 		t.Fatalf("SMTPS MaxMessageBytes was not configured: %#v", server.smtpsServer)
+	}
+	if !server.smtpsServer.EnableSMTPUTF8 {
+		t.Fatal("SMTPS server should advertise SMTPUTF8 for internationalized messages")
 	}
 }
 

--- a/internal/sendmail/sendmail.go
+++ b/internal/sendmail/sendmail.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/emersion/go-sasl"
 	smtp "github.com/emersion/go-smtp"
@@ -30,8 +31,9 @@ const (
 )
 
 const (
-	defaultHost = "127.0.0.1"
-	defaultPort = 1025
+	defaultHost    = "127.0.0.1"
+	defaultPort    = 1025
+	defaultTimeout = 30 * time.Second
 )
 
 type errorKind int
@@ -61,6 +63,7 @@ type config struct {
 	smtps      bool
 	username   string
 	password   string
+	timeout    time.Duration
 	readHeader bool
 	from       string
 	fromSet    bool
@@ -110,7 +113,7 @@ func Run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 	if len(recipients) == 0 {
 		if cfg.readHeader {
-			err = newCommandError(kindData, "message has no To, Cc, or Bcc recipients")
+			err = newCommandError(kindData, "message has no To, Cc, Bcc, or Resent recipients")
 		} else {
 			err = newCommandError(kindUsage, "no recipients; pass recipients or use -t")
 		}
@@ -225,6 +228,15 @@ func parseArgs(args []string, lookupEnv func(string) (string, bool)) (config, bo
 			if err != nil {
 				return config{}, false, err
 			}
+		case "--timeout":
+			var value string
+			value, i, err = nextValue(args, i, arg)
+			if err == nil {
+				cfg.timeout, err = parseTimeout(value, arg)
+			}
+			if err != nil {
+				return config{}, false, err
+			}
 		case "--starttls":
 			cfg.startTLS = true
 		case "--smtps":
@@ -272,7 +284,7 @@ func configFromEnvironment(lookupEnv func(string) (string, bool)) (config, error
 	if lookupEnv == nil {
 		lookupEnv = func(string) (string, bool) { return "", false }
 	}
-	cfg := config{host: defaultHost, port: defaultPort}
+	cfg := config{host: defaultHost, port: defaultPort, timeout: defaultTimeout}
 	if value, ok := lookupEnv("OWLMAIL_SENDMAIL_HOST"); ok {
 		cfg.host = value
 	}
@@ -295,6 +307,13 @@ func configFromEnvironment(lookupEnv func(string) (string, bool)) (config, error
 	}
 	if value, ok := lookupEnv("OWLMAIL_SENDMAIL_PASSWORD"); ok {
 		cfg.password = value
+	}
+	if value, ok := lookupEnv("OWLMAIL_SENDMAIL_TIMEOUT"); ok {
+		timeout, err := parseTimeout(value, "OWLMAIL_SENDMAIL_TIMEOUT")
+		if err != nil {
+			return config{}, err
+		}
+		cfg.timeout = timeout
 	}
 	return cfg, nil
 }
@@ -333,6 +352,12 @@ func applyLongOption(cfg *config, arg string) error {
 		cfg.username = value
 	case "--password":
 		cfg.password = value
+	case "--timeout":
+		timeout, err := parseTimeout(value, name)
+		if err != nil {
+			return err
+		}
+		cfg.timeout = timeout
 	case "--starttls":
 		parsed, err := strconv.ParseBool(value)
 		if err != nil {
@@ -357,6 +382,14 @@ func parsePort(value, name string) (int, error) {
 		return 0, newCommandError(kindUsage, "%s must be an integer from 1 to 65535", name)
 	}
 	return port, nil
+}
+
+func parseTimeout(value, name string) (time.Duration, error) {
+	timeout, err := time.ParseDuration(value)
+	if err != nil || timeout <= 0 {
+		return 0, newCommandError(kindUsage, "%s must be a positive duration", name)
+	}
+	return timeout, nil
 }
 
 func parseMailbox(value string, allowEmpty bool) (string, error) {
@@ -389,7 +422,7 @@ func prepareMessage(input io.Reader) (preparedMessage, error) {
 	flush := func() {
 		value := strings.TrimSpace(currentValue.String())
 		switch strings.ToLower(currentName) {
-		case "to", "cc", "bcc":
+		case "to", "cc", "bcc", "resent-to", "resent-cc", "resent-bcc":
 			if value != "" {
 				recipientValues = append(recipientValues, value)
 			}
@@ -429,7 +462,7 @@ func prepareMessage(input io.Reader) (preparedMessage, error) {
 			if currentName == "" {
 				return preparedMessage{}, newCommandError(kindData, "message contains an invalid folded header")
 			}
-			if !strings.EqualFold(currentName, "bcc") {
+			if !isBlindRecipientHeader(currentName) {
 				sanitized.WriteString(line)
 				if !isASCII(line) {
 					requiresUTF8 = true
@@ -450,7 +483,7 @@ func prepareMessage(input io.Reader) (preparedMessage, error) {
 			return preparedMessage{}, newCommandError(kindData, "message contains an invalid header field name")
 		}
 		currentValue.WriteString(strings.TrimSpace(withoutEnding[colon+1:]))
-		if !strings.EqualFold(currentName, "bcc") {
+		if !isBlindRecipientHeader(currentName) {
 			sanitized.WriteString(line)
 			if !isASCII(line) {
 				requiresUTF8 = true
@@ -460,7 +493,7 @@ func prepareMessage(input io.Reader) (preparedMessage, error) {
 
 	headerRecipients, err := parseHeaderAddresses(recipientValues)
 	if err != nil {
-		return preparedMessage{}, newCommandError(kindData, "message contains an invalid To, Cc, or Bcc address")
+		return preparedMessage{}, newCommandError(kindData, "message contains an invalid recipient header address")
 	}
 	headerSender := ""
 	if len(senderValues) > 0 {
@@ -495,8 +528,15 @@ func parseHeaderAddresses(values []string) ([]string, error) {
 	return recipients, nil
 }
 
+func isBlindRecipientHeader(name string) bool {
+	return strings.EqualFold(name, "bcc") || strings.EqualFold(name, "resent-bcc")
+}
+
 func submit(cfg config, from string, recipients []string, message preparedMessage) error {
 	address := net.JoinHostPort(cfg.host, strconv.Itoa(cfg.port))
+	if cfg.timeout <= 0 {
+		cfg.timeout = defaultTimeout
+	}
 	tlsConfig := cfg.tlsConfig
 	if tlsConfig == nil {
 		tlsConfig = &tls.Config{MinVersion: tls.VersionTLS12, ServerName: cfg.host}
@@ -507,16 +547,7 @@ func submit(cfg config, from string, recipients []string, message preparedMessag
 		}
 	}
 
-	var client *smtp.Client
-	var err error
-	switch {
-	case cfg.smtps:
-		client, err = smtp.DialTLS(address, tlsConfig)
-	case cfg.startTLS:
-		client, err = smtp.DialStartTLS(address, tlsConfig)
-	default:
-		client, err = smtp.Dial(address)
-	}
+	client, err := dialSMTP(address, cfg, tlsConfig)
 	if err != nil {
 		return fmt.Errorf("connect to SMTP server: %w", err)
 	}
@@ -560,6 +591,59 @@ func submit(cfg config, from string, recipients []string, message preparedMessag
 	// must not make PHP or cron resend an already accepted message.
 	_ = client.Quit()
 	return nil
+}
+
+type cappedDeadlineConn struct {
+	net.Conn
+	deadline time.Time
+}
+
+func (conn *cappedDeadlineConn) SetDeadline(deadline time.Time) error {
+	return conn.Conn.SetDeadline(conn.cap(deadline))
+}
+
+func (conn *cappedDeadlineConn) SetReadDeadline(deadline time.Time) error {
+	return conn.Conn.SetReadDeadline(conn.cap(deadline))
+}
+
+func (conn *cappedDeadlineConn) SetWriteDeadline(deadline time.Time) error {
+	return conn.Conn.SetWriteDeadline(conn.cap(deadline))
+}
+
+func (conn *cappedDeadlineConn) cap(deadline time.Time) time.Time {
+	if deadline.IsZero() || deadline.After(conn.deadline) {
+		return conn.deadline
+	}
+	return deadline
+}
+
+func dialSMTP(address string, cfg config, tlsConfig *tls.Config) (*smtp.Client, error) {
+	connection, err := (&net.Dialer{Timeout: cfg.timeout}).Dial("tcp", address)
+	if err != nil {
+		return nil, err
+	}
+	bounded := &cappedDeadlineConn{Conn: connection, deadline: time.Now().Add(cfg.timeout)}
+	if err := bounded.SetDeadline(bounded.deadline); err != nil {
+		_ = connection.Close()
+		return nil, err
+	}
+
+	var client *smtp.Client
+	switch {
+	case cfg.smtps:
+		client = smtp.NewClient(tls.Client(bounded, tlsConfig))
+	case cfg.startTLS:
+		client, err = smtp.NewClientStartTLS(bounded, tlsConfig)
+	default:
+		client = smtp.NewClient(bounded)
+	}
+	if err != nil {
+		_ = connection.Close()
+		return nil, err
+	}
+	client.CommandTimeout = cfg.timeout
+	client.SubmissionTimeout = cfg.timeout
+	return client, nil
 }
 
 func copyMessage(destination io.Writer, source io.Reader) error {
@@ -614,7 +698,7 @@ const usageText = `Usage: owlmail sendmail [options] [recipient ...]
 Read an RFC 5322 message from stdin and submit it to OwlMail through SMTP.
 
 Sendmail-compatible options:
-  -t                       Read To, Cc, and Bcc recipients from message headers
+  -t                       Read To/Cc/Bcc and Resent recipients from headers
   -f ADDRESS               Set the envelope sender (-fADDRESS is also accepted)
   -i, -oi                  Accepted compatibility options; dots are handled safely
   --                       End options (required for recipients beginning with '-')
@@ -626,12 +710,14 @@ SMTP options:
   --smtps                  Use implicit TLS
   --username USER          SMTP AUTH username
   --password PASSWORD      SMTP AUTH password (prefer the environment variable)
+  --timeout DURATION       Whole SMTP submission deadline (default 30s)
   -h, --help               Show this help
 
 Environment:
   OWLMAIL_SENDMAIL_HOST, OWLMAIL_SENDMAIL_PORT,
   OWLMAIL_SENDMAIL_STARTTLS, OWLMAIL_SENDMAIL_SMTPS,
-  OWLMAIL_SENDMAIL_USERNAME, OWLMAIL_SENDMAIL_PASSWORD
+  OWLMAIL_SENDMAIL_USERNAME, OWLMAIL_SENDMAIL_PASSWORD,
+  OWLMAIL_SENDMAIL_TIMEOUT
 
 Exit status: 0 success, 64 usage, 65 message data, 69 permanent SMTP,
 74 local I/O, 75 temporary SMTP or network failure.

--- a/internal/sendmail/sendmail.go
+++ b/internal/sendmail/sendmail.go
@@ -617,12 +617,24 @@ func (conn *cappedDeadlineConn) cap(deadline time.Time) time.Time {
 	return deadline
 }
 
+type smtpDialFunc func(network, address string, deadline time.Time) (net.Conn, error)
+
 func dialSMTP(address string, cfg config, tlsConfig *tls.Config) (*smtp.Client, error) {
-	connection, err := (&net.Dialer{Timeout: cfg.timeout}).Dial("tcp", address)
+	return dialSMTPWith(address, cfg, tlsConfig, func(network, address string, deadline time.Time) (net.Conn, error) {
+		return (&net.Dialer{Deadline: deadline}).Dial(network, address)
+	})
+}
+
+func dialSMTPWith(address string, cfg config, tlsConfig *tls.Config, dial smtpDialFunc) (*smtp.Client, error) {
+	// One absolute deadline covers the complete operation. In particular, do
+	// not start a fresh timeout after Dial succeeds: a slow connection must
+	// consume the same budget as greeting, TLS, AUTH, commands, and DATA.
+	deadline := time.Now().Add(cfg.timeout)
+	connection, err := dial("tcp", address, deadline)
 	if err != nil {
 		return nil, err
 	}
-	bounded := &cappedDeadlineConn{Conn: connection, deadline: time.Now().Add(cfg.timeout)}
+	bounded := &cappedDeadlineConn{Conn: connection, deadline: deadline}
 	if err := bounded.SetDeadline(bounded.deadline); err != nil {
 		_ = connection.Close()
 		return nil, err

--- a/internal/sendmail/sendmail.go
+++ b/internal/sendmail/sendmail.go
@@ -1,0 +1,638 @@
+// Package sendmail implements the sendmail-compatible OwlMail CLI client.
+package sendmail
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/mail"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/emersion/go-sasl"
+	smtp "github.com/emersion/go-smtp"
+)
+
+// Exit statuses follow sysexits(3), as traditional sendmail-compatible
+// programs do. Keep these values stable for callers such as PHP and cron.
+const (
+	ExitOK          = 0
+	ExitUsage       = 64
+	ExitDataError   = 65
+	ExitUnavailable = 69
+	ExitIOError     = 74
+	ExitTempFailure = 75
+)
+
+const (
+	defaultHost = "127.0.0.1"
+	defaultPort = 1025
+)
+
+type errorKind int
+
+const (
+	kindUsage errorKind = iota
+	kindData
+	kindIO
+)
+
+type commandError struct {
+	kind errorKind
+	err  error
+}
+
+func (e *commandError) Error() string { return e.err.Error() }
+func (e *commandError) Unwrap() error { return e.err }
+
+func newCommandError(kind errorKind, format string, args ...any) error {
+	return &commandError{kind: kind, err: fmt.Errorf(format, args...)}
+}
+
+type config struct {
+	host       string
+	port       int
+	startTLS   bool
+	smtps      bool
+	username   string
+	password   string
+	readHeader bool
+	from       string
+	fromSet    bool
+	recipients []string
+	tlsConfig  *tls.Config
+}
+
+type preparedMessage struct {
+	reader           io.Reader
+	headerRecipients []string
+	headerSender     string
+	requiresUTF8     bool
+}
+
+// Run reads an RFC 5322 message from stdin and submits it through SMTP. It
+// never prints message content, credentials, or an SMTP authentication trace.
+func Run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	if stdin == nil {
+		stdin = strings.NewReader("")
+	}
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
+
+	cfg, help, err := parseArgs(args, os.LookupEnv)
+	if help {
+		_, _ = io.WriteString(stdout, usageText)
+		return ExitOK
+	}
+	if err != nil {
+		printError(stderr, err)
+		return exitCode(err)
+	}
+
+	message, err := prepareMessage(stdin)
+	if err != nil {
+		printError(stderr, err)
+		return exitCode(err)
+	}
+
+	recipients := append([]string(nil), cfg.recipients...)
+	if cfg.readHeader {
+		recipients = append(recipients, message.headerRecipients...)
+	}
+	if len(recipients) == 0 {
+		if cfg.readHeader {
+			err = newCommandError(kindData, "message has no To, Cc, or Bcc recipients")
+		} else {
+			err = newCommandError(kindUsage, "no recipients; pass recipients or use -t")
+		}
+		printError(stderr, err)
+		return exitCode(err)
+	}
+
+	from := message.headerSender
+	if cfg.fromSet {
+		from = cfg.from
+	}
+	if err := submit(cfg, from, recipients, message); err != nil {
+		printError(stderr, err)
+		return exitCode(err)
+	}
+	return ExitOK
+}
+
+func printError(w io.Writer, err error) {
+	_, _ = fmt.Fprintf(w, "owlmail sendmail: %v\n", err)
+}
+
+func exitCode(err error) int {
+	if err == nil {
+		return ExitOK
+	}
+	var commandErr *commandError
+	if errors.As(err, &commandErr) {
+		switch commandErr.kind {
+		case kindUsage:
+			return ExitUsage
+		case kindData:
+			return ExitDataError
+		case kindIO:
+			return ExitIOError
+		}
+	}
+	var smtpErr *smtp.SMTPError
+	if errors.As(err, &smtpErr) {
+		if smtpErr.Temporary() {
+			return ExitTempFailure
+		}
+		return ExitUnavailable
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return ExitTempFailure
+	}
+	return ExitUnavailable
+}
+
+func parseArgs(args []string, lookupEnv func(string) (string, bool)) (config, bool, error) {
+	for _, arg := range args {
+		if arg == "--" {
+			break
+		}
+		if arg == "-h" || arg == "--help" {
+			return config{}, true, nil
+		}
+	}
+	cfg, err := configFromEnvironment(lookupEnv)
+	if err != nil {
+		return config{}, false, err
+	}
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			cfg.recipients = append(cfg.recipients, args[i+1:]...)
+			break
+		}
+		switch arg {
+		case "-h", "--help":
+			return cfg, true, nil
+		case "-t":
+			cfg.readHeader = true
+		case "-i", "-oi":
+			// Dot termination is handled by the SMTP client, so these accepted
+			// sendmail compatibility options do not change input processing.
+		case "-f":
+			value, next, valueErr := nextValue(args, i, "-f")
+			if valueErr != nil {
+				return config{}, false, valueErr
+			}
+			i = next
+			cfg.from, err = parseMailbox(value, true)
+			if err != nil {
+				return config{}, false, newCommandError(kindUsage, "invalid -f envelope sender")
+			}
+			cfg.fromSet = true
+		case "--host", "--smtp-host", "--smtp-ip":
+			cfg.host, i, err = nextValue(args, i, arg)
+			if err != nil {
+				return config{}, false, err
+			}
+		case "--port", "--smtp-port":
+			var value string
+			value, i, err = nextValue(args, i, arg)
+			if err == nil {
+				cfg.port, err = parsePort(value, arg)
+			}
+			if err != nil {
+				return config{}, false, err
+			}
+		case "--username":
+			cfg.username, i, err = nextValue(args, i, arg)
+			if err != nil {
+				return config{}, false, err
+			}
+		case "--password":
+			cfg.password, i, err = nextValue(args, i, arg)
+			if err != nil {
+				return config{}, false, err
+			}
+		case "--starttls":
+			cfg.startTLS = true
+		case "--smtps":
+			cfg.smtps = true
+		default:
+			switch {
+			case strings.HasPrefix(arg, "-f") && len(arg) > 2:
+				cfg.from, err = parseMailbox(arg[2:], true)
+				if err != nil {
+					return config{}, false, newCommandError(kindUsage, "invalid -f envelope sender")
+				}
+				cfg.fromSet = true
+			case strings.HasPrefix(arg, "--") && strings.Contains(arg, "="):
+				if err := applyLongOption(&cfg, arg); err != nil {
+					return config{}, false, err
+				}
+			case strings.HasPrefix(arg, "-"):
+				return config{}, false, newCommandError(kindUsage, "unknown option %q; use -- before recipients beginning with '-'", arg)
+			default:
+				cfg.recipients = append(cfg.recipients, arg)
+			}
+		}
+	}
+
+	cfg.host = strings.TrimSpace(cfg.host)
+	if cfg.host == "" {
+		return config{}, false, newCommandError(kindUsage, "SMTP host must not be empty")
+	}
+	if cfg.startTLS && cfg.smtps {
+		return config{}, false, newCommandError(kindUsage, "--starttls and --smtps are mutually exclusive")
+	}
+	if (cfg.username == "") != (cfg.password == "") {
+		return config{}, false, newCommandError(kindUsage, "SMTP username and password must be configured together")
+	}
+	for i, recipient := range cfg.recipients {
+		cfg.recipients[i], err = parseMailbox(recipient, false)
+		if err != nil {
+			return config{}, false, newCommandError(kindUsage, "invalid recipient argument")
+		}
+	}
+	return cfg, false, nil
+}
+
+func configFromEnvironment(lookupEnv func(string) (string, bool)) (config, error) {
+	if lookupEnv == nil {
+		lookupEnv = func(string) (string, bool) { return "", false }
+	}
+	cfg := config{host: defaultHost, port: defaultPort}
+	if value, ok := lookupEnv("OWLMAIL_SENDMAIL_HOST"); ok {
+		cfg.host = value
+	}
+	if value, ok := lookupEnv("OWLMAIL_SENDMAIL_PORT"); ok {
+		port, err := parsePort(value, "OWLMAIL_SENDMAIL_PORT")
+		if err != nil {
+			return config{}, err
+		}
+		cfg.port = port
+	}
+	var err error
+	if cfg.startTLS, err = envBool(lookupEnv, "OWLMAIL_SENDMAIL_STARTTLS"); err != nil {
+		return config{}, err
+	}
+	if cfg.smtps, err = envBool(lookupEnv, "OWLMAIL_SENDMAIL_SMTPS"); err != nil {
+		return config{}, err
+	}
+	if value, ok := lookupEnv("OWLMAIL_SENDMAIL_USERNAME"); ok {
+		cfg.username = value
+	}
+	if value, ok := lookupEnv("OWLMAIL_SENDMAIL_PASSWORD"); ok {
+		cfg.password = value
+	}
+	return cfg, nil
+}
+
+func envBool(lookupEnv func(string) (string, bool), name string) (bool, error) {
+	value, ok := lookupEnv(name)
+	if !ok || value == "" {
+		return false, nil
+	}
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, newCommandError(kindUsage, "%s must be a boolean", name)
+	}
+	return parsed, nil
+}
+
+func nextValue(args []string, index int, name string) (string, int, error) {
+	if index+1 >= len(args) {
+		return "", index, newCommandError(kindUsage, "%s requires a value", name)
+	}
+	return args[index+1], index + 1, nil
+}
+
+func applyLongOption(cfg *config, arg string) error {
+	name, value, _ := strings.Cut(arg, "=")
+	switch name {
+	case "--host", "--smtp-host", "--smtp-ip":
+		cfg.host = value
+	case "--port", "--smtp-port":
+		port, err := parsePort(value, name)
+		if err != nil {
+			return err
+		}
+		cfg.port = port
+	case "--username":
+		cfg.username = value
+	case "--password":
+		cfg.password = value
+	case "--starttls":
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			return newCommandError(kindUsage, "%s must be a boolean", name)
+		}
+		cfg.startTLS = parsed
+	case "--smtps":
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			return newCommandError(kindUsage, "%s must be a boolean", name)
+		}
+		cfg.smtps = parsed
+	default:
+		return newCommandError(kindUsage, "unknown option %q", name)
+	}
+	return nil
+}
+
+func parsePort(value, name string) (int, error) {
+	port, err := strconv.Atoi(value)
+	if err != nil || port < 1 || port > 65535 {
+		return 0, newCommandError(kindUsage, "%s must be an integer from 1 to 65535", name)
+	}
+	return port, nil
+}
+
+func parseMailbox(value string, allowEmpty bool) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "<>" {
+		value = ""
+	}
+	if value == "" {
+		if allowEmpty {
+			return "", nil
+		}
+		return "", errors.New("empty mailbox")
+	}
+	address, err := mail.ParseAddress(value)
+	if err != nil || address.Address == "" || strings.ContainsAny(address.Address, "\r\n") {
+		return "", errors.New("invalid mailbox")
+	}
+	return address.Address, nil
+}
+
+func prepareMessage(input io.Reader) (preparedMessage, error) {
+	reader := bufio.NewReader(input)
+	var sanitized bytes.Buffer
+	var currentName string
+	var currentValue strings.Builder
+	var recipientValues []string
+	var senderValues []string
+	requiresUTF8 := false
+
+	flush := func() {
+		value := strings.TrimSpace(currentValue.String())
+		switch strings.ToLower(currentName) {
+		case "to", "cc", "bcc":
+			if value != "" {
+				recipientValues = append(recipientValues, value)
+			}
+		case "sender":
+			if value != "" {
+				senderValues = append([]string{value}, senderValues...)
+			}
+		case "from":
+			if value != "" {
+				senderValues = append(senderValues, value)
+			}
+		}
+		currentName = ""
+		currentValue.Reset()
+	}
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			return preparedMessage{}, newCommandError(kindIO, "read message headers: %v", err)
+		}
+		withoutEnding := strings.TrimSuffix(line, "\n")
+		withoutEnding = strings.TrimSuffix(withoutEnding, "\r")
+		if withoutEnding == "" {
+			flush()
+			if line == "" {
+				return preparedMessage{}, newCommandError(kindData, "message is missing the header/body separator")
+			}
+			sanitized.WriteString(line)
+			break
+		}
+		if errors.Is(err, io.EOF) {
+			return preparedMessage{}, newCommandError(kindData, "message is missing the header/body separator")
+		}
+
+		if withoutEnding[0] == ' ' || withoutEnding[0] == '\t' {
+			if currentName == "" {
+				return preparedMessage{}, newCommandError(kindData, "message contains an invalid folded header")
+			}
+			if !strings.EqualFold(currentName, "bcc") {
+				sanitized.WriteString(line)
+				if !isASCII(line) {
+					requiresUTF8 = true
+				}
+			}
+			currentValue.WriteByte(' ')
+			currentValue.WriteString(strings.TrimSpace(withoutEnding))
+			continue
+		}
+
+		flush()
+		colon := strings.IndexByte(withoutEnding, ':')
+		if colon <= 0 {
+			return preparedMessage{}, newCommandError(kindData, "message contains an invalid header field")
+		}
+		currentName = strings.TrimSpace(withoutEnding[:colon])
+		if !validHeaderFieldName(currentName) {
+			return preparedMessage{}, newCommandError(kindData, "message contains an invalid header field name")
+		}
+		currentValue.WriteString(strings.TrimSpace(withoutEnding[colon+1:]))
+		if !strings.EqualFold(currentName, "bcc") {
+			sanitized.WriteString(line)
+			if !isASCII(line) {
+				requiresUTF8 = true
+			}
+		}
+	}
+
+	headerRecipients, err := parseHeaderAddresses(recipientValues)
+	if err != nil {
+		return preparedMessage{}, newCommandError(kindData, "message contains an invalid To, Cc, or Bcc address")
+	}
+	headerSender := ""
+	if len(senderValues) > 0 {
+		addresses, parseErr := mail.ParseAddressList(senderValues[0])
+		if parseErr != nil || len(addresses) == 0 {
+			return preparedMessage{}, newCommandError(kindData, "message contains an invalid Sender or From address")
+		}
+		headerSender = addresses[0].Address
+	}
+	return preparedMessage{
+		reader:           io.MultiReader(bytes.NewReader(sanitized.Bytes()), reader),
+		headerRecipients: headerRecipients,
+		headerSender:     headerSender,
+		requiresUTF8:     requiresUTF8,
+	}, nil
+}
+
+func parseHeaderAddresses(values []string) ([]string, error) {
+	var recipients []string
+	for _, value := range values {
+		addresses, err := mail.ParseAddressList(value)
+		if err != nil {
+			return nil, err
+		}
+		for _, address := range addresses {
+			if address == nil || address.Address == "" || strings.ContainsAny(address.Address, "\r\n") {
+				return nil, errors.New("invalid mailbox")
+			}
+			recipients = append(recipients, address.Address)
+		}
+	}
+	return recipients, nil
+}
+
+func submit(cfg config, from string, recipients []string, message preparedMessage) error {
+	address := net.JoinHostPort(cfg.host, strconv.Itoa(cfg.port))
+	tlsConfig := cfg.tlsConfig
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{MinVersion: tls.VersionTLS12, ServerName: cfg.host}
+	} else {
+		tlsConfig = tlsConfig.Clone()
+		if tlsConfig.ServerName == "" {
+			tlsConfig.ServerName = cfg.host
+		}
+	}
+
+	var client *smtp.Client
+	var err error
+	switch {
+	case cfg.smtps:
+		client, err = smtp.DialTLS(address, tlsConfig)
+	case cfg.startTLS:
+		client, err = smtp.DialStartTLS(address, tlsConfig)
+	default:
+		client, err = smtp.Dial(address)
+	}
+	if err != nil {
+		return fmt.Errorf("connect to SMTP server: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	if cfg.username != "" {
+		if err := client.Auth(sasl.NewPlainClient("", cfg.username, cfg.password)); err != nil {
+			return fmt.Errorf("SMTP authentication failed: %w", err)
+		}
+	}
+
+	utf8Required := message.requiresUTF8 || !isASCII(from)
+	for _, recipient := range recipients {
+		utf8Required = utf8Required || !isASCII(recipient)
+	}
+	var mailOptions *smtp.MailOptions
+	if utf8Required {
+		mailOptions = &smtp.MailOptions{UTF8: true}
+	}
+	if err := client.Mail(from, mailOptions); err != nil {
+		return fmt.Errorf("SMTP MAIL FROM failed: %w", err)
+	}
+	for _, recipient := range recipients {
+		if err := client.Rcpt(recipient, nil); err != nil {
+			return fmt.Errorf("SMTP RCPT TO failed: %w", err)
+		}
+	}
+	data, err := client.Data()
+	if err != nil {
+		return fmt.Errorf("SMTP DATA failed: %w", err)
+	}
+	if err := copyMessage(data, message.reader); err != nil {
+		// Do not close the DATA writer: closing sends the terminating dot and
+		// could accept a truncated message after a local input error.
+		return err
+	}
+	if err := data.Close(); err != nil {
+		return fmt.Errorf("SMTP message submission failed: %w", err)
+	}
+	// A 250 response to DATA is the acceptance boundary. A later QUIT failure
+	// must not make PHP or cron resend an already accepted message.
+	_ = client.Quit()
+	return nil
+}
+
+func copyMessage(destination io.Writer, source io.Reader) error {
+	buffer := make([]byte, 32*1024)
+	for {
+		read, readErr := source.Read(buffer)
+		if read > 0 {
+			written, writeErr := destination.Write(buffer[:read])
+			if writeErr != nil {
+				return fmt.Errorf("transmit message data: %w", writeErr)
+			}
+			if written != read {
+				return fmt.Errorf("transmit message data: %w", io.ErrShortWrite)
+			}
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				return nil
+			}
+			return newCommandError(kindIO, "read message data: %v", readErr)
+		}
+		if read == 0 {
+			return newCommandError(kindIO, "read message data: no progress")
+		}
+	}
+}
+
+func isASCII(value string) bool {
+	for i := 0; i < len(value); i++ {
+		if value[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
+}
+
+func validHeaderFieldName(value string) bool {
+	if value == "" {
+		return false
+	}
+	for i := 0; i < len(value); i++ {
+		// RFC 5322 field names are printable US-ASCII except colon.
+		if value[i] < 33 || value[i] > 126 || value[i] == ':' {
+			return false
+		}
+	}
+	return true
+}
+
+const usageText = `Usage: owlmail sendmail [options] [recipient ...]
+
+Read an RFC 5322 message from stdin and submit it to OwlMail through SMTP.
+
+Sendmail-compatible options:
+  -t                       Read To, Cc, and Bcc recipients from message headers
+  -f ADDRESS               Set the envelope sender (-fADDRESS is also accepted)
+  -i, -oi                  Accepted compatibility options; dots are handled safely
+  --                       End options (required for recipients beginning with '-')
+
+SMTP options:
+  --host HOST              SMTP host (default 127.0.0.1)
+  --port PORT              SMTP port (default 1025)
+  --starttls               Require STARTTLS
+  --smtps                  Use implicit TLS
+  --username USER          SMTP AUTH username
+  --password PASSWORD      SMTP AUTH password (prefer the environment variable)
+  -h, --help               Show this help
+
+Environment:
+  OWLMAIL_SENDMAIL_HOST, OWLMAIL_SENDMAIL_PORT,
+  OWLMAIL_SENDMAIL_STARTTLS, OWLMAIL_SENDMAIL_SMTPS,
+  OWLMAIL_SENDMAIL_USERNAME, OWLMAIL_SENDMAIL_PASSWORD
+
+Exit status: 0 success, 64 usage, 65 message data, 69 permanent SMTP,
+74 local I/O, 75 temporary SMTP or network failure.
+`

--- a/internal/sendmail/sendmail_test.go
+++ b/internal/sendmail/sendmail_test.go
@@ -1,0 +1,439 @@
+package sendmail
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"io"
+	"math/big"
+	"net"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/emersion/go-sasl"
+	smtp "github.com/emersion/go-smtp"
+)
+
+func TestParseArgs(t *testing.T) {
+	lookup := func(values map[string]string) func(string) (string, bool) {
+		return func(name string) (string, bool) {
+			value, ok := values[name]
+			return value, ok
+		}
+	}
+
+	cfg, help, err := parseArgs([]string{
+		"-t", "-oi", "-i", "-fbounce@example.com", "--host=mail.local",
+		"--port", "2525", "--starttls", "--username", "user", "--password", "secret",
+		"first@example.com", "--", "-recipient@example.com",
+	}, lookup(nil))
+	if err != nil || help {
+		t.Fatalf("parseArgs() = %#v, %t, %v", cfg, help, err)
+	}
+	if cfg.host != "mail.local" || cfg.port != 2525 || !cfg.startTLS || cfg.smtps || !cfg.readHeader {
+		t.Fatalf("unexpected config: %#v", cfg)
+	}
+	if cfg.from != "bounce@example.com" || !cfg.fromSet || cfg.username != "user" || cfg.password != "secret" {
+		t.Fatalf("unexpected sender or credentials: %#v", cfg)
+	}
+	if !reflect.DeepEqual(cfg.recipients, []string{"first@example.com", "-recipient@example.com"}) {
+		t.Fatalf("recipients = %#v", cfg.recipients)
+	}
+
+	environment := map[string]string{
+		"OWLMAIL_SENDMAIL_HOST":     "env.local",
+		"OWLMAIL_SENDMAIL_PORT":     "2465",
+		"OWLMAIL_SENDMAIL_STARTTLS": "true",
+		"OWLMAIL_SENDMAIL_USERNAME": "env-user",
+		"OWLMAIL_SENDMAIL_PASSWORD": "env-secret",
+	}
+	cfg, _, err = parseArgs([]string{"--host", "cli.local", "--starttls=false", "to@example.com"}, lookup(environment))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.host != "cli.local" || cfg.port != 2465 || cfg.startTLS || cfg.username != "env-user" || cfg.password != "env-secret" {
+		t.Fatalf("CLI did not override environment correctly: %#v", cfg)
+	}
+}
+
+func TestParseArgsErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		env  map[string]string
+	}{
+		{name: "unknown", args: []string{"-x"}},
+		{name: "missing value", args: []string{"--host"}},
+		{name: "bad port", args: []string{"--port", "0"}},
+		{name: "conflicting TLS", args: []string{"--starttls", "--smtps"}},
+		{name: "partial auth", args: []string{"--username", "user"}},
+		{name: "bad environment boolean", env: map[string]string{"OWLMAIL_SENDMAIL_SMTPS": "sometimes"}},
+		{name: "bad environment port", env: map[string]string{"OWLMAIL_SENDMAIL_PORT": "smtp"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			lookup := func(name string) (string, bool) {
+				value, ok := test.env[name]
+				return value, ok
+			}
+			_, _, err := parseArgs(test.args, lookup)
+			if err == nil || exitCode(err) != ExitUsage {
+				t.Fatalf("parseArgs() error = %v, exit = %d", err, exitCode(err))
+			}
+		})
+	}
+}
+
+func TestPrepareMessageExtractsRecipientsAndRemovesBcc(t *testing.T) {
+	input := "From: =?UTF-8?Q?Jos=C3=A9?= <sender@example.com>\n" +
+		"To: One <one@example.com>,\n\tTwo <two@example.com>\n" +
+		"Cc: three@example.com\n" +
+		"Bcc: hidden@example.com,\n\tfolded@example.com\n" +
+		"Subject: こんにちは\n\nhello\n.leading dot\n"
+	message, err := prepareMessage(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if message.headerSender != "sender@example.com" {
+		t.Fatalf("header sender = %q", message.headerSender)
+	}
+	wantRecipients := []string{"one@example.com", "two@example.com", "three@example.com", "hidden@example.com", "folded@example.com"}
+	if !reflect.DeepEqual(message.headerRecipients, wantRecipients) {
+		t.Fatalf("recipients = %#v, want %#v", message.headerRecipients, wantRecipients)
+	}
+	if !message.requiresUTF8 {
+		t.Fatal("raw UTF-8 header should require SMTPUTF8")
+	}
+	sanitized, err := io.ReadAll(message.reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(bytes.ToLower(sanitized), []byte("bcc:")) || bytes.Contains(sanitized, []byte("folded@example.com")) {
+		t.Fatalf("Bcc field was not removed: %q", sanitized)
+	}
+	if !bytes.Contains(sanitized, []byte("Subject: こんにちは")) || !bytes.Contains(sanitized, []byte(".leading dot")) {
+		t.Fatalf("message content changed unexpectedly: %q", sanitized)
+	}
+}
+
+func TestPrepareMessageRejectsMalformedInput(t *testing.T) {
+	for _, input := range []string{
+		"Subject: missing separator",
+		" folded-without-field\n\nbody",
+		"Not a header\n\nbody",
+		"To: not-an-address\n\nbody",
+	} {
+		_, err := prepareMessage(strings.NewReader(input))
+		if err == nil || exitCode(err) != ExitDataError {
+			t.Fatalf("prepareMessage(%q) error = %v, exit = %d", input, err, exitCode(err))
+		}
+	}
+}
+
+func TestRunSubmitsThroughSMTP(t *testing.T) {
+	backend := &fakeBackend{username: "user", password: "secret"}
+	host, port := startFakeServer(t, backend, nil, false)
+	message := "From: sender@example.com\n" +
+		"To: =?UTF-8?Q?T=C3=A9st?= <one@example.com>\n" +
+		"Cc: two@example.com\n" +
+		"Bcc: hidden@example.com\n" +
+		"Subject: こんにちは\n\nfirst\n.leading\nlast"
+	var stdout, stderr bytes.Buffer
+	exit := Run([]string{
+		"-t", "-oi", "-f<>", "--host", host, "--port", port,
+		"--username", "user", "--password", "secret", "explicit@example.com",
+	}, strings.NewReader(message), &stdout, &stderr)
+	if exit != ExitOK {
+		t.Fatalf("Run() exit = %d, stderr = %q", exit, stderr.String())
+	}
+
+	received := backend.snapshot()
+	if received.from != "" {
+		t.Fatalf("MAIL FROM = %q, want empty reverse path", received.from)
+	}
+	wantRecipients := []string{"explicit@example.com", "one@example.com", "two@example.com", "hidden@example.com"}
+	if !reflect.DeepEqual(received.recipients, wantRecipients) {
+		t.Fatalf("RCPT TO = %#v, want %#v", received.recipients, wantRecipients)
+	}
+	if received.mailOptions == nil || !received.mailOptions.UTF8 {
+		t.Fatalf("MAIL options = %#v, want SMTPUTF8", received.mailOptions)
+	}
+	if strings.Contains(strings.ToLower(received.data), "bcc:") || strings.Contains(received.data, "hidden@example.com") {
+		t.Fatalf("Bcc leaked into DATA: %q", received.data)
+	}
+	if !strings.Contains(received.data, "\r\n.leading\r\n") || !strings.HasSuffix(received.data, "last\r\n") {
+		t.Fatalf("CRLF or dot-stuffing round trip failed: %q", received.data)
+	}
+	if received.username != "user" || received.password != "secret" {
+		t.Fatalf("AUTH credentials were not received by fake server")
+	}
+}
+
+func TestSubmitSupportsSTARTTLSAndSMTPS(t *testing.T) {
+	serverTLS, clientTLS := testTLSConfigs(t)
+	for _, test := range []struct {
+		name     string
+		startTLS bool
+		smtps    bool
+	}{
+		{name: "STARTTLS", startTLS: true},
+		{name: "SMTPS", smtps: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			backend := &fakeBackend{}
+			host, port := startFakeServer(t, backend, serverTLS, test.smtps)
+			message, err := prepareMessage(strings.NewReader("From: sender@example.com\r\nTo: to@example.com\r\n\r\nTLS\r\n"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			portNumber, err := parsePort(port, "test port")
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = submit(config{
+				host: host, port: portNumber, startTLS: test.startTLS, smtps: test.smtps, tlsConfig: clientTLS,
+			}, "sender@example.com", []string{"to@example.com"}, message)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !backend.snapshot().tls {
+				t.Fatal("fake server did not observe TLS")
+			}
+		})
+	}
+}
+
+func TestRunClassifiesSMTPFailuresWithoutLeakingSensitiveInput(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		err  error
+		exit int
+	}{
+		{name: "temporary", err: &smtp.SMTPError{Code: 451, EnhancedCode: smtp.EnhancedCode{4, 3, 2}, Message: "try later"}, exit: ExitTempFailure},
+		{name: "permanent", err: &smtp.SMTPError{Code: 552, EnhancedCode: smtp.EnhancedCode{5, 3, 4}, Message: "too large"}, exit: ExitUnavailable},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			backend := &fakeBackend{dataErr: test.err}
+			host, port := startFakeServer(t, backend, nil, false)
+			const secret = "password-that-must-not-leak"
+			const body = "body-that-must-not-leak"
+			var stderr bytes.Buffer
+			exit := Run([]string{"-t", "--host", host, "--port", port}, strings.NewReader(
+				"From: sender@example.com\r\nTo: to@example.com\r\n\r\n"+body+"\r\n",
+			), io.Discard, &stderr)
+			if exit != test.exit {
+				t.Fatalf("Run() exit = %d, want %d, stderr = %q", exit, test.exit, stderr.String())
+			}
+			if strings.Contains(stderr.String(), secret) || strings.Contains(stderr.String(), body) {
+				t.Fatalf("sensitive input leaked: %q", stderr.String())
+			}
+		})
+	}
+
+	t.Run("authentication rejection hides password and body", func(t *testing.T) {
+		backend := &fakeBackend{username: "user", password: "expected"}
+		host, port := startFakeServer(t, backend, nil, false)
+		const password = "password-that-must-not-leak"
+		const body = "body-that-must-not-leak"
+		var stderr bytes.Buffer
+		exit := Run([]string{
+			"-t", "--host", host, "--port", port,
+			"--username", "user", "--password", password,
+		}, strings.NewReader(
+			"From: sender@example.com\r\nTo: to@example.com\r\n\r\n"+body+"\r\n",
+		), io.Discard, &stderr)
+		if exit != ExitUnavailable {
+			t.Fatalf("Run() exit = %d, stderr = %q", exit, stderr.String())
+		}
+		if strings.Contains(stderr.String(), password) || strings.Contains(stderr.String(), body) {
+			t.Fatalf("sensitive input leaked: %q", stderr.String())
+		}
+	})
+}
+
+func TestRunUsageAndHelp(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if exit := Run([]string{"--help"}, nil, &stdout, &stderr); exit != ExitOK || !strings.Contains(stdout.String(), "OWLMAIL_SENDMAIL_PASSWORD") {
+		t.Fatalf("help exit/output = %d, %q", exit, stdout.String())
+	}
+	stdout.Reset()
+	if exit := Run(nil, strings.NewReader("From: sender@example.com\r\n\r\nbody"), &stdout, &stderr); exit != ExitUsage {
+		t.Fatalf("missing recipient exit = %d, stderr = %q", exit, stderr.String())
+	}
+}
+
+type fakeBackend struct {
+	mu       sync.Mutex
+	username string
+	password string
+	dataErr  error
+	received fakeReceived
+}
+
+type fakeReceived struct {
+	from        string
+	recipients  []string
+	data        string
+	username    string
+	password    string
+	tls         bool
+	mailOptions *smtp.MailOptions
+}
+
+func (backend *fakeBackend) NewSession(conn *smtp.Conn) (smtp.Session, error) {
+	return &fakeSession{backend: backend, conn: conn}, nil
+}
+
+func (backend *fakeBackend) snapshot() fakeReceived {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	received := backend.received
+	received.recipients = append([]string(nil), received.recipients...)
+	if received.mailOptions != nil {
+		copy := *received.mailOptions
+		received.mailOptions = &copy
+	}
+	return received
+}
+
+type fakeSession struct {
+	backend *fakeBackend
+	conn    *smtp.Conn
+}
+
+func (session *fakeSession) Reset()        {}
+func (session *fakeSession) Logout() error { return nil }
+
+func (session *fakeSession) AuthMechanisms() []string { return []string{sasl.Plain} }
+
+func (session *fakeSession) Auth(mechanism string) (sasl.Server, error) {
+	if mechanism != sasl.Plain {
+		return nil, smtp.ErrAuthUnknownMechanism
+	}
+	return sasl.NewPlainServer(func(_, username, password string) error {
+		if session.backend.username != "" && (username != session.backend.username || password != session.backend.password) {
+			return smtp.ErrAuthFailed
+		}
+		session.backend.mu.Lock()
+		session.backend.received.username = username
+		session.backend.received.password = password
+		session.backend.mu.Unlock()
+		return nil
+	}), nil
+}
+
+func (session *fakeSession) Mail(from string, options *smtp.MailOptions) error {
+	session.backend.mu.Lock()
+	defer session.backend.mu.Unlock()
+	session.backend.received.from = from
+	_, session.backend.received.tls = session.conn.TLSConnectionState()
+	if options != nil {
+		copy := *options
+		session.backend.received.mailOptions = &copy
+	}
+	return nil
+}
+
+func (session *fakeSession) Rcpt(to string, _ *smtp.RcptOptions) error {
+	session.backend.mu.Lock()
+	defer session.backend.mu.Unlock()
+	session.backend.received.recipients = append(session.backend.received.recipients, to)
+	return nil
+}
+
+func (session *fakeSession) Data(reader io.Reader) error {
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+	session.backend.mu.Lock()
+	session.backend.received.data = string(data)
+	configuredErr := session.backend.dataErr
+	session.backend.mu.Unlock()
+	return configuredErr
+}
+
+func startFakeServer(t *testing.T, backend smtp.Backend, tlsConfig *tls.Config, implicitTLS bool) (string, string) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := smtp.NewServer(backend)
+	server.Domain = "localhost"
+	server.AllowInsecureAuth = true
+	server.EnableSMTPUTF8 = true
+	server.TLSConfig = tlsConfig
+	serveListener := listener
+	if implicitTLS {
+		serveListener = tls.NewListener(listener, tlsConfig)
+	}
+	done := make(chan error, 1)
+	go func() { done <- server.Serve(serveListener) }()
+	t.Cleanup(func() {
+		_ = server.Close()
+		_ = listener.Close()
+		select {
+		case err := <-done:
+			if err != nil && !errors.Is(err, net.ErrClosed) {
+				t.Errorf("fake SMTP server: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Error("fake SMTP server did not stop")
+		}
+	})
+	host, port, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return host, port
+}
+
+func testTLSConfigs(t *testing.T) (*tls.Config, *tls.Config) {
+	t.Helper()
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	certificateDER, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateDER, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certificate, err := tls.X509KeyPair(
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificateDER}),
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateDER}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	roots := x509.NewCertPool()
+	parsedCertificate, err := x509.ParseCertificate(certificateDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+	roots.AddCert(parsedCertificate)
+	return &tls.Config{Certificates: []tls.Certificate{certificate}, MinVersion: tls.VersionTLS12},
+		&tls.Config{RootCAs: roots, MinVersion: tls.VersionTLS12}
+}

--- a/internal/sendmail/sendmail_test.go
+++ b/internal/sendmail/sendmail_test.go
@@ -334,6 +334,47 @@ func TestRunTimesOutWhenServerWithholdsGreeting(t *testing.T) {
 	}
 }
 
+func TestDialSMTPReusesTheDialDeadline(t *testing.T) {
+	connection := &deadlineCaptureConn{}
+	var dialDeadline time.Time
+	client, err := dialSMTPWith("mail.example:25", config{timeout: time.Minute}, &tls.Config{}, func(_, _ string, deadline time.Time) (net.Conn, error) {
+		dialDeadline = deadline
+		return connection, nil
+	})
+	if err != nil {
+		t.Fatalf("dialSMTPWith() error = %v", err)
+	}
+	_ = client.Close()
+	if dialDeadline.IsZero() {
+		t.Fatal("dial deadline was not set")
+	}
+	if !connection.deadline.Equal(dialDeadline) {
+		t.Fatalf("connection deadline = %s, dial deadline = %s", connection.deadline, dialDeadline)
+	}
+}
+
+type deadlineCaptureConn struct {
+	deadline time.Time
+}
+
+func (conn *deadlineCaptureConn) Read([]byte) (int, error)         { return 0, io.EOF }
+func (conn *deadlineCaptureConn) Write(buffer []byte) (int, error) { return len(buffer), nil }
+func (conn *deadlineCaptureConn) Close() error                     { return nil }
+func (conn *deadlineCaptureConn) LocalAddr() net.Addr              { return &net.TCPAddr{} }
+func (conn *deadlineCaptureConn) RemoteAddr() net.Addr             { return &net.TCPAddr{} }
+func (conn *deadlineCaptureConn) SetDeadline(deadline time.Time) error {
+	conn.deadline = deadline
+	return nil
+}
+func (conn *deadlineCaptureConn) SetReadDeadline(deadline time.Time) error {
+	conn.deadline = deadline
+	return nil
+}
+func (conn *deadlineCaptureConn) SetWriteDeadline(deadline time.Time) error {
+	conn.deadline = deadline
+	return nil
+}
+
 type fakeBackend struct {
 	mu       sync.Mutex
 	username string

--- a/internal/sendmail/sendmail_test.go
+++ b/internal/sendmail/sendmail_test.go
@@ -34,7 +34,7 @@ func TestParseArgs(t *testing.T) {
 	cfg, help, err := parseArgs([]string{
 		"-t", "-oi", "-i", "-fbounce@example.com", "--host=mail.local",
 		"--port", "2525", "--starttls", "--username", "user", "--password", "secret",
-		"first@example.com", "--", "-recipient@example.com",
+		"--timeout", "45s", "first@example.com", "--", "-recipient@example.com",
 	}, lookup(nil))
 	if err != nil || help {
 		t.Fatalf("parseArgs() = %#v, %t, %v", cfg, help, err)
@@ -44,6 +44,9 @@ func TestParseArgs(t *testing.T) {
 	}
 	if cfg.from != "bounce@example.com" || !cfg.fromSet || cfg.username != "user" || cfg.password != "secret" {
 		t.Fatalf("unexpected sender or credentials: %#v", cfg)
+	}
+	if cfg.timeout != 45*time.Second {
+		t.Fatalf("timeout = %s", cfg.timeout)
 	}
 	if !reflect.DeepEqual(cfg.recipients, []string{"first@example.com", "-recipient@example.com"}) {
 		t.Fatalf("recipients = %#v", cfg.recipients)
@@ -55,12 +58,13 @@ func TestParseArgs(t *testing.T) {
 		"OWLMAIL_SENDMAIL_STARTTLS": "true",
 		"OWLMAIL_SENDMAIL_USERNAME": "env-user",
 		"OWLMAIL_SENDMAIL_PASSWORD": "env-secret",
+		"OWLMAIL_SENDMAIL_TIMEOUT":  "1m",
 	}
 	cfg, _, err = parseArgs([]string{"--host", "cli.local", "--starttls=false", "to@example.com"}, lookup(environment))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.host != "cli.local" || cfg.port != 2465 || cfg.startTLS || cfg.username != "env-user" || cfg.password != "env-secret" {
+	if cfg.host != "cli.local" || cfg.port != 2465 || cfg.startTLS || cfg.username != "env-user" || cfg.password != "env-secret" || cfg.timeout != time.Minute {
 		t.Fatalf("CLI did not override environment correctly: %#v", cfg)
 	}
 }
@@ -78,6 +82,8 @@ func TestParseArgsErrors(t *testing.T) {
 		{name: "partial auth", args: []string{"--username", "user"}},
 		{name: "bad environment boolean", env: map[string]string{"OWLMAIL_SENDMAIL_SMTPS": "sometimes"}},
 		{name: "bad environment port", env: map[string]string{"OWLMAIL_SENDMAIL_PORT": "smtp"}},
+		{name: "bad timeout", args: []string{"--timeout", "forever"}},
+		{name: "bad environment timeout", env: map[string]string{"OWLMAIL_SENDMAIL_TIMEOUT": "0s"}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -90,6 +96,33 @@ func TestParseArgsErrors(t *testing.T) {
 				t.Fatalf("parseArgs() error = %v, exit = %d", err, exitCode(err))
 			}
 		})
+	}
+}
+
+func TestPrepareMessageHandlesResentRecipients(t *testing.T) {
+	input := "From: sender@example.com\r\n" +
+		"To: original@example.com\r\n" +
+		"Resent-To: resent@example.com\r\n" +
+		"Resent-Cc: resent-copy@example.com\r\n" +
+		"Resent-Bcc: resent-hidden@example.com,\r\n\tresent-folded@example.com\r\n" +
+		"Subject: resent\r\n\r\nbody\r\n"
+	message, err := prepareMessage(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"original@example.com", "resent@example.com", "resent-copy@example.com",
+		"resent-hidden@example.com", "resent-folded@example.com",
+	}
+	if !reflect.DeepEqual(message.headerRecipients, want) {
+		t.Fatalf("recipients = %#v, want %#v", message.headerRecipients, want)
+	}
+	sanitized, err := io.ReadAll(message.reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(bytes.ToLower(sanitized), []byte("resent-bcc:")) || bytes.Contains(sanitized, []byte("resent-hidden@example.com")) {
+		t.Fatalf("Resent-Bcc field was not removed: %q", sanitized)
 	}
 }
 
@@ -268,6 +301,36 @@ func TestRunUsageAndHelp(t *testing.T) {
 	stdout.Reset()
 	if exit := Run(nil, strings.NewReader("From: sender@example.com\r\n\r\nbody"), &stdout, &stderr); exit != ExitUsage {
 		t.Fatalf("missing recipient exit = %d, stderr = %q", exit, stderr.String())
+	}
+}
+
+func TestRunTimesOutWhenServerWithholdsGreeting(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		connection, _ := listener.Accept()
+		accepted <- connection
+	}()
+	host, port, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := time.Now()
+	exit := Run([]string{
+		"--host", host, "--port", port, "--timeout", "50ms", "to@example.com",
+	}, strings.NewReader("From: sender@example.com\r\n\r\nbody\r\n"), io.Discard, io.Discard)
+	if connection := <-accepted; connection != nil {
+		_ = connection.Close()
+	}
+	if exit != ExitTempFailure {
+		t.Fatalf("Run() exit = %d, want %d", exit, ExitTempFailure)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("submission timeout took %s", elapsed)
 	}
 }
 

--- a/tests/docs/markdown.test.js
+++ b/tests/docs/markdown.test.js
@@ -262,6 +262,37 @@ test("root README configuration tables match flags, defaults, and environment al
   }
 });
 
+test("sendmail CLI documentation covers every locale and its stable contract", () => {
+  const localeDocs = ["en", "zh-CN", "de", "fr", "it", "ja", "ko"].map(
+    (locale) => `docs/${locale}/Sendmail.md`,
+  );
+  for (const document of localeDocs) {
+    const markdown = fs.readFileSync(path.join(root, document), "utf8");
+    for (const marker of [
+      "owlmail sendmail -t -i",
+      "sendmail_path",
+      "OWLMAIL_SENDMAIL_HOST",
+      "OWLMAIL_SENDMAIL_PORT",
+      "OWLMAIL_SENDMAIL_STARTTLS",
+      "OWLMAIL_SENDMAIL_SMTPS",
+      "OWLMAIL_SENDMAIL_USERNAME",
+      "OWLMAIL_SENDMAIL_PASSWORD",
+      "`64`",
+      "`65`",
+      "`69`",
+      "`74`",
+      "`75`",
+    ]) {
+      assert.ok(markdown.includes(marker), `${document} is missing ${marker}`);
+    }
+  }
+
+  for (const readme of translatedReadmes) {
+    const markdown = fs.readFileSync(path.join(root, readme), "utf8");
+    assert.ok(markdown.includes("Sendmail.md"), `${readme} does not link the sendmail guide`);
+  }
+});
+
 test("security-sensitive SMTP authentication modes remain explicit", () => {
   const smtpWarnings = new Map([
     ["README.md", "NO AUTH"],

--- a/tests/docs/markdown.test.js
+++ b/tests/docs/markdown.test.js
@@ -277,6 +277,7 @@ test("sendmail CLI documentation covers every locale and its stable contract", (
       "OWLMAIL_SENDMAIL_SMTPS",
       "OWLMAIL_SENDMAIL_USERNAME",
       "OWLMAIL_SENDMAIL_PASSWORD",
+      "OWLMAIL_SENDMAIL_TIMEOUT",
       "`64`",
       "`65`",
       "`69`",


### PR DESCRIPTION
## Summary

- add `owlmail sendmail` as a sendmail-compatible stdin-to-SMTP client for PHP, cron, and legacy programs
- support `-t`, `-f ADDRESS` / `-fADDRESS`, `-i` / `-oi`, explicit recipients, and `--`
- extract To/Cc/Bcc and Resent-* envelope recipients, remove every Bcc/Resent-Bcc field and folded continuation before DATA, preserve message content, and negotiate SMTPUTF8 when required
- add host/port, strict STARTTLS, SMTPS, PLAIN AUTH, and a whole-submission timeout through CLI options and `OWLMAIL_SENDMAIL_*` environment variables
- keep delivery behind OwlMail's ordinary SMTP AUTH, TLS, SIZE, recipient, and DATA-concurrency enforcement
- document PHP `sendmail_path` and the complete contract in English, Simplified Chinese, German, French, Italian, Japanese, and Korean

## Safety and delivery boundary

The command never writes directly to mailbox storage. It always performs a real SMTP transaction, so it cannot bypass inbound authentication, TLS policy, message-size limits, or the process-wide DATA concurrency limiter.

- CRLF normalization and dot-stuffing are handled by the SMTP DATA writer
- `-f '<>'` preserves the null reverse path
- `--timeout` / `OWLMAIL_SENDMAIL_TIMEOUT` bounds connect, greeting, STARTTLS, AUTH, commands, and DATA acceptance (default `30s`)
- passwords, message bodies, and full AUTH exchanges are never logged
- TLS certificates use normal host-name and system trust-store verification; there is no insecure-skip-verification option
- after the server accepts DATA with 250, a later QUIT failure remains success to prevent duplicate retries

## Stable exit statuses

- `0`: accepted
- `64`: invalid argument/configuration
- `65`: invalid message header data or no `-t` recipients
- `69`: permanent SMTP failure
- `74`: local input/I/O failure
- `75`: temporary SMTP 4xx, network, or timeout failure

## Verification

- `go test -race ./...`
- `go vet ./...`
- `go build ./cmd/owlmail`
- `golangci-lint v2.13.1 run --timeout=5m`
- `bun test ./tests/web ./tests/docs` (Bun 1.4.0)
- `gofmt -s -l .`
- `git diff --check`

Fake SMTP coverage includes plain SMTP, AUTH success/rejection, STARTTLS, SMTPS, null sender, multiple and resent recipients, Bcc/Resent-Bcc stripping, internationalized headers/SMTPUTF8, CRLF/dot-stuffing, a server that withholds its greeting, and 4xx/5xx classification.