### PR TITLE
docs: refresh MailDev and MailCatcher comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to OwlMail are documented in this file. The format follows
 
 ### Added
 
+- A source-pinned three-way OwlMail, MailDev, and MailCatcher comparison that
+  distinguishes release and main-branch versions, corrects the current MCP
+  boundary, and documents API, live-event, storage, sendmail, and migration
+  tradeoffs without claiming unverified performance equivalence.
+
 - An optional, default-off MailDev REST facade under `/api`, with independent
   MailDev-shaped full-email and summary DTOs, filtering and pagination,
   read-on-detail behavior, bulk deletion, content downloads, synchronous relay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to OwlMail are documented in this file. The format follows
   distinguishes release and main-branch versions, corrects the current MCP
   boundary, and documents API, live-event, storage, sendmail, and migration
   tradeoffs without claiming unverified performance equivalence.
-- - Read-only MCP testing workflows with compact latest-email lookup, bounded
+- Read-only MCP testing workflows with compact latest-email lookup, bounded
   event-driven delivery waits, Web UI deep links, inbox/statistics/email
   resources, and verification/reset/delivery prompts. Waiters are limited per
   session and process and are removed on cancellation, timeout, session close,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,12 @@ All notable changes to OwlMail are documented in this file. The format follows
   distinguishes release and main-branch versions, corrects the current MCP
   boundary, and documents API, live-event, storage, sendmail, and migration
   tradeoffs without claiming unverified performance equivalence.
-
+- - Read-only MCP testing workflows with compact latest-email lookup, bounded
+  event-driven delivery waits, Web UI deep links, inbox/statistics/email
+  resources, and verification/reset/delivery prompts. Waiters are limited per
+  session and process and are removed on cancellation, timeout, session close,
+  or shutdown; generated links support HTTPS, reverse-proxy base paths, and the
+  explicit `OWLMAIL_WEB_EXTERNAL_URL` origin.
 - An optional, default-off MailDev REST facade under `/api`, with independent
   MailDev-shaped full-email and summary DTOs, filtering and pagination,
   read-on-detail behavior, bulk deletion, content downloads, synchronous relay

--- a/docs/de/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
+++ b/docs/de/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
@@ -19,7 +19,7 @@ aber **nicht protokollgleich oder ohne Prüfung austauschbar**. API-Präfixe,
 Antwortformen, Lesezustand und Live-Protokolle unterscheiden sich. Die aktuelle
 [API-Referenz](../en/API-Reference.md) enthält die verifizierte Abgrenzung.
 
-OwlMail bietet inzwischen einen standardmäßig deaktivierten, schreibgeschützten MCP-Endpunkt. MailDev 3 bietet einen breiteren MCP-Workflow; MailCatcher bietet kein integriertes MCP. Die standardmäßig deaktivierte Option `-maildev-rest-compat` stellt die aktuellen
+OwlMail bietet im geprüften main-Branch (nicht in v0.6.0) einen standardmäßig deaktivierten, schreibgeschützten MCP-Endpunkt. MailDev 3 bietet einen breiteren MCP-Workflow; MailCatcher bietet kein integriertes MCP. Die standardmäßig deaktivierte Option `-maildev-rest-compat` stellt die aktuellen
 MailDev-REST-Routen unter `/api` bereit. Sie bietet keine Socket.IO-Kompatibilität.
 
 > **Hinweis**: Der vollständige Inhalt wird verfügbar sein, sobald die Übersetzung abgeschlossen ist. Bitte verweisen Sie in der Zwischenzeit auf die englische Version für vollständige Details.

--- a/docs/de/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
+++ b/docs/de/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
@@ -1,4 +1,4 @@
-# OwlMail × MailDev: Vollständiger Funktions- und API-Vergleich sowie Migrations-Whitepaper
+# OwlMail × MailDev × MailCatcher: Vollständiger Funktions- und API-Vergleich sowie Migrations-Whitepaper
 
 > **Ein tiefer Quellcode-Vergleich + Migrationsleitfaden für Benutzer und Entwickler**
 
@@ -14,12 +14,12 @@
 
 ## 📋 Executive Summary
 
-OwlMail und MailDev decken dieselben grundlegenden Entwicklungsabläufe ab, sind
+OwlMail, MailDev und MailCatcher decken dieselben grundlegenden Entwicklungsabläufe ab, sind
 aber **nicht protokollgleich oder ohne Prüfung austauschbar**. API-Präfixe,
 Antwortformen, Lesezustand und Live-Protokolle unterscheiden sich. Die aktuelle
 [API-Referenz](../en/API-Reference.md) enthält die verifizierte Abgrenzung.
 
-Die standardmäßig deaktivierte Option `-maildev-rest-compat` stellt die aktuellen
+OwlMail bietet inzwischen einen standardmäßig deaktivierten, schreibgeschützten MCP-Endpunkt. MailDev 3 bietet einen breiteren MCP-Workflow; MailCatcher bietet kein integriertes MCP. Die standardmäßig deaktivierte Option `-maildev-rest-compat` stellt die aktuellen
 MailDev-REST-Routen unter `/api` bereit. Sie bietet keine Socket.IO-Kompatibilität.
 
 > **Hinweis**: Der vollständige Inhalt wird verfügbar sein, sobald die Übersetzung abgeschlossen ist. Bitte verweisen Sie in der Zwischenzeit auf die englische Version für vollständige Details.

--- a/docs/en/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
+++ b/docs/en/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
@@ -29,34 +29,34 @@ but optimize for different workflows:
 - **MailCatcher** emphasizes a small Ruby workflow, a simple browser inbox, and
   the catchmail sendmail analogue.
 
-OwlMail is not a universal drop-in replacement for either project. Its optional
+OwlMail is not a universal drop-in replacement for either project. On the reviewed main branch, its optional
 MailDev REST facade covers the current MailDev REST contract, but does not
 implement Socket.IO or the Node API. MailCatcher uses a different messages API
 and live-update contract.
 
 ## Feature comparison
 
-| Capability | OwlMail 0.6.0 + reviewed main | MailDev 3.0.0-rc.3 | MailCatcher main 0.11.0 |
-|---|---|---|---|
-| Runtime | Go single binary with embedded Web assets | Node.js 20+, TypeScript monorepo and React UI | Ruby 3.3+, EventMachine/Sinatra |
-| Primary strength | Reliable storage and automation | Interactive email inspection and integration breadth | Minimal Ruby/sendmail workflow |
-| SMTP capture | Yes; SMTP, STARTTLS and direct SMTPS | Yes; configurable SMTP/TLS behavior | Yes; intentionally simple SMTP server |
-| Message size | Configurable; 100 MiB default | Configurable; 50 MiB default on current main | No equivalent documented control |
-| DATA concurrency | Configurable per process; 8 default, 0 unlimited | No equivalent documented process-wide DATA limiter | No equivalent documented limiter |
-| Persistence | Atomic EML commit, recovery and quarantine | Optional EML and attachment directory with restore | SQLite in-memory database |
-| Retention | Age, count and local-disk limits | Maximum email count | Maximum message count |
-| Attachments | Streaming staging; local or optional S3 | Local attachment files when persistence is enabled | Stored with the in-memory message database |
-| REST API | Native versioned API plus optional MailDev REST facade | Current API below /api | Messages API below /messages |
-| Live updates | Native RFC 6455 WebSocket | Socket.IO | WebSocket with polling fallback |
-| UI | Lightweight multilingual UI, secure HTML isolation, responsive widths | Rich React UI, source/header views and responsive preview | Simple HTML/plain/source UI with keyboard navigation |
-| MCP | Optional, default-off, read-only Streamable HTTP endpoint | HTTP and stdio MCP with broader tools, resources and prompts | No built-in MCP |
-| Webhooks | Generic filters, templates, HMAC, retry, local outbox and optional Redis Streams | No equivalent generic durable webhook pipeline | No built-in generic webhook pipeline |
-| Relay | Manual and automatic outgoing SMTP relay | Manual and automatic outgoing SMTP relay | No comparable outgoing relay workflow |
-| sendmail analogue | owlmail sendmail | No bundled equivalent documented | catchmail |
-| Embedding | No stable Go library surface; internal packages remain internal | Public Node API | Primarily a standalone Ruby command |
-| Base path | Yes | Yes | Yes through http-path |
-| Authentication | Web Basic Auth; real SMTP AUTH; optional TLS requirement | Web and incoming SMTP credentials | Intended for trusted development use |
-| Multi-instance mailbox | No shared mailbox database | No | No |
+| Capability | OwlMail 0.6.0 | OwlMail reviewed main | MailDev 3.0.0-rc.3 | MailCatcher main 0.11.0 |
+|---|---|---|---|---|
+| Runtime | Go single binary with embedded Web assets | Same | Node.js 20+, TypeScript monorepo and React UI | Ruby 3.3+, EventMachine/Sinatra |
+| Primary strength | Recoverable local storage and durable webhooks | Storage, automation, and broader integrations | Interactive email inspection and integration breadth | Minimal Ruby/sendmail workflow |
+| SMTP capture | SMTP, STARTTLS and direct SMTPS | Same | Configurable SMTP/TLS behavior | Intentionally simple SMTP server |
+| Message size | Fixed 1 MiB | Configurable; 100 MiB default | Configurable; 50 MiB default on current main | No equivalent documented control |
+| DATA concurrency | No process-wide limiter | Configurable per process; 8 default, 0 unlimited | No equivalent documented process-wide limiter | No equivalent documented limiter |
+| Persistence | Atomic EML commit, recovery and quarantine | Same | Optional EML and attachment directory with restore | SQLite in-memory database |
+| Retention | Age, count and local-disk limits | Same | Maximum email count | Maximum message count |
+| Attachments | Local decoded attachments | Streaming staging; local or optional S3 | Local attachment files when persistence is enabled | Stored with the in-memory message database |
+| REST API | Native versioned and historical unversioned routes | Same, plus an optional MailDev REST facade | Current API below /api | Messages API below /messages |
+| Live updates | Native RFC 6455 WebSocket | Same | Socket.IO | WebSocket with polling fallback |
+| UI | Lightweight multilingual UI, secure HTML isolation, responsive widths | Same | Rich React UI, source/header views and responsive preview | Simple HTML/plain/source UI with keyboard navigation |
+| MCP | No built-in endpoint | Optional, default-off, read-only Streamable HTTP endpoint | HTTP and stdio MCP with broader tools, resources and prompts | No built-in MCP |
+| Webhooks | Generic filters, templates, HMAC, retry, local outbox and optional Redis Streams | Same | No equivalent generic durable webhook pipeline | No built-in generic webhook pipeline |
+| Relay | Manual and automatic outgoing SMTP relay | Same | Manual and automatic outgoing SMTP relay | No comparable outgoing relay workflow |
+| sendmail analogue | No bundled command | owlmail sendmail | No bundled equivalent documented | catchmail |
+| Embedding | No stable Go library surface; internal packages remain internal | Same | Public Node API | Primarily a standalone Ruby command |
+| Base path | No configurable URL prefix | Configurable URL prefix | Yes | Yes through http-path |
+| Authentication | Web Basic Auth; SMTP credential settings are not enforced | Web Basic Auth; real SMTP AUTH; optional TLS requirement | Web and incoming SMTP credentials | Intended for trusted development use |
+| Multi-instance mailbox | No shared mailbox database | Same | No | No |
 
 No cross-project performance ranking is claimed. Runtime language, binary size,
 or a synthetic microbenchmark does not establish end-to-end behavior under MIME
@@ -74,7 +74,7 @@ parsing, disk pressure, TLS, S3, webhook, or browser workloads.
 | Live events | Socket.IO | Native WebSocket, not Socket.IO | Project-specific WebSocket/polling |
 | Embedded API | Node MailDev class | None | None |
 
-Enable the OwlMail MailDev facade explicitly with
+On the reviewed OwlMail main branch, enable the MailDev facade explicitly with
 OWLMAIL_MAILDEV_REST_COMPAT=true or -maildev-rest-compat. It shares the normal
 Basic Auth, HTTPS, storage, and base-path boundary. It does not enable Socket.IO.
 
@@ -84,7 +84,7 @@ delivery.
 
 ## Agent integration
 
-OwlMail now provides a default-off MCP endpoint at /mcp with five closed-world,
+The reviewed OwlMail main branch provides a default-off MCP endpoint at /mcp with five closed-world,
 read-only tools: list, search, detached detail, bounded base64 source, and
 attachment metadata. It shares the Web listener and authentication boundary.
 It deliberately excludes deletion, read-state mutation, relay, configuration
@@ -117,7 +117,7 @@ database-backed production mailbox service.
 
 ## Selection guide
 
-Choose **OwlMail** when a single binary, ARM/cross-platform deployment, durable
+Choose the reviewed **OwlMail main** when a single binary, ARM/cross-platform deployment, durable
 webhook automation, recoverable disk storage, optional S3 attachments, SMTP
 resource controls, or a small read-only agent surface matters most.
 
@@ -134,7 +134,7 @@ inventorying REST and live-event consumers. For MailCatcher, treat SMTP capture
 and the sendmail analogue as the portable concepts; adapt every HTTP or
 WebSocket integration.
 
-## Known OwlMail gaps at this baseline
+## Known OwlMail main-branch gaps at this baseline
 
 - The native WebSocket endpoint is not Socket.IO.
 - There is no public stable Go embedding SDK or general application config file.

--- a/docs/en/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
+++ b/docs/en/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
@@ -84,8 +84,9 @@ delivery.
 
 ## Agent integration
 
-The reviewed OwlMail main branch provides a default-off MCP endpoint at /mcp
-with seven closed-world, read-only tools: list, search, detached detail,
+The reviewed OwlMail main branch provides a default-off MCP endpoint at `/mcp`
+for a root deployment and `<base-pathname>/mcp` when a base pathname is
+configured, with seven closed-world, read-only tools: list, search, detached detail,
 bounded base64 source, attachment metadata, latest-email lookup ordered by
 receipt, and an event-driven bounded delivery wait. It also exposes bounded
 inbox, statistics, and email resources plus registration-verification,

--- a/docs/en/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
+++ b/docs/en/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
@@ -5,7 +5,7 @@
 
 **Review baseline:** 2026-09-02.
 
-- OwlMail: release 0.6.0; main at 03bbad9a8223d61a2d841f341b1d953bf5af1d05.
+- OwlMail: release 0.6.0; reviewed main at 279571b62a5e4891f0a204837d8553b131b89b20.
 - MailDev: release candidate maildev@3.0.0-rc.3; main at
   9d4141f42b0acedfa544a306f96a5373ded8c8a3. The latest stable 2.x release is
   2.2.1 and differs materially from the 3.x codebase.
@@ -48,8 +48,8 @@ and live-update contract.
 | Attachments | Local decoded attachments | Streaming staging; local or optional S3 | Local attachment files when persistence is enabled | Stored with the in-memory message database |
 | REST API | Native versioned and historical unversioned routes | Same, plus an optional MailDev REST facade | Current API below /api | Messages API below /messages |
 | Live updates | Native RFC 6455 WebSocket | Same | Socket.IO | WebSocket with polling fallback |
-| UI | Lightweight multilingual UI, secure HTML isolation, responsive widths | Same | Rich React UI, source/header views and responsive preview | Simple HTML/plain/source UI with keyboard navigation |
-| MCP | No built-in endpoint | Optional, default-off, read-only Streamable HTTP endpoint | HTTP and stdio MCP with broader tools, resources and prompts | No built-in MCP |
+| UI | Lightweight multilingual inbox | Same, plus secure HTML isolation and responsive widths | Rich React UI, source/header views and responsive preview | Simple HTML/plain/source UI with keyboard navigation |
+| MCP | No built-in endpoint | Optional, default-off Streamable HTTP with seven read-only tools, resources and prompts | HTTP and stdio MCP with broader tools, resources and prompts | No built-in MCP |
 | Webhooks | Generic filters, templates, HMAC, retry, local outbox and optional Redis Streams | Same | No equivalent generic durable webhook pipeline | No built-in generic webhook pipeline |
 | Relay | Manual and automatic outgoing SMTP relay | Same | Manual and automatic outgoing SMTP relay | No comparable outgoing relay workflow |
 | sendmail analogue | No bundled command | owlmail sendmail | No bundled equivalent documented | catchmail |
@@ -84,10 +84,14 @@ delivery.
 
 ## Agent integration
 
-The reviewed OwlMail main branch provides a default-off MCP endpoint at /mcp with five closed-world,
-read-only tools: list, search, detached detail, bounded base64 source, and
-attachment metadata. It shares the Web listener and authentication boundary.
-It deliberately excludes deletion, read-state mutation, relay, configuration
+The reviewed OwlMail main branch provides a default-off MCP endpoint at /mcp
+with seven closed-world, read-only tools: list, search, detached detail,
+bounded base64 source, attachment metadata, latest-email lookup ordered by
+receipt, and an event-driven bounded delivery wait. It also exposes bounded
+inbox, statistics, and email resources plus registration-verification,
+password-reset, and delivery prompts. It shares the Web listener and
+authentication boundary and generates base-path-aware Web links. It
+deliberately excludes deletion, read-state mutation, relay, configuration
 changes, and attachment bytes.
 
 MailDev 3 exposes a broader MCP server and supports both HTTP and stdio

--- a/docs/en/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
+++ b/docs/en/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
@@ -1,207 +1,160 @@
-# OwlMail × MailDev: Feature, API, and Migration Guide
+# OwlMail × MailDev × MailCatcher: Feature, API, and Migration Guide
 
-> A source-based comparison for users deciding whether and how to migrate.
+> A source-based comparison for choosing a development mail server. It describes
+> verified behavior, not drop-in compatibility.
 
-**Review baseline:** 2026-08-29. This guide compares the OwlMail source tree
-with the current [MailDev REST documentation](https://github.com/maildev/maildev/blob/main/docs/rest.md).
-Both projects can evolve; validate the exact versions you deploy.
+**Review baseline:** 2026-09-02.
+
+- OwlMail: release 0.6.0; main at 03bbad9a8223d61a2d841f341b1d953bf5af1d05.
+- MailDev: release candidate maildev@3.0.0-rc.3; main at
+  9d4141f42b0acedfa544a306f96a5373ded8c8a3. The latest stable 2.x release is
+  2.2.1 and differs materially from the 3.x codebase.
+- MailCatcher: latest GitHub release v0.10.0; main declares 0.11.0 at
+  43e488e2a5692532c131a87d5bd16a973ee8db56.
+
+All three projects can evolve. Pin the version used by development and CI, and
+validate the exact build before migration.
 
 ## Executive summary
 
-OwlMail and MailDev solve the same central development problem: accept SMTP
-mail, retain it for inspection, show it in a browser, and optionally relay it.
-That overlap makes SMTP-only migrations straightforward in many environments.
+The three projects accept development SMTP mail and expose it for inspection,
+but optimize for different workflows:
 
-OwlMail also provides a single Go binary, a versioned `/api/v1` surface, native
-SMTPS, browser notifications, generic webhook forwarding, and embedded local
-help. Those are OwlMail features, not proof of protocol equivalence.
+- **OwlMail** emphasizes a single Go binary, durable and recoverable local
+  storage, optional S3 attachments, generic durable webhooks, a versioned API,
+  and a default-off read-only MCP endpoint.
+- **MailDev 3** emphasizes a rich React inspection experience, Node embedding,
+  exact Socket.IO integration, a broad MCP workflow, and a configurable
+  TypeScript application surface.
+- **MailCatcher** emphasizes a small Ruby workflow, a simple browser inbox, and
+  the catchmail sendmail analogue.
 
-OwlMail is **not an exact drop-in replacement for current MailDev**. It now has
-an explicit, default-off REST facade for MailDev's current `/api` paths and
-payloads, but the browser UI, Socket.IO live protocol, configuration breadth,
-and MCP tool contracts remain distinct. Enable the facade for REST migrations
-and still test every non-REST integration.
+OwlMail is not a universal drop-in replacement for either project. Its optional
+MailDev REST facade covers the current MailDev REST contract, but does not
+implement Socket.IO or the Node API. MailCatcher uses a different messages API
+and live-update contract.
 
 ## Feature comparison
 
-| Capability | MailDev | OwlMail | Migration note |
+| Capability | OwlMail 0.6.0 + reviewed main | MailDev 3.0.0-rc.3 | MailCatcher main 0.11.0 |
 |---|---|---|---|
-| SMTP capture | Yes | Yes, default port 1025 | Usually only the hostname changes |
-| Browser inbox | Yes | Yes, default port 1080 | UI customizations are not portable |
-| EML directory | Yes | Yes | Test an archive copy before switching |
-| Individual relay | Yes | Yes | Requires outgoing SMTP settings |
-| Automatic relay | Yes | Yes | OwlMail supports allow/deny JSON rules |
-| Inbound SMTP auth | Yes | PLAIN/LOGIN; required with both credentials, otherwise NO AUTH | Configure both credentials when migrating an authentication boundary |
-| Web Basic Auth | Yes | Yes | OwlMail health endpoints remain public |
-| SMTP TLS / STARTTLS | Yes | Yes | Certificate paths must be readable |
-| Direct SMTPS | Version-dependent | Yes, port 465 when SMTP TLS is enabled | OwlMail-specific behavior |
-| REST API | Yes | Yes, plus an opt-in MailDev `/api` facade | Native OwlMail routes remain different |
-| Live updates | Socket.IO | Native WebSocket | Client code must change |
-| Generic outgoing webhooks | Version-dependent | Yes | OwlMail supports templates, HMAC, retry, and filters |
-| Browser notifications | UI/version-dependent | Opt-in per browser | Requires permission and a secure context |
-| MCP server | Current MailDev provides one | No | Keep MailDev or add another integration if required |
-| General JS/JSON config file | Current MailDev provides one | No general config file | OwlMail uses flags and environment variables; webhook targets use JSON |
-| Configurable base pathname | Yes | Yes | OwlMail prefixes every UI, API, native WebSocket, compatibility, and Service Worker route |
+| Runtime | Go single binary with embedded Web assets | Node.js 20+, TypeScript monorepo and React UI | Ruby 3.3+, EventMachine/Sinatra |
+| Primary strength | Reliable storage and automation | Interactive email inspection and integration breadth | Minimal Ruby/sendmail workflow |
+| SMTP capture | Yes; SMTP, STARTTLS and direct SMTPS | Yes; configurable SMTP/TLS behavior | Yes; intentionally simple SMTP server |
+| Message size | Configurable; 100 MiB default | Configurable; 50 MiB default on current main | No equivalent documented control |
+| DATA concurrency | Configurable per process; 8 default, 0 unlimited | No equivalent documented process-wide DATA limiter | No equivalent documented limiter |
+| Persistence | Atomic EML commit, recovery and quarantine | Optional EML and attachment directory with restore | SQLite in-memory database |
+| Retention | Age, count and local-disk limits | Maximum email count | Maximum message count |
+| Attachments | Streaming staging; local or optional S3 | Local attachment files when persistence is enabled | Stored with the in-memory message database |
+| REST API | Native versioned API plus optional MailDev REST facade | Current API below /api | Messages API below /messages |
+| Live updates | Native RFC 6455 WebSocket | Socket.IO | WebSocket with polling fallback |
+| UI | Lightweight multilingual UI, secure HTML isolation, responsive widths | Rich React UI, source/header views and responsive preview | Simple HTML/plain/source UI with keyboard navigation |
+| MCP | Optional, default-off, read-only Streamable HTTP endpoint | HTTP and stdio MCP with broader tools, resources and prompts | No built-in MCP |
+| Webhooks | Generic filters, templates, HMAC, retry, local outbox and optional Redis Streams | No equivalent generic durable webhook pipeline | No built-in generic webhook pipeline |
+| Relay | Manual and automatic outgoing SMTP relay | Manual and automatic outgoing SMTP relay | No comparable outgoing relay workflow |
+| sendmail analogue | owlmail sendmail | No bundled equivalent documented | catchmail |
+| Embedding | No stable Go library surface; internal packages remain internal | Public Node API | Primarily a standalone Ruby command |
+| Base path | Yes | Yes | Yes through http-path |
+| Authentication | Web Basic Auth; real SMTP AUTH; optional TLS requirement | Web and incoming SMTP credentials | Intended for trusted development use |
+| Multi-instance mailbox | No shared mailbox database | No | No |
 
-No performance rating is included here because the repository does not contain
-a reproducible cross-project benchmark. A compiled Go binary can simplify
-deployment, but throughput and memory claims should be measured against the
-actual workload, storage, TLS, and webhook downstreams.
+No cross-project performance ranking is claimed. Runtime language, binary size,
+or a synthetic microbenchmark does not establish end-to-end behavior under MIME
+parsing, disk pressure, TLS, S3, webhook, or browser workloads.
 
-## API compatibility boundary
+## API and real-time compatibility
 
-### Current MailDev interface
+| Workflow | MailDev | OwlMail | MailCatcher |
+|---|---|---|---|
+| List | GET /api/email | Same path only when MailDev facade is enabled; native GET /api/v1/emails | GET /messages |
+| Compact list | GET /api/email/summary | Same path and shape only with the facade | No equivalent documented summary contract |
+| Detail | GET /api/email/:id and mark read | Facade preserves that side effect; native detail does not | GET /messages/:id.json |
+| HTML/text/source | MailDev-specific /api routes | Facade plus native versioned routes | /messages/:id.html, .plain and .source |
+| Attachments | MailDev attachment route | Facade plus native attachment route | /messages/:id/parts/:cid |
+| Live events | Socket.IO | Native WebSocket, not Socket.IO | Project-specific WebSocket/polling |
+| Embedded API | Node MailDev class | None | None |
 
-Current MailDev documents routes below `/api`, including `/api/email`,
-`/api/email/summary`, `/api/email/delete`, and `/api/config`. It marks a message
-as read when `GET /api/email/:id` is called. Live events use Socket.IO and the
-event names `newMail` and `deleteMail`.
+Enable the OwlMail MailDev facade explicitly with
+OWLMAIL_MAILDEV_REST_COMPAT=true or -maildev-rest-compat. It shares the normal
+Basic Auth, HTTPS, storage, and base-path boundary. It does not enable Socket.IO.
 
-### OwlMail interface
+Do not point a MailCatcher API client at OwlMail without an adapter. SMTP-only
+applications are much easier to migrate because all three accept ordinary SMTP
+delivery.
 
-OwlMail exposes three HTTP surfaces:
+## Agent integration
 
-- `/api/v1/*`: the preferred, versioned OwlMail API.
-- Unversioned `/email`, `/config`, `/healthz`, and `/socket.io` paths retained
-  for existing OwlMail clients and common MailDev-style workflows.
-- Optional `/api/*` MailDev REST routes, enabled only by
-  `-maildev-rest-compat` or `OWLMAIL_MAILDEV_REST_COMPAT=true`.
+OwlMail now provides a default-off MCP endpoint at /mcp with five closed-world,
+read-only tools: list, search, detached detail, bounded base64 source, and
+attachment metadata. It shares the Web listener and authentication boundary.
+It deliberately excludes deletion, read-state mutation, relay, configuration
+changes, and attachment bytes.
 
-When `-base-pathname /owlmail` (or `OWLMAIL_BASE_PATHNAME=/owlmail`) is set,
-prepend `/owlmail` to every path in this section. The compatible
-`MAILDEV_BASE_PATHNAME` variable is also accepted. This changes route location,
-not protocol: `/owlmail/socket.io` is still native RFC 6455 WebSocket.
+MailDev 3 exposes a broader MCP server and supports both HTTP and stdio
+workflows. Tool and payload names are not interchangeable with OwlMail. An
+existing MailDev MCP client therefore requires an explicit compatibility check.
 
-The REST facade shares OwlMail storage, authentication, HTTPS, and base-path
-routing. Only its detail route marks a message read, and its DTOs preserve the
-MailDev array, summary, envelope, attachment, mutation, and error shapes. The
-`/socket.io` OwlMail path is still a native RFC 6455 WebSocket endpoint. Its
-name does not make it Socket.IO compatible, and the REST option never enables
-Socket.IO.
+MailCatcher has no built-in MCP endpoint. Agents can use its HTTP API only
+through a separate tool or adapter.
 
-| Workflow | Current MailDev | OwlMail |
-|---|---|---|
-| list emails | `GET /api/email` | Same path when facade enabled; otherwise native routes differ |
-| compact list | `GET /api/email/summary` | Same path and summary envelope when facade enabled |
-| get detail | `GET /api/email/:id`, marks read | Same behavior only in the facade; native detail routes have no read side effect |
-| mark one read | implicit on detail | `PATCH /email/:id/read` or `PATCH /api/v1/emails/:id/read` |
-| delete many | `POST /api/email/delete` | Same request/result shape when facade enabled |
-| reload directory | `GET /api/reloadMailsFromDirectory` | Same path when facade enabled |
-| configuration | `GET /api/config` | Same compact shape when facade enabled |
-| health | `GET /api/healthz` | Same public JSON boolean when facade enabled |
-| live events | Socket.IO `newMail`, `deleteMail` | native WS `{type:"new"}`, `{type:"delete"}` |
+## Storage and reliability boundary
 
-Native collection shapes still differ: `/api/v1` returns a pagination envelope
-such as `{ "total": 3, "limit": 50, "offset": 0, "emails": [...] }`. The
-opt-in facade instead returns MailDev's array and summary-envelope shapes.
+OwlMail commits attachments before the final EML marker, makes a message visible
+only after the storage transaction completes, and quarantines incomplete or
+unparseable recovery artifacts. Its optional S3 mode stores decoded attachments
+remotely while retaining EML, metadata, transaction state, and the webhook
+outbox locally.
 
-See the [OwlMail API reference](./API-Reference.md) for the complete route list,
-payloads, status behavior, authentication, and WebSocket protocol.
+MailDev can persist EML and attachments and restore them at startup, but its
+storage model and operational guarantees are not the same as OwlMail's
+transaction and quarantine contract.
 
-## Configuration compatibility boundary
+MailCatcher stores messages in an in-memory SQLite database. Its message limit
+bounds the active inbox, but it is not a durable archive.
 
-OwlMail accepts a documented subset of familiar `MAILDEV_*` environment
-variables and gives explicitly supplied CLI flags priority. It also provides
-`OWLMAIL_*` names for OwlMail-specific settings. This is a convenience layer,
-not full compatibility with every current MailDev option.
+None of the projects should be described as a horizontally shared,
+database-backed production mailbox service.
 
-Common direct mappings include:
+## Selection guide
 
-| Purpose | MailDev-style variable accepted by OwlMail | OwlMail variable |
-|---|---|---|
-| SMTP port | `MAILDEV_SMTP_PORT` | `OWLMAIL_SMTP_PORT` |
-| Web port | `MAILDEV_WEB_PORT` | `OWLMAIL_WEB_PORT` |
-| Mail directory | `MAILDEV_MAIL_DIRECTORY` | `OWLMAIL_MAIL_DIR` |
-| Web user | `MAILDEV_WEB_USER` | `OWLMAIL_WEB_USER` |
-| Web password | `MAILDEV_WEB_PASS` | `OWLMAIL_WEB_PASSWORD` |
-| Base pathname | `MAILDEV_BASE_PATHNAME` | `OWLMAIL_BASE_PATHNAME` |
-| Outgoing host | `MAILDEV_OUTGOING_HOST` | `OWLMAIL_OUTGOING_HOST` |
-| Incoming user | `MAILDEV_INCOMING_USER` | `OWLMAIL_SMTP_USER` |
+Choose **OwlMail** when a single binary, ARM/cross-platform deployment, durable
+webhook automation, recoverable disk storage, optional S3 attachments, SMTP
+resource controls, or a small read-only agent surface matters most.
 
-Review the root README configuration table for the complete OwlMail-supported
-set. MailDev features such as MCP or a general configuration file do not become
-available merely because other `MAILDEV_*` names are recognized.
+Choose **MailDev** when the richest interactive UI, Node embedding, exact
+Socket.IO behavior, configuration files, or its broader MCP workflow matters
+most.
 
-## Operational differences to plan for
+Choose **MailCatcher** when the smallest familiar Ruby workflow and catchmail
+integration are more valuable than persistence, relaying, webhooks, or agent
+integration.
 
-### Web credentials
+For an existing MailDev deployment, enable the OwlMail REST facade only after
+inventorying REST and live-event consumers. For MailCatcher, treat SMTP capture
+and the sendmail analogue as the portable concepts; adapt every HTTP or
+WebSocket integration.
 
-- Neither username nor password: Basic Auth is disabled.
-- Username only: OwlMail generates a 32-character password and prints it once
-  to stderr. It changes on restart.
-- Password only: OwlMail uses `admin` as the username.
-- Both: OwlMail uses the supplied pair.
+## Known OwlMail gaps at this baseline
 
-Configure both values for stable automation. Use HTTPS when credentials travel
-outside localhost.
+- The native WebSocket endpoint is not Socket.IO.
+- There is no public stable Go embedding SDK or general application config file.
+- SMTP read/write timeouts and the recipient count are still fixed defaults.
+- Native relay acceptance is asynchronous and does not expose durable delivery
+  status.
+- The Web inbox does not yet provide complete browser-history and keyboard
+  navigation semantics.
+- The mailbox index remains in memory even when EML files are durable.
+- There is no Prometheus metrics endpoint.
 
-### Webhook delivery pressure
+These are roadmap observations, not claims that MailDev or MailCatcher
+necessarily implement the same behavior.
 
-OwlMail's webhook deliveries use a process-wide concurrency limit. The
-recommended default is 8. Set `-webhook-max-concurrency 0` only when unlimited
-delivery is intentional and downstream capacity has been verified. A finite
-limit applies backpressure to new-message processing when every delivery slot is
-busy; it prevents an unbounded population of goroutines waiting on slow targets.
+## Primary sources
 
-See [Webhook Forwarding](./Webhook-Forwarding.md) and the
-[scenario examples](../../examples/webhooks/README.md).
-
-### Browser notifications
-
-Notifications are off by default and enabled per browser from the inbox. Only
-new live events produce notifications. HTTPS or a trusted localhost origin is
-required, and browser permission can be revoked independently of OwlMail.
-
-## Migration playbooks
-
-### SMTP-only application
-
-1. Start OwlMail on an unused host/port.
-2. Point a staging application's SMTP host to OwlMail port 1025.
-3. Send plain text, HTML, multipart, BCC, and attachment messages.
-4. Verify envelope recipients and persisted EML files if persistence is used.
-5. Switch the development environment after the checks pass.
-
-### REST client
-
-1. Inventory every method, path, query parameter, and expected response shape.
-2. Choose `/api/v1` instead of depending on the unversioned aliases.
-3. Update the base path and unwrap OwlMail's pagination envelope.
-4. Replace detail-fetch read side effects with an explicit `PATCH` request.
-5. Test not-found, validation, relay failure, and authentication responses.
-6. Pin the OwlMail version used by CI or container deployments.
-
-### Live-event client
-
-1. Replace the Socket.IO library with a native WebSocket client.
-2. Connect to `/api/v1/ws`.
-3. Handle `connected`, `new`, and `delete` message types.
-4. Add reconnect/backoff logic in the client.
-5. If Basic Auth is enabled in a browser, serve the client from OwlMail's own
-   origin or use a server-side bridge that omits `Origin`.
-
-### EML archive
-
-1. Back up the MailDev directory.
-2. Start OwlMail against a copy, never the only archive.
-3. Verify counts, HTML, source, and attachments for representative messages.
-4. Keep the original until rollback is no longer required.
-
-## Acceptance checklist
-
-- SMTP plain text, HTML, Unicode, BCC, and attachments display correctly.
-- API clients parse collection envelopes and explicit error codes.
-- Read state changes only when the client requests it.
-- Delete, batch, export, relay, and reload operations behave as expected.
-- WebSocket reconnect and event handling are tested.
-- Basic Auth, HTTPS, health checks, and same-origin behavior are understood.
-- Webhook filters, signatures, retry, timeout, and concurrency are load-tested.
-- Rollback preserves the original EML archive and prior configuration.
-
-## Conclusion
-
-Choose OwlMail when its Go deployment model, versioned API, native WebSocket,
-webhooks, browser notifications, or built-in help fit the workflow. Keep or
-choose MailDev when exact current MailDev REST, Socket.IO, MCP, base-path, or
-configuration behavior is required. For mixed environments, a reverse proxy or
-small adapter is safer than relying on undocumented equivalence.
+- OwlMail API reference: [docs/en/API-Reference.md](./API-Reference.md)
+- OwlMail operations guide: [docs/en/Operations.md](./Operations.md)
+- MailDev README: https://github.com/maildev/maildev/blob/9d4141f42b0acedfa544a306f96a5373ded8c8a3/README.md
+- MailDev REST documentation: https://github.com/maildev/maildev/blob/9d4141f42b0acedfa544a306f96a5373ded8c8a3/docs/rest.md
+- MailDev MCP documentation: https://github.com/maildev/maildev/blob/9d4141f42b0acedfa544a306f96a5373ded8c8a3/docs/mcp.md
+- MailCatcher README: https://github.com/sj26/mailcatcher/blob/43e488e2a5692532c131a87d5bd16a973ee8db56/README.md
+- MailCatcher version: https://github.com/sj26/mailcatcher/blob/43e488e2a5692532c131a87d5bd16a973ee8db56/lib/mail_catcher/version.rb

--- a/docs/fr/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
+++ b/docs/fr/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
@@ -19,7 +19,7 @@ mais ils ne sont **ni identiques au niveau du protocole, ni interchangeables san
 validation**. Les préfixes API, les réponses, l'état de lecture et le protocole
 temps réel diffèrent. Consultez la [référence API](../en/API-Reference.md).
 
-OwlMail fournit désormais un point de terminaison MCP en lecture seule, désactivé par défaut. MailDev 3 propose un workflow MCP plus large ; MailCatcher n'intègre pas MCP. L'option `-maildev-rest-compat`, désactivée par défaut, expose les routes REST
+OwlMail fournit, uniquement sur la branche main examinée (pas dans la v0.6.0), un point de terminaison MCP en lecture seule, désactivé par défaut. MailDev 3 propose un workflow MCP plus large ; MailCatcher n'intègre pas MCP. L'option `-maildev-rest-compat`, désactivée par défaut, expose les routes REST
 MailDev actuelles sous `/api`. Elle n'ajoute aucune compatibilité Socket.IO.
 
 > **Note** : Le contenu complet sera disponible une fois la traduction terminée. En attendant, veuillez vous référer à la version anglaise pour les détails complets.

--- a/docs/fr/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
+++ b/docs/fr/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
@@ -1,4 +1,4 @@
-# OwlMail × MailDev : Livre blanc complet sur les fonctionnalités, l'API et la migration
+# OwlMail × MailDev × MailCatcher : Livre blanc complet sur les fonctionnalités, l'API et la migration
 
 > **Une comparaison approfondie au niveau du code source + Guide de migration pour les utilisateurs et les développeurs**
 
@@ -14,12 +14,12 @@
 
 ## 📋 Résumé exécutif
 
-OwlMail et MailDev couvrent les mêmes workflows de développement essentiels,
+OwlMail, MailDev et MailCatcher couvrent les mêmes workflows de développement essentiels,
 mais ils ne sont **ni identiques au niveau du protocole, ni interchangeables sans
 validation**. Les préfixes API, les réponses, l'état de lecture et le protocole
 temps réel diffèrent. Consultez la [référence API](../en/API-Reference.md).
 
-L'option `-maildev-rest-compat`, désactivée par défaut, expose les routes REST
+OwlMail fournit désormais un point de terminaison MCP en lecture seule, désactivé par défaut. MailDev 3 propose un workflow MCP plus large ; MailCatcher n'intègre pas MCP. L'option `-maildev-rest-compat`, désactivée par défaut, expose les routes REST
 MailDev actuelles sous `/api`. Elle n'ajoute aucune compatibilité Socket.IO.
 
 > **Note** : Le contenu complet sera disponible une fois la traduction terminée. En attendant, veuillez vous référer à la version anglaise pour les détails complets.

--- a/docs/it/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
+++ b/docs/it/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
@@ -19,7 +19,7 @@ sono equivalenti a livello di protocollo né intercambiabili senza verifica**.
 Prefissi API, risposte, stato di lettura e protocollo in tempo reale differiscono.
 Consulta il [riferimento API](../en/API-Reference.md).
 
-OwlMail ora include un endpoint MCP di sola lettura, disattivato per impostazione predefinita. MailDev 3 offre un flusso MCP più ampio; MailCatcher non include MCP. L'opzione `-maildev-rest-compat`, disattivata per impostazione predefinita,
+OwlMail include, solo nel branch main esaminato (non in v0.6.0), un endpoint MCP di sola lettura, disattivato per impostazione predefinita. MailDev 3 offre un flusso MCP più ampio; MailCatcher non include MCP. L'opzione `-maildev-rest-compat`, disattivata per impostazione predefinita,
 espone le route REST MailDev correnti sotto `/api`. Non abilita Socket.IO.
 
 > **Nota**: Il contenuto completo sarà disponibile una volta completata la traduzione. Nel frattempo, si prega di fare riferimento alla versione inglese per i dettagli completi.

--- a/docs/it/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
+++ b/docs/it/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
@@ -1,4 +1,4 @@
-# OwlMail × MailDev: Libro bianco completo su funzionalità, API e migrazione
+# OwlMail × MailDev × MailCatcher: Libro bianco completo su funzionalità, API e migrazione
 
 > **Un confronto approfondito a livello di codice sorgente + Guida alla migrazione per utenti e sviluppatori**
 
@@ -14,12 +14,12 @@
 
 ## 📋 Executive Summary
 
-OwlMail e MailDev coprono gli stessi flussi di sviluppo fondamentali, ma **non
+OwlMail, MailDev e MailCatcher coprono gli stessi flussi di sviluppo fondamentali, ma **non
 sono equivalenti a livello di protocollo né intercambiabili senza verifica**.
 Prefissi API, risposte, stato di lettura e protocollo in tempo reale differiscono.
 Consulta il [riferimento API](../en/API-Reference.md).
 
-L'opzione `-maildev-rest-compat`, disattivata per impostazione predefinita,
+OwlMail ora include un endpoint MCP di sola lettura, disattivato per impostazione predefinita. MailDev 3 offre un flusso MCP più ampio; MailCatcher non include MCP. L'opzione `-maildev-rest-compat`, disattivata per impostazione predefinita,
 espone le route REST MailDev correnti sotto `/api`. Non abilita Socket.IO.
 
 > **Nota**: Il contenuto completo sarà disponibile una volta completata la traduzione. Nel frattempo, si prega di fare riferimento alla versione inglese per i dettagli completi.

--- a/docs/ja/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
+++ b/docs/ja/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
@@ -19,7 +19,7 @@ OwlMail、MailDev、MailCatcher は基本的な開発ワークフローを共有
 レスポンス、既読状態、リアルタイム通信が異なります。現在の境界は
 [API リファレンス](../en/API-Reference.md)を参照してください。
 
-OwlMail は既定で無効の読み取り専用 MCP エンドポイントを提供します。MailDev 3 の MCP はより広範で、MailCatcher に組み込み MCP はありません。既定で無効の `-maildev-rest-compat` を有効にすると、現在の MailDev REST
+OwlMail はレビュー対象の main ブランチでのみ（v0.6.0 には含まれません）、既定で無効の読み取り専用 MCP エンドポイントを提供します。MailDev 3 の MCP はより広範で、MailCatcher に組み込み MCP はありません。既定で無効の `-maildev-rest-compat` を有効にすると、現在の MailDev REST
 ルートが `/api` 配下に追加されます。Socket.IO 互換性は提供されません。
 
 > **注**：翻訳が完了すると、完全なコンテンツが利用可能になります。それまでの間、完全な詳細については英語版を参照してください。

--- a/docs/ja/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
+++ b/docs/ja/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
@@ -1,4 +1,4 @@
-# OwlMail × MailDev: 完全な機能と API の比較および移行ホワイトペーパー
+# OwlMail × MailDev × MailCatcher: 完全な機能と API の比較および移行ホワイトペーパー
 
 > **ソースコードレベルの詳細比較 + ユーザーと開発者向けの移行ガイド**
 
@@ -14,12 +14,12 @@
 
 ## 📋 エグゼクティブサマリー
 
-OwlMail と MailDev は基本的な開発ワークフローを共有しますが、**プロトコルが
+OwlMail、MailDev、MailCatcher は基本的な開発ワークフローを共有しますが、**プロトコルが
 同一ではなく、検証なしに置き換えることはできません**。API プレフィックス、
 レスポンス、既読状態、リアルタイム通信が異なります。現在の境界は
 [API リファレンス](../en/API-Reference.md)を参照してください。
 
-既定で無効の `-maildev-rest-compat` を有効にすると、現在の MailDev REST
+OwlMail は既定で無効の読み取り専用 MCP エンドポイントを提供します。MailDev 3 の MCP はより広範で、MailCatcher に組み込み MCP はありません。既定で無効の `-maildev-rest-compat` を有効にすると、現在の MailDev REST
 ルートが `/api` 配下に追加されます。Socket.IO 互換性は提供されません。
 
 > **注**：翻訳が完了すると、完全なコンテンツが利用可能になります。それまでの間、完全な詳細については英語版を参照してください。

--- a/docs/ko/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
+++ b/docs/ko/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
@@ -1,4 +1,4 @@
-# OwlMail × MailDev: 전체 기능 및 API 비교 및 마이그레이션 화이트페이퍼
+# OwlMail × MailDev × MailCatcher: 전체 기능 및 API 비교 및 마이그레이션 화이트페이퍼
 
 > **소스 코드 수준의 심층 비교 + 사용자 및 개발자를 위한 마이그레이션 가이드**
 
@@ -14,12 +14,12 @@
 
 ## 📋 실행 요약
 
-OwlMail과 MailDev는 기본 개발 워크플로를 공유하지만 **프로토콜이 동일하지
+OwlMail, MailDev 및 MailCatcher는 기본 개발 워크플로를 공유하지만 **프로토콜이 동일하지
 않으며 검증 없이 교체할 수 없습니다**. API 접두사, 응답 형식, 읽음 상태 및
 실시간 프로토콜이 다릅니다. 현재 범위는
 [API 참조](../en/API-Reference.md)를 확인하세요.
 
-기본적으로 비활성화된 `-maildev-rest-compat` 옵션은 현재 MailDev REST 경로를
+OwlMail은 기본적으로 비활성화된 읽기 전용 MCP 엔드포인트를 제공합니다. MailDev 3의 MCP 범위는 더 넓고 MailCatcher에는 내장 MCP가 없습니다. 기본적으로 비활성화된 `-maildev-rest-compat` 옵션은 현재 MailDev REST 경로를
 `/api` 아래에 제공합니다. Socket.IO 호환성은 제공하지 않습니다.
 
 > **참고**: 번역이 완료되면 전체 내용을 사용할 수 있습니다. 그동안 전체 세부사항은 영어 버전을 참조하세요.

--- a/docs/ko/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
+++ b/docs/ko/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
@@ -19,7 +19,7 @@ OwlMail, MailDev 및 MailCatcher는 기본 개발 워크플로를 공유하지�
 실시간 프로토콜이 다릅니다. 현재 범위는
 [API 참조](../en/API-Reference.md)를 확인하세요.
 
-OwlMail은 기본적으로 비활성화된 읽기 전용 MCP 엔드포인트를 제공합니다. MailDev 3의 MCP 범위는 더 넓고 MailCatcher에는 내장 MCP가 없습니다. 기본적으로 비활성화된 `-maildev-rest-compat` 옵션은 현재 MailDev REST 경로를
+OwlMail은 검토된 main 브랜치에서만(v0.6.0에는 포함되지 않음) 기본적으로 비활성화된 읽기 전용 MCP 엔드포인트를 제공합니다. MailDev 3의 MCP 범위는 더 넓고 MailCatcher에는 내장 MCP가 없습니다. 기본적으로 비활성화된 `-maildev-rest-compat` 옵션은 현재 MailDev REST 경로를
 `/api` 아래에 제공합니다. Socket.IO 호환성은 제공하지 않습니다.
 
 > **참고**: 번역이 완료되면 전체 내용을 사용할 수 있습니다. 그동안 전체 세부사항은 영어 버전을 참조하세요.

--- a/docs/zh-CN/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
+++ b/docs/zh-CN/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
@@ -77,7 +77,8 @@ HTTPS、存储和 base path，但不会启用 Socket.IO。
 
 ## Agent 集成
 
-已审查 OwlMail main 已提供默认关闭的 /mcp，包含七个封闭只读工具：列表、搜索、
+已审查 OwlMail main 已提供默认关闭的 MCP：根路径部署使用 `/mcp`，配置 base
+pathname 后使用 `<base-pathname>/mcp`。它包含七个封闭只读工具：列表、搜索、
 独立详情快照、受限 base64 原始源码、附件元数据、按接收顺序取得最新邮件，以及
 事件驱动且有界的投递等待。它还提供有界的收件箱、统计与单邮件资源，以及注册验证、
 密码重置和投递等待 Prompts；生成的 Web 链接会保留 base path。它与 Web API 共用

--- a/docs/zh-CN/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
+++ b/docs/zh-CN/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
@@ -25,33 +25,33 @@
 - **MailCatcher** 侧重简单 Ruby 工作流、轻量收件箱及 catchmail sendmail
   替代命令。
 
-OwlMail 不是另外两者的通用无缝替代。可选 MailDev REST facade 能覆盖当前
+OwlMail 不是另外两者的通用无缝替代。已审查 main 上的可选 MailDev REST facade 能覆盖当前
 MailDev REST 合约，但不实现 Socket.IO 或 Node API；MailCatcher 的 messages
 API 和实时协议也不同。
 
 ## 功能对比
 
-| 能力 | OwlMail 0.6.0 + 已审查 main | MailDev 3.0.0-rc.3 | MailCatcher main 0.11.0 |
-|---|---|---|---|
-| 运行时 | Go 单二进制，内嵌 Web 资源 | Node.js 20+、TypeScript monorepo、React | Ruby 3.3+、EventMachine/Sinatra |
-| 核心优势 | 可靠存储与自动化 | 交互式邮件检查与集成广度 | 极简 Ruby/sendmail 工作流 |
-| SMTP 捕获 | SMTP、STARTTLS、直接 SMTPS | SMTP 与可配置 TLS | 简单 SMTP Server |
-| 邮件大小 | 可配置，默认 100 MiB | 可配置，当前默认 50 MiB | 未记录等价控制 |
-| DATA 并发 | 进程级可配置，默认 8，0 为无限制 | 未记录等价 DATA 限流 | 未记录等价限流 |
-| 持久化 | EML 原子提交、恢复与 quarantine | 可选 EML/附件目录并在启动时恢复 | SQLite 内存数据库 |
-| 保留策略 | 按时间、数量和本地磁盘占用 | 最大邮件数量 | 最大消息数量 |
-| 附件 | 流式 staging；本地或可选 S3 | 启用持久化时保存本地附件 | 随内存消息数据库保存 |
-| REST API | 原生 /api/v1 加可选 MailDev facade | 当前接口位于 /api | messages API 位于 /messages |
-| 实时更新 | 原生 RFC 6455 WebSocket | Socket.IO | WebSocket，浏览器可退化为轮询 |
-| UI | 轻量多语言、安全 HTML 隔离、响应式宽度 | React UI、源码/Header 与响应式预览 | 简单 HTML/纯文本/源码视图及键盘导航 |
-| MCP | 默认关闭的只读 Streamable HTTP | HTTP 与 stdio，更丰富的工具、资源和 Prompts | 无内置 MCP |
-| Webhook | 过滤、模板、HMAC、重试、本地 outbox、可选 Redis Streams | 无等价通用持久 Webhook 管道 | 无内置通用 Webhook |
-| Relay | 手动与自动出站 SMTP 中继 | 手动与自动出站 SMTP 中继 | 无可比的出站中继流程 |
-| sendmail 替代 | owlmail sendmail | 未记录内置等价命令 | catchmail |
-| 嵌入能力 | 无稳定公共 Go SDK，internal 不是公共接口 | 公共 Node API | 主要作为独立 Ruby 命令 |
-| Base path | 支持 | 支持 | 通过 http-path 支持 |
-| 鉴权 | Web Basic Auth；真实 SMTP AUTH；可选强制 TLS | Web 与入站 SMTP 凭据 | 面向可信开发环境 |
-| 多实例共享邮箱 | 不支持 | 不支持 | 不支持 |
+| 能力 | OwlMail 0.6.0 | OwlMail 已审查 main | MailDev 3.0.0-rc.3 | MailCatcher main 0.11.0 |
+|---|---|---|---|---|
+| 运行时 | Go 单二进制，内嵌 Web 资源 | 相同 | Node.js 20+、TypeScript monorepo、React | Ruby 3.3+、EventMachine/Sinatra |
+| 核心优势 | 可恢复本地存储与持久 Webhook | 存储、自动化及更多集成能力 | 交互式邮件检查与集成广度 | 极简 Ruby/sendmail 工作流 |
+| SMTP 捕获 | SMTP、STARTTLS、直接 SMTPS | 相同 | 可配置 SMTP/TLS | 简单 SMTP Server |
+| 邮件大小 | 固定 1 MiB | 可配置，默认 100 MiB | 可配置，当前 main 默认 50 MiB | 未记录等价控制 |
+| DATA 并发 | 无进程级限制 | 进程级可配置，默认 8，0 为无限制 | 未记录等价 DATA 限流 | 未记录等价限流 |
+| 持久化 | EML 原子提交、恢复与 quarantine | 相同 | 可选 EML/附件目录并在启动时恢复 | SQLite 内存数据库 |
+| 保留策略 | 按时间、数量和本地磁盘占用 | 相同 | 最大邮件数量 | 最大消息数量 |
+| 附件 | 本地保存解码附件 | 流式 staging；本地或可选 S3 | 启用持久化时保存本地附件 | 随内存消息数据库保存 |
+| REST API | 原生版本化及历史无版本路由 | 相同，另有可选 MailDev facade | 当前接口位于 /api | messages API 位于 /messages |
+| 实时更新 | 原生 RFC 6455 WebSocket | 相同 | Socket.IO | WebSocket，浏览器可退化为轮询 |
+| UI | 轻量多语言、安全 HTML 隔离、响应式宽度 | 相同 | React UI、源码/Header 与响应式预览 | 简单 HTML/纯文本/源码视图及键盘导航 |
+| MCP | 无内置端点 | 默认关闭的只读 Streamable HTTP | HTTP 与 stdio，更丰富的工具、资源和 Prompts | 无内置 MCP |
+| Webhook | 过滤、模板、HMAC、重试、本地 outbox、可选 Redis Streams | 相同 | 无等价通用持久 Webhook 管道 | 无内置通用 Webhook |
+| Relay | 手动与自动出站 SMTP 中继 | 相同 | 手动与自动出站 SMTP 中继 | 无可比的出站中继流程 |
+| sendmail 替代 | 无内置命令 | owlmail sendmail | 未记录内置等价命令 | catchmail |
+| 嵌入能力 | 无稳定公共 Go SDK，internal 不是公共接口 | 相同 | 公共 Node API | 主要作为独立 Ruby 命令 |
+| Base path | 无可配置 URL 前缀 | 支持可配置 URL 前缀 | 支持 | 通过 http-path 支持 |
+| 鉴权 | Web Basic Auth；SMTP 凭据设置不强制验证 | Web Basic Auth；真实 SMTP AUTH；可选强制 TLS | Web 与入站 SMTP 凭据 | 面向可信开发环境 |
+| 多实例共享邮箱 | 不支持 | 相同 | 不支持 | 不支持 |
 
 本文不提供跨项目性能排名。运行语言、二进制大小或微基准不能代表 MIME 解析、
 磁盘压力、TLS、S3、Webhook 下游和浏览器共同作用下的端到端性能。
@@ -68,7 +68,7 @@ API 和实时协议也不同。
 | 实时事件 | Socket.IO | 原生 WebSocket，不是 Socket.IO | 项目专用 WebSocket/轮询 |
 | 嵌入 API | Node MailDev 类 | 无 | 无 |
 
-必须显式设置 OWLMAIL_MAILDEV_REST_COMPAT=true 或
+在已审查 OwlMail main 上，必须显式设置 OWLMAIL_MAILDEV_REST_COMPAT=true 或
 -maildev-rest-compat 才会启用 OwlMail MailDev facade。它复用现有 Basic Auth、
 HTTPS、存储和 base path，但不会启用 Socket.IO。
 
@@ -77,7 +77,7 @@ HTTPS、存储和 base path，但不会启用 Socket.IO。
 
 ## Agent 集成
 
-OwlMail 当前已经提供默认关闭的 /mcp，只包含五个封闭只读能力：列表、搜索、
+已审查 OwlMail main 已提供默认关闭的 /mcp，只包含五个封闭只读能力：列表、搜索、
 独立详情快照、受限 base64 原始源码和附件元数据。它与 Web API 共用监听器与
 鉴权边界，并明确不提供删除、已读修改、Relay、配置修改或附件二进制。
 
@@ -101,7 +101,7 @@ MailCatcher 使用内存 SQLite。消息上限能限制活动收件箱，但它�
 
 ## 选型建议
 
-以下情况优先选择 **OwlMail**：需要单文件部署、ARM/跨平台、持久 Webhook
+以下情况优先选择已审查的 **OwlMail main**：需要单文件部署、ARM/跨平台、持久 Webhook
 自动化、磁盘异常恢复、可选 S3 附件、SMTP 资源控制或小型只读 Agent 接口。
 
 以下情况优先选择 **MailDev**：需要更完整的交互 UI、Node 嵌入、精确
@@ -114,7 +114,7 @@ Socket.IO、配置文件或更广的 MCP 工作流。
 从 MailCatcher 迁移时，应把 SMTP 捕获和 sendmail 替代视为可迁移概念，并对
 HTTP 与 WebSocket 集成逐项适配。
 
-## 本基线下 OwlMail 仍有的缺口
+## 本基线下 OwlMail main 仍有的缺口
 
 - 原生 WebSocket 不是 Socket.IO。
 - 没有稳定公共 Go 嵌入 SDK，也没有通用应用配置文件。
@@ -130,8 +130,8 @@ HTTP 与 WebSocket 集成逐项适配。
 
 - OwlMail API：[docs/zh-CN/API-Reference.md](./API-Reference.md)
 - OwlMail 运维：[docs/zh-CN/Operations.md](./Operations.md)
-- MailDev README：https://github.com/maildev/maildev/blob/9d4141f42b0acedfa544a306f96a5373ded8c8a3/README.md
-- MailDev REST：https://github.com/maildev/maildev/blob/9d4141f42b0acedfa544a306f96a5373ded8c8a3/docs/rest.md
-- MailDev MCP：https://github.com/maildev/maildev/blob/9d4141f42b0acedfa544a306f96a5373ded8c8a3/docs/mcp.md
-- MailCatcher README：https://github.com/sj26/mailcatcher/blob/43e488e2a5692532c131a87d5bd16a973ee8db56/README.md
-- MailCatcher 版本：https://github.com/sj26/mailcatcher/blob/43e488e2a5692532c131a87d5bd16a973ee8db56/lib/mail_catcher/version.rb
+- [MailDev README](https://github.com/maildev/maildev/blob/9d4141f42b0acedfa544a306f96a5373ded8c8a3/README.md)
+- [MailDev REST](https://github.com/maildev/maildev/blob/9d4141f42b0acedfa544a306f96a5373ded8c8a3/docs/rest.md)
+- [MailDev MCP](https://github.com/maildev/maildev/blob/9d4141f42b0acedfa544a306f96a5373ded8c8a3/docs/mcp.md)
+- [MailCatcher README](https://github.com/sj26/mailcatcher/blob/43e488e2a5692532c131a87d5bd16a973ee8db56/README.md)
+- [MailCatcher 版本](https://github.com/sj26/mailcatcher/blob/43e488e2a5692532c131a87d5bd16a973ee8db56/lib/mail_catcher/version.rb)

--- a/docs/zh-CN/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
+++ b/docs/zh-CN/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
@@ -1,192 +1,137 @@
-# OwlMail × MailDev：功能、API 与迁移指南
+# OwlMail × MailDev × MailCatcher：功能、API 与迁移指南
 
-> 面向选型与迁移的源码级对比，而不是未经验证的兼容性承诺。
+> 面向开发邮件服务器选型的源码级比较。本文记录已验证行为，不承诺无缝兼容。
 
-**审查基线：** 2026-08-29。本文对照当前 OwlMail 源码与
-[MailDev 官方 REST 文档](https://github.com/maildev/maildev/blob/main/docs/rest.md)。
-两个项目都可能继续变化，部署前仍应核对实际版本。
+**审查基线：2026-09-02。**
+
+- OwlMail：正式版 0.6.0；main 为
+  03bbad9a8223d61a2d841f341b1d953bf5af1d05。
+- MailDev：候选版 maildev@3.0.0-rc.3；main 为
+  9d4141f42b0acedfa544a306f96a5373ded8c8a3。最新稳定 2.x 为 2.2.1，
+  与 3.x 主线架构存在明显差异。
+- MailCatcher：GitHub 最新 Release 为 v0.10.0；main 已声明 0.11.0，
+  审查提交为 43e488e2a5692532c131a87d5bd16a973ee8db56。
+
+三个项目都会继续变化。开发和 CI 应固定版本，迁移前应按实际构建重新验证。
 
 ## 执行摘要
 
-OwlMail 与 MailDev 的核心目标一致：接收 SMTP 邮件、保存以供检查、通过浏览器
-展示，并按需中继。因此，只使用 SMTP 接收功能的环境通常迁移较简单。
+三者都能接收开发环境 SMTP 邮件并提供检查界面，但优化方向不同：
 
-OwlMail 还提供单一 Go 二进制、版本化 `/api/v1`、原生 SMTPS、浏览器通知、
-通用 Webhook 转发和内嵌本地帮助。这些是 OwlMail 的自身能力，不代表协议等价。
+- **OwlMail** 侧重 Go 单二进制、可恢复的持久化、本地或 S3 附件、通用持久
+  Webhook、版本化 API，以及默认关闭的只读 MCP。
+- **MailDev 3** 侧重 React 邮件检查体验、Node 嵌入、真正的 Socket.IO、
+  更完整的 MCP 工作流和 TypeScript 应用配置。
+- **MailCatcher** 侧重简单 Ruby 工作流、轻量收件箱及 catchmail sendmail
+  替代命令。
 
-OwlMail **不是当前 MailDev 的精确无缝替代品**。现在可以显式开启默认关闭的
-MailDev `/api` REST facade 来兼容当前路由与载荷，但浏览器 UI、Socket.IO 实时
-协议、配置覆盖范围和 MCP 工具合约仍不相同。REST 迁移可使用 facade，非 REST
-集成仍必须逐项验证。
+OwlMail 不是另外两者的通用无缝替代。可选 MailDev REST facade 能覆盖当前
+MailDev REST 合约，但不实现 Socket.IO 或 Node API；MailCatcher 的 messages
+API 和实时协议也不同。
 
-## 功能比较
+## 功能对比
 
-| 能力 | MailDev | OwlMail | 迁移说明 |
+| 能力 | OwlMail 0.6.0 + 已审查 main | MailDev 3.0.0-rc.3 | MailCatcher main 0.11.0 |
 |---|---|---|---|
-| SMTP 捕获 | 支持 | 支持，默认 1025 | 通常只需修改主机名 |
-| 浏览器收件箱 | 支持 | 支持，默认 1080 | UI 定制不能直接移植 |
-| EML 目录 | 支持 | 支持 | 切换前先用归档副本验证 |
-| 单封中继 | 支持 | 支持 | 需要出站 SMTP 设置 |
-| 自动中继 | 支持 | 支持 | OwlMail 支持 allow/deny JSON 规则 |
-| 入站 SMTP 鉴权 | 支持 | PLAIN/LOGIN；两项凭据同时配置时强制，否则为 NO AUTH | 迁移鉴权边界时同时配置用户名和密码 |
-| Web Basic Auth | 支持 | 支持 | OwlMail 健康检查仍公开 |
-| SMTP TLS / STARTTLS | 支持 | 支持 | 证书路径必须可读 |
-| 直接 SMTPS | 随版本而异 | 开启 SMTP TLS 时监听 465 | OwlMail 特有行为 |
-| REST API | 支持 | 支持，并提供可选 MailDev `/api` facade | OwlMail 原生路由仍不同 |
-| 实时更新 | Socket.IO | 原生 WebSocket | 客户端代码需要修改 |
-| 通用出站 Webhook | 随版本而异 | 支持 | OwlMail 提供模板、HMAC、重试和过滤 |
-| 浏览器通知 | 随 UI/版本而异 | 浏览器内按需开启 | 需要权限和安全上下文 |
-| MCP 服务 | 当前 MailDev 提供 | 不提供 | 依赖时需保留 MailDev 或另行集成 |
-| 通用 JS/JSON 配置文件 | 当前 MailDev 提供 | 无通用配置文件 | OwlMail 使用参数和环境变量；Webhook 目标使用 JSON |
-| 可配置基础路径 | 支持 | 支持 | OwlMail 会统一前缀 UI、API、原生 WebSocket、兼容路由与 Service Worker |
+| 运行时 | Go 单二进制，内嵌 Web 资源 | Node.js 20+、TypeScript monorepo、React | Ruby 3.3+、EventMachine/Sinatra |
+| 核心优势 | 可靠存储与自动化 | 交互式邮件检查与集成广度 | 极简 Ruby/sendmail 工作流 |
+| SMTP 捕获 | SMTP、STARTTLS、直接 SMTPS | SMTP 与可配置 TLS | 简单 SMTP Server |
+| 邮件大小 | 可配置，默认 100 MiB | 可配置，当前默认 50 MiB | 未记录等价控制 |
+| DATA 并发 | 进程级可配置，默认 8，0 为无限制 | 未记录等价 DATA 限流 | 未记录等价限流 |
+| 持久化 | EML 原子提交、恢复与 quarantine | 可选 EML/附件目录并在启动时恢复 | SQLite 内存数据库 |
+| 保留策略 | 按时间、数量和本地磁盘占用 | 最大邮件数量 | 最大消息数量 |
+| 附件 | 流式 staging；本地或可选 S3 | 启用持久化时保存本地附件 | 随内存消息数据库保存 |
+| REST API | 原生 /api/v1 加可选 MailDev facade | 当前接口位于 /api | messages API 位于 /messages |
+| 实时更新 | 原生 RFC 6455 WebSocket | Socket.IO | WebSocket，浏览器可退化为轮询 |
+| UI | 轻量多语言、安全 HTML 隔离、响应式宽度 | React UI、源码/Header 与响应式预览 | 简单 HTML/纯文本/源码视图及键盘导航 |
+| MCP | 默认关闭的只读 Streamable HTTP | HTTP 与 stdio，更丰富的工具、资源和 Prompts | 无内置 MCP |
+| Webhook | 过滤、模板、HMAC、重试、本地 outbox、可选 Redis Streams | 无等价通用持久 Webhook 管道 | 无内置通用 Webhook |
+| Relay | 手动与自动出站 SMTP 中继 | 手动与自动出站 SMTP 中继 | 无可比的出站中继流程 |
+| sendmail 替代 | owlmail sendmail | 未记录内置等价命令 | catchmail |
+| 嵌入能力 | 无稳定公共 Go SDK，internal 不是公共接口 | 公共 Node API | 主要作为独立 Ruby 命令 |
+| Base path | 支持 | 支持 | 通过 http-path 支持 |
+| 鉴权 | Web Basic Auth；真实 SMTP AUTH；可选强制 TLS | Web 与入站 SMTP 凭据 | 面向可信开发环境 |
+| 多实例共享邮箱 | 不支持 | 不支持 | 不支持 |
 
-本文不提供性能星级，因为仓库中没有可复现的跨项目基准。编译后的 Go 二进制
-可以简化部署，但吞吐和内存应按实际邮件、存储、TLS 与 Webhook 下游测量。
+本文不提供跨项目性能排名。运行语言、二进制大小或微基准不能代表 MIME 解析、
+磁盘压力、TLS、S3、Webhook 下游和浏览器共同作用下的端到端性能。
 
-## API 兼容边界
+## API 与实时兼容边界
 
-### 当前 MailDev 接口
+| 工作流 | MailDev | OwlMail | MailCatcher |
+|---|---|---|---|
+| 列表 | GET /api/email | 仅开启 facade 后同路径；原生为 GET /api/v1/emails | GET /messages |
+| 精简列表 | GET /api/email/summary | 仅 facade 保持同路径和形状 | 未记录等价 summary 合约 |
+| 详情 | GET /api/email/:id，并标记已读 | facade 保留副作用；原生详情不标记 | GET /messages/:id.json |
+| HTML/文本/源码 | MailDev 专用 /api 路径 | facade 与原生版本化路径 | /messages/:id.html、.plain、.source |
+| 附件 | MailDev attachment 路径 | facade 与原生附件路径 | /messages/:id/parts/:cid |
+| 实时事件 | Socket.IO | 原生 WebSocket，不是 Socket.IO | 项目专用 WebSocket/轮询 |
+| 嵌入 API | Node MailDev 类 | 无 | 无 |
 
-当前 MailDev 把路由放在 `/api` 下，包括 `/api/email`、
-`/api/email/summary`、`/api/email/delete` 和 `/api/config`。调用
-`GET /api/email/:id` 会把邮件标记为已读；实时事件使用 Socket.IO，事件名为
-`newMail` 和 `deleteMail`。
+必须显式设置 OWLMAIL_MAILDEV_REST_COMPAT=true 或
+-maildev-rest-compat 才会启用 OwlMail MailDev facade。它复用现有 Basic Auth、
+HTTPS、存储和 base path，但不会启用 Socket.IO。
 
-### OwlMail 接口
+不要把 MailCatcher HTTP 客户端直接指向 OwlMail。仅使用 SMTP 的应用迁移更简单，
+因为三者都接受普通 SMTP 投递。
 
-OwlMail 提供三个 HTTP 接口面：
+## Agent 集成
 
-- `/api/v1/*`：推荐的新集成接口。
-- 无版本的 `/email`、`/config`、`/healthz` 和 `/socket.io`：保留给已有
-  OwlMail 客户端及常见 MailDev 风格工作流。
-- 可选 `/api/*` MailDev REST 路由，仅在 `-maildev-rest-compat` 或
-  `OWLMAIL_MAILDEV_REST_COMPAT=true` 时启用。
+OwlMail 当前已经提供默认关闭的 /mcp，只包含五个封闭只读能力：列表、搜索、
+独立详情快照、受限 base64 原始源码和附件元数据。它与 Web API 共用监听器与
+鉴权边界，并明确不提供删除、已读修改、Relay、配置修改或附件二进制。
 
-设置 `-base-pathname /owlmail`（或 `OWLMAIL_BASE_PATHNAME=/owlmail`）后，
-本节所有路径都应加上 `/owlmail` 前缀；同时接受兼容变量
-`MAILDEV_BASE_PATHNAME`。该设置只改变路由位置，不改变协议：
-`/owlmail/socket.io` 仍是原生 RFC 6455 WebSocket。
+MailDev 3 的 MCP 范围更广，同时支持 HTTP 和 stdio。两者的工具名称和载荷不能
+直接互换，已有 MailDev MCP 客户端仍需显式兼容验证。
 
-REST facade 复用 OwlMail 的存储、认证、HTTPS 与 base path。只有 facade 的详情
-路由会将邮件标记已读，其 DTO 保留 MailDev 的数组、summary、信封、附件、修改与
-错误形状。OwlMail 的 `/socket.io` 仍是原生 RFC 6455 WebSocket；路径名称并不
-意味着兼容 Socket.IO，REST 开关也绝不会启用 Socket.IO。
+MailCatcher 没有内置 MCP；Agent 只能通过单独的工具或适配器使用其 HTTP API。
 
-| 工作流 | 当前 MailDev | OwlMail |
-|---|---|---|
-| 邮件列表 | `GET /api/email` | 启用 facade 后路径与数组载荷相同；否则原生路由不同 |
-| 精简列表 | `GET /api/email/summary` | 启用 facade 后路径与 summary 信封相同 |
-| 获取详情 | `GET /api/email/:id`，同时标记已读 | 仅 facade 行为相同；原生详情无已读副作用 |
-| 标记单封已读 | 获取详情时隐式完成 | `PATCH /email/:id/read` 或 `PATCH /api/v1/emails/:id/read` |
-| 批量删除 | `POST /api/email/delete` | 启用 facade 后请求和结果形状相同 |
-| 重载目录 | `GET /api/reloadMailsFromDirectory` | 启用 facade 后路径相同 |
-| 配置信息 | `GET /api/config` | 启用 facade 后提供相同精简形状 |
-| 健康检查 | `GET /api/healthz` | 启用 facade 后提供相同公开 JSON 布尔值 |
-| 实时事件 | Socket.IO `newMail`、`deleteMail` | 原生 WS `{type:"new"}`、`{type:"delete"}` |
+## 存储与可靠性边界
 
-原生集合响应仍不同：`/api/v1` 返回分页信封，例如
-`{ "total": 3, "limit": 50, "offset": 0, "emails": [...] }`。可选 facade
-则返回 MailDev 的数组和 summary 信封形状。
+OwlMail 在最终 EML 标记前提交附件，只在完整存储事务成功后将邮件暴露给 API，
+并在启动恢复时隔离不完整或不可解析的文件。可选 S3 模式只远程保存解码附件；
+EML、元数据、事务状态和 Webhook outbox 仍保留在本地。
 
-完整路由、载荷、状态行为、鉴权和 WebSocket 协议见
-[OwlMail API 参考](./API-Reference.md)。
+MailDev 可保存并恢复 EML 和附件，但其存储模型与 OwlMail 的事务和 quarantine
+保证并不相同。
 
-## 配置兼容边界
+MailCatcher 使用内存 SQLite。消息上限能限制活动收件箱，但它不是持久归档。
 
-OwlMail 接受文档中列出的部分 `MAILDEV_*` 环境变量，显式 CLI 参数优先级更高；
-OwlMail 特有设置还提供 `OWLMAIL_*` 名称。这是迁移便利层，并非支持当前
-MailDev 的每个选项。
+三者都不应被描述为支持水平扩展、共享数据库的生产邮箱系统。
 
-常见直接映射：
+## 选型建议
 
-| 用途 | OwlMail 接受的 MailDev 风格变量 | OwlMail 变量 |
-|---|---|---|
-| SMTP 端口 | `MAILDEV_SMTP_PORT` | `OWLMAIL_SMTP_PORT` |
-| Web 端口 | `MAILDEV_WEB_PORT` | `OWLMAIL_WEB_PORT` |
-| 邮件目录 | `MAILDEV_MAIL_DIRECTORY` | `OWLMAIL_MAIL_DIR` |
-| Web 用户名 | `MAILDEV_WEB_USER` | `OWLMAIL_WEB_USER` |
-| Web 密码 | `MAILDEV_WEB_PASS` | `OWLMAIL_WEB_PASSWORD` |
-| 基础路径 | `MAILDEV_BASE_PATHNAME` | `OWLMAIL_BASE_PATHNAME` |
-| 出站主机 | `MAILDEV_OUTGOING_HOST` | `OWLMAIL_OUTGOING_HOST` |
-| 入站用户名 | `MAILDEV_INCOMING_USER` | `OWLMAIL_SMTP_USER` |
+以下情况优先选择 **OwlMail**：需要单文件部署、ARM/跨平台、持久 Webhook
+自动化、磁盘异常恢复、可选 S3 附件、SMTP 资源控制或小型只读 Agent 接口。
 
-完整支持范围以根 README 配置表为准。MCP、通用配置文件等 MailDev 能力，不会
-因为 OwlMail 接受其他 `MAILDEV_*` 变量而自动可用。
+以下情况优先选择 **MailDev**：需要更完整的交互 UI、Node 嵌入、精确
+Socket.IO、配置文件或更广的 MCP 工作流。
 
-## 需要规划的运行差异
+以下情况优先选择 **MailCatcher**：熟悉 Ruby，且 catchmail 与最小部署流程
+比持久化、Relay、Webhook 或 Agent 集成更重要。
 
-### Web 凭据
+从 MailDev 迁移时，应先盘点 REST 和实时客户端，再决定是否开启 facade。
+从 MailCatcher 迁移时，应把 SMTP 捕获和 sendmail 替代视为可迁移概念，并对
+HTTP 与 WebSocket 集成逐项适配。
 
-- 用户名和密码都不设置：关闭 Basic Auth。
-- 只设置用户名：生成 32 字符密码，只在 stderr 输出一次；重启后变化。
-- 只设置密码：默认用户名为 `admin`。
-- 两项都设置：使用明确配置的凭据。
+## 本基线下 OwlMail 仍有的缺口
 
-自动化场景应同时配置两项。凭据离开 localhost 时应启用 HTTPS。
+- 原生 WebSocket 不是 Socket.IO。
+- 没有稳定公共 Go 嵌入 SDK，也没有通用应用配置文件。
+- SMTP 读写超时和收件人数仍使用固定默认值。
+- 原生 Relay 只表示异步入队，不提供持久化投递状态。
+- Web 收件箱尚未提供完整浏览器历史与键盘导航语义。
+- 即使 EML 已持久化，邮箱索引仍主要位于内存。
+- 没有 Prometheus 指标端点。
 
-### Webhook 投递压力
+以上是 OwlMail 路线观察，并不表示 MailDev 或 MailCatcher 一定实现同等能力。
 
-OwlMail 对 Webhook 投递使用进程级并发上限，建议默认值为 8。只有在明确需要
-无限并发且已验证下游容量时，才设置 `-webhook-max-concurrency 0`。有限上限在
-所有槽位繁忙时对新邮件处理施加背压，避免慢下游造成无限等待 goroutine。
+## 主要源码
 
-详见 [Webhook 消息转发](./Webhook-Forwarding.md)和
-[场景示例](../../examples/webhooks/README.zh-CN.md)。
-
-### 浏览器通知
-
-通知默认关闭，由每个浏览器在收件箱内独立开启。只有实时到达的新消息才通知。
-需要 HTTPS 或可信 localhost 来源，浏览器也可以独立撤销权限。
-
-## 迁移手册
-
-### 仅使用 SMTP 的应用
-
-1. 在未占用的主机/端口启动 OwlMail。
-2. 将预发布应用的 SMTP 主机指向 OwlMail 1025 端口。
-3. 发送纯文本、HTML、多段、BCC 与附件邮件。
-4. 使用持久化时核对信封收件人与 EML 文件。
-5. 所有检查通过后再切换开发环境。
-
-### REST 客户端
-
-1. 盘点每个方法、路径、查询参数和预期响应结构。
-2. 优先选择 `/api/v1`，不要新增对无版本别名的依赖。
-3. 修改基础路径并解析 OwlMail 分页信封。
-4. 将“读取详情即已读”改为显式 `PATCH`。
-5. 验证未找到、参数错误、中继失败和鉴权响应。
-6. 在 CI 或容器部署中固定 OwlMail 版本。
-
-### 实时事件客户端
-
-1. 用原生 WebSocket 客户端替换 Socket.IO 库。
-2. 连接 `/api/v1/ws`。
-3. 处理 `connected`、`new` 和 `delete` 类型。
-4. 在客户端实现重连与退避。
-5. 浏览器启用 Basic Auth 时，从 OwlMail 同源提供客户端；否则使用不携带
-   `Origin` 的服务端桥接。
-
-### EML 归档
-
-1. 备份 MailDev 目录。
-2. 让 OwlMail 先读取副本，绝不直接使用唯一归档。
-3. 抽样核对数量、HTML、源码和附件。
-4. 在不再需要回滚前保留原目录。
-
-## 验收清单
-
-- 纯文本、HTML、Unicode、BCC 与附件展示正确。
-- API 客户端能解析集合信封和明确错误码。
-- 只有客户端显式请求时才修改已读状态。
-- 删除、批量、导出、中继和重载符合预期。
-- WebSocket 重连和事件处理已经测试。
-- 明确 Basic Auth、HTTPS、健康检查和同源行为。
-- 对 Webhook 过滤、签名、重试、超时与并发做负载验证。
-- 回滚方案保留原 EML 归档和旧配置。
-
-## 结论
-
-当 Go 部署模型、版本化 API、原生 WebSocket、Webhook、浏览器通知或内置帮助
-符合需求时，可以选择 OwlMail；如果依赖当前 MailDev 的精确 REST、Socket.IO、
-MCP、基础路径或配置行为，应继续使用 MailDev。混合环境中，反向代理或小型适配
-层比依赖未文档化的“等价性”更安全。
+- OwlMail API：[docs/zh-CN/API-Reference.md](./API-Reference.md)
+- OwlMail 运维：[docs/zh-CN/Operations.md](./Operations.md)
+- MailDev README：https://github.com/maildev/maildev/blob/9d4141f42b0acedfa544a306f96a5373ded8c8a3/README.md
+- MailDev REST：https://github.com/maildev/maildev/blob/9d4141f42b0acedfa544a306f96a5373ded8c8a3/docs/rest.md
+- MailDev MCP：https://github.com/maildev/maildev/blob/9d4141f42b0acedfa544a306f96a5373ded8c8a3/docs/mcp.md
+- MailCatcher README：https://github.com/sj26/mailcatcher/blob/43e488e2a5692532c131a87d5bd16a973ee8db56/README.md
+- MailCatcher 版本：https://github.com/sj26/mailcatcher/blob/43e488e2a5692532c131a87d5bd16a973ee8db56/lib/mail_catcher/version.rb

--- a/docs/zh-CN/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
+++ b/docs/zh-CN/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md
@@ -4,8 +4,8 @@
 
 **审查基线：2026-09-02。**
 
-- OwlMail：正式版 0.6.0；main 为
-  03bbad9a8223d61a2d841f341b1d953bf5af1d05。
+- OwlMail：正式版 0.6.0；已审查 main 为
+  279571b62a5e4891f0a204837d8553b131b89b20。
 - MailDev：候选版 maildev@3.0.0-rc.3；main 为
   9d4141f42b0acedfa544a306f96a5373ded8c8a3。最新稳定 2.x 为 2.2.1，
   与 3.x 主线架构存在明显差异。
@@ -43,8 +43,8 @@ API 和实时协议也不同。
 | 附件 | 本地保存解码附件 | 流式 staging；本地或可选 S3 | 启用持久化时保存本地附件 | 随内存消息数据库保存 |
 | REST API | 原生版本化及历史无版本路由 | 相同，另有可选 MailDev facade | 当前接口位于 /api | messages API 位于 /messages |
 | 实时更新 | 原生 RFC 6455 WebSocket | 相同 | Socket.IO | WebSocket，浏览器可退化为轮询 |
-| UI | 轻量多语言、安全 HTML 隔离、响应式宽度 | 相同 | React UI、源码/Header 与响应式预览 | 简单 HTML/纯文本/源码视图及键盘导航 |
-| MCP | 无内置端点 | 默认关闭的只读 Streamable HTTP | HTTP 与 stdio，更丰富的工具、资源和 Prompts | 无内置 MCP |
+| UI | 轻量多语言收件箱 | 相同，并增加安全 HTML 隔离和响应式宽度 | React UI、源码/Header 与响应式预览 | 简单 HTML/纯文本/源码视图及键盘导航 |
+| MCP | 无内置端点 | 默认关闭的 Streamable HTTP，含七个只读工具、资源和 Prompts | HTTP 与 stdio，更丰富的工具、资源和 Prompts | 无内置 MCP |
 | Webhook | 过滤、模板、HMAC、重试、本地 outbox、可选 Redis Streams | 相同 | 无等价通用持久 Webhook 管道 | 无内置通用 Webhook |
 | Relay | 手动与自动出站 SMTP 中继 | 相同 | 手动与自动出站 SMTP 中继 | 无可比的出站中继流程 |
 | sendmail 替代 | 无内置命令 | owlmail sendmail | 未记录内置等价命令 | catchmail |
@@ -77,9 +77,11 @@ HTTPS、存储和 base path，但不会启用 Socket.IO。
 
 ## Agent 集成
 
-已审查 OwlMail main 已提供默认关闭的 /mcp，只包含五个封闭只读能力：列表、搜索、
-独立详情快照、受限 base64 原始源码和附件元数据。它与 Web API 共用监听器与
-鉴权边界，并明确不提供删除、已读修改、Relay、配置修改或附件二进制。
+已审查 OwlMail main 已提供默认关闭的 /mcp，包含七个封闭只读工具：列表、搜索、
+独立详情快照、受限 base64 原始源码、附件元数据、按接收顺序取得最新邮件，以及
+事件驱动且有界的投递等待。它还提供有界的收件箱、统计与单邮件资源，以及注册验证、
+密码重置和投递等待 Prompts；生成的 Web 链接会保留 base path。它与 Web API 共用
+监听器和鉴权边界，并明确不提供删除、已读修改、Relay、配置修改或附件二进制。
 
 MailDev 3 的 MCP 范围更广，同时支持 HTTP 和 stdio。两者的工具名称和载荷不能
 直接互换，已有 MailDev MCP 客户端仍需显式兼容验证。

--- a/tests/docs/markdown.test.js
+++ b/tests/docs/markdown.test.js
@@ -387,6 +387,29 @@ test("OpenAPI contract is linked from every translated README", () => {
   }
 });
 
+test("three-way comparison stays source-pinned and reflects MCP support", () => {
+  for (const document of [
+    "docs/en/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md",
+    "docs/zh-CN/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md",
+  ]) {
+    const markdown = fs.readFileSync(path.join(root, document), "utf8");
+    for (const marker of [
+      "OwlMail × MailDev × MailCatcher",
+      "2026-09-02",
+      "03bbad9a8223d61a2d841f341b1d953bf5af1d05",
+      "9d4141f42b0acedfa544a306f96a5373ded8c8a3",
+      "43e488e2a5692532c131a87d5bd16a973ee8db56",
+      "0.11.0",
+      "MCP",
+      "MailCatcher",
+    ]) {
+      assert.ok(markdown.includes(marker), `${document} is missing ${marker}`);
+    }
+    assert.ok(!markdown.includes("| MCP server | Current MailDev provides one | No |"));
+    assert.ok(!markdown.includes("| MCP 服务 | 当前 MailDev 提供 | 不提供 |"));
+  }
+});
+
 test("0.6.0 release documentation and workflow stay connected", () => {
   const changelog = fs.readFileSync(path.join(root, "CHANGELOG.md"), "utf8");
   const releaseStart = changelog.indexOf("## [0.6.0]");

--- a/tests/docs/markdown.test.js
+++ b/tests/docs/markdown.test.js
@@ -409,6 +409,16 @@ test("three-way comparison stays source-pinned and reflects MCP support", () => 
     assert.ok(!markdown.includes("| MCP 服务 | 当前 MailDev 提供 | 不提供 |"));
     assert.ok(!markdown.includes("with five closed-world"));
     assert.ok(!markdown.includes("只包含五个封闭只读能力"));
+    assert.ok(markdown.includes("<base-pathname>/mcp"));
+  }
+
+  for (const locale of ["de", "fr", "it", "ja", "ko"]) {
+    const stub = fs.readFileSync(
+      path.join(root, `docs/${locale}/OwlMail × MailDev - Full Feature & API Comparison and Migration White Paper.md`),
+      "utf8",
+    );
+    assert.ok(stub.includes("main"), `${locale} comparison does not qualify the MCP branch`);
+    assert.ok(stub.includes("v0.6.0"), `${locale} comparison does not qualify the stable release`);
   }
 });
 

--- a/tests/docs/markdown.test.js
+++ b/tests/docs/markdown.test.js
@@ -396,7 +396,7 @@ test("three-way comparison stays source-pinned and reflects MCP support", () => 
     for (const marker of [
       "OwlMail × MailDev × MailCatcher",
       "2026-09-02",
-      "03bbad9a8223d61a2d841f341b1d953bf5af1d05",
+      "279571b62a5e4891f0a204837d8553b131b89b20",
       "9d4141f42b0acedfa544a306f96a5373ded8c8a3",
       "43e488e2a5692532c131a87d5bd16a973ee8db56",
       "0.11.0",
@@ -407,6 +407,8 @@ test("three-way comparison stays source-pinned and reflects MCP support", () => 
     }
     assert.ok(!markdown.includes("| MCP server | Current MailDev provides one | No |"));
     assert.ok(!markdown.includes("| MCP 服务 | 当前 MailDev 提供 | 不提供 |"));
+    assert.ok(!markdown.includes("with five closed-world"));
+    assert.ok(!markdown.includes("只包含五个封闭只读能力"));
   }
 });
 


### PR DESCRIPTION
## Summary

- replace the stale two-project baseline with a source-pinned OwlMail, MailDev, and MailCatcher comparison
- distinguish stable releases from current main branches
- document OwlMail's merged MCP server, including seven tools plus resources and prompts
- document REST, live-event, storage, relay, sendmail, security, UI, and deployment boundaries
- update the five translation stubs and add a documentation regression test

## Verified baselines

- OwlMail main: 279571b62a5e4891f0a204837d8553b131b89b20
- MailDev main: 9d4141f42b0acedfa544a306f96a5373ded8c8a3; release candidate 3.0.0-rc.3
- MailCatcher main: 43e488e2a5692532c131a87d5bd16a973ee8db56; declared version 0.11.0; latest GitHub release v0.10.0

## Validation

The added Bun documentation test locks the three project names, review date, exact source commits, version distinction, current MCP surface, and the stable-versus-main UI boundary. Existing Markdown link/fence validation continues to cover both full documents.