### PR TITLE
feat(web): add history and keyboard navigation

### DIFF
--- a/tests/web/app.test.js
+++ b/tests/web/app.test.js
@@ -608,3 +608,39 @@ test('mailbox keyboard navigation supports arrows, j/k, escape, and ignores inpu
     assert.equal(harness.run('state.currentEmail'), null);
     assert.equal(harness.window.location.search, '');
 });
+
+
+test('slower email detail responses cannot overwrite newer navigation', async () => {
+    const pending = new Map();
+    const harness = createHarness({
+        fetchImpl: (url) => new Promise((resolve) => {
+            const id = new URL(url).pathname.split('/').pop();
+            pending.set(id, () => resolve(jsonResponse({ id, subject: id, from: [], to: [], attachments: [] })));
+        })
+    });
+
+    const first = harness.run("loadEmailDetail('mail-slow')");
+    const second = harness.run("loadEmailDetail('mail-fast')");
+    pending.get('mail-fast')();
+    await second;
+    pending.get('mail-slow')();
+    await first;
+
+    assert.equal(harness.run('state.currentEmail.id'), 'mail-fast');
+    assert.equal(new URL(harness.window.location.href).searchParams.get('email'), 'mail-fast');
+});
+
+test('reselecting the current email does not add a duplicate history entry', async () => {
+    const harness = createHarness({
+        fetchImpl: async (url) => {
+            const id = new URL(url).pathname.split('/').pop();
+            return jsonResponse({ id, subject: id, from: [], to: [], attachments: [] });
+        }
+    });
+
+    await harness.run("loadEmailDetail('mail-42')");
+    await harness.run("loadEmailDetail('mail-42')");
+
+    assert.equal(harness.historyCalls.length, 1);
+    assert.equal(harness.historyCalls[0].method, 'pushState');
+});

--- a/tests/web/app.test.js
+++ b/tests/web/app.test.js
@@ -10,7 +10,9 @@ const styleSource = fs.readFileSync(path.join(__dirname, '../../web/style.css'),
 function createClassList() {
     const values = new Set();
     return {
+        add(...names) { names.forEach((name) => values.add(name)); },
         contains: (name) => values.has(name),
+        remove(...names) { names.forEach((name) => values.delete(name)); },
         toggle(name, enabled) {
             if (enabled) values.add(name);
             else values.delete(name);

--- a/tests/web/app.test.js
+++ b/tests/web/app.test.js
@@ -96,6 +96,7 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
     const serviceWorkerRegistrations = [];
     const webSocketURLs = [];
     const historyCalls = [];
+    const alerts = [];
 
     function Notification(title, options) {
         const instance = { title, options, closed: false, close() { this.closed = true; } };
@@ -191,12 +192,14 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
         URL,
         URLSearchParams,
         Blob,
+        alert(message) { alerts.push(String(message)); },
         confirm: () => true
     };
     vm.createContext(sandbox);
     vm.runInContext(appSource, sandbox, { filename: 'web/app.js' });
 
     return {
+        alerts,
         documentListeners,
         emailDetail,
         emailList,
@@ -643,4 +646,64 @@ test('reselecting the current email does not add a duplicate history entry', asy
 
     assert.equal(harness.historyCalls.length, 1);
     assert.equal(harness.historyCalls[0].method, 'pushState');
+});
+
+test('delayed initial deep link cannot supersede newer history navigation', async () => {
+    let resolvePreview;
+    const detailRequests = [];
+    const harness = createHarness({
+        fetchImpl: async (url) => {
+            const requestURL = new URL(url);
+            if (requestURL.pathname.endsWith('/emails/preview')) {
+                return new Promise((resolve) => {
+                    resolvePreview = () => resolve(jsonResponse({ previews: [], total: 0 }));
+                });
+            }
+            const id = requestURL.pathname.split('/').pop();
+            detailRequests.push(id);
+            return jsonResponse({ id, subject: id, from: [], to: [], attachments: [] });
+        }
+    });
+    harness.window.location.href = 'http://owlmail.test/?email=mail-a';
+    harness.window.location.search = '?email=mail-a';
+
+    harness.documentListeners.get('DOMContentLoaded')();
+    harness.window.location.href = 'http://owlmail.test/?email=mail-b';
+    harness.window.location.search = '?email=mail-b';
+    harness.run('handleHistoryNavigation()');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(harness.run('state.currentEmail.id'), 'mail-b');
+
+    resolvePreview();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.deepEqual(detailRequests, ['mail-b']);
+    assert.equal(harness.run('state.currentEmail.id'), 'mail-b');
+});
+
+test('failed history detail load clears the previously rendered selection', async () => {
+    const harness = createHarness({
+        fetchImpl: async (url) => {
+            const id = new URL(url).pathname.split('/').pop();
+            if (id === 'mail-missing') {
+                return {
+                    ok: false,
+                    status: 404,
+                    headers: { get: () => 'application/json' },
+                    async json() { return { message: 'not found' }; },
+                    async text() { return '{"message":"not found"}'; }
+                };
+            }
+            return jsonResponse({ id, subject: id, from: [], to: [], attachments: [] });
+        }
+    });
+    await harness.run("loadEmailDetail('mail-a')");
+    harness.window.location.href = 'http://owlmail.test/?email=mail-missing';
+    harness.window.location.search = '?email=mail-missing';
+
+    harness.run('handleHistoryNavigation()');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.equal(harness.run('state.currentEmail'), null);
+    assert.equal(harness.window.location.search, '?email=mail-missing');
+    assert.equal(harness.alerts.length, 1);
 });

--- a/tests/web/app.test.js
+++ b/tests/web/app.test.js
@@ -95,6 +95,7 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
     const serviceNotifications = [];
     const serviceWorkerRegistrations = [];
     const webSocketURLs = [];
+    const historyCalls = [];
 
     function Notification(title, options) {
         const instance = { title, options, closed: false, close() { this.closed = true; } };
@@ -110,7 +111,33 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
     const window = {
         Notification,
         isSecureContext: secure,
-        location: { origin: 'http://owlmail.test', protocol: 'http:', host: 'owlmail.test', search: '' },
+        location: {
+            origin: 'http://owlmail.test',
+            protocol: 'http:',
+            host: 'owlmail.test',
+            pathname: '/',
+            search: '',
+            hash: '',
+            href: 'http://owlmail.test/'
+        },
+        history: {
+            pushState(state, title, url) {
+                historyCalls.push({ method: 'pushState', state, title, url: String(url) });
+                const next = new URL(String(url), window.location.href);
+                window.location.href = next.href;
+                window.location.pathname = next.pathname;
+                window.location.search = next.search;
+                window.location.hash = next.hash;
+            },
+            replaceState(state, title, url) {
+                historyCalls.push({ method: 'replaceState', state, title, url: String(url) });
+                const next = new URL(String(url), window.location.href);
+                window.location.href = next.href;
+                window.location.pathname = next.pathname;
+                window.location.search = next.search;
+                window.location.hash = next.hash;
+            }
+        },
         addEventListener(name, handler) { windowListeners.set(name, handler); },
         focus() {}
     };
@@ -177,6 +204,7 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
         emailViewportFrame,
         emailViewportStage,
         fetchRequests,
+        historyCalls,
         notificationStatus,
         notificationToggle,
         notifications,
@@ -529,4 +557,54 @@ test('initial language setup translates the empty email detail', () => {
     harness.run("setLanguage('fr', false)");
 
     assert.match(harness.emailDetail.innerHTML, /Sélectionnez un email/);
+});
+
+
+test('email selection updates browser history and popstate restores the message', async () => {
+    const harness = createHarness({
+        fetchImpl: async (url) => {
+            const id = new URL(url).pathname.split('/').pop();
+            return jsonResponse({ id, subject: id, from: [], to: [], attachments: [] });
+        }
+    });
+
+    await harness.run("loadEmailDetail('mail-42')");
+    assert.equal(harness.historyCalls.length, 1);
+    assert.equal(harness.historyCalls[0].method, 'pushState');
+    assert.equal(new URL(harness.historyCalls[0].url, 'http://owlmail.test').searchParams.get('email'), 'mail-42');
+
+    harness.window.location.href = 'http://owlmail.test/?email=mail-17';
+    harness.window.location.search = '?email=mail-17';
+    harness.run('handleHistoryNavigation()');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(harness.run('state.currentEmail.id'), 'mail-17');
+
+    harness.window.location.href = 'http://owlmail.test/';
+    harness.window.location.search = '';
+    harness.run('handleHistoryNavigation()');
+    assert.equal(harness.run('state.currentEmail'), null);
+});
+
+test('mailbox keyboard navigation supports arrows, j/k, escape, and ignores inputs', async () => {
+    const harness = createHarness({
+        fetchImpl: async (url) => {
+            const id = new URL(url).pathname.split('/').pop();
+            return jsonResponse({ id, subject: id, from: [], to: [], attachments: [] });
+        }
+    });
+    harness.run("state.emails = [{ id: 'mail-1' }, { id: 'mail-2' }]");
+
+    await harness.run("handleMailboxKeydown({ key: 'j', target: { tagName: 'BODY' }, preventDefault() {} })");
+    assert.equal(harness.run('state.currentEmail.id'), 'mail-1');
+
+    await harness.run("handleMailboxKeydown({ key: 'ArrowDown', target: { tagName: 'BODY' }, preventDefault() {} })");
+    assert.equal(harness.run('state.currentEmail.id'), 'mail-2');
+
+    const requestsBeforeInput = harness.fetchRequests.length;
+    harness.run("handleMailboxKeydown({ key: 'k', target: { tagName: 'INPUT' }, preventDefault() {} })");
+    assert.equal(harness.fetchRequests.length, requestsBeforeInput);
+
+    harness.run("handleMailboxKeydown({ key: 'Escape', target: { tagName: 'BODY' }, preventDefault() {} })");
+    assert.equal(harness.run('state.currentEmail'), null);
+    assert.equal(harness.window.location.search, '');
 });

--- a/web/app.js
+++ b/web/app.js
@@ -783,6 +783,7 @@ function currentEmailIDFromLocation() {
 
 function updateEmailLocation(emailID, mode = 'push') {
     if (!window.history || typeof window.history.pushState !== 'function') return;
+    if (currentEmailIDFromLocation() === (emailID || '')) return;
     try {
         const fallback = `${window.location.origin || ''}${window.location.pathname || '/'}${window.location.search || ''}`;
         const url = new URL(window.location.href || fallback, window.location.origin || undefined);
@@ -795,7 +796,10 @@ function updateEmailLocation(emailID, mode = 'push') {
     }
 }
 
+let emailDetailRequestSequence = 0;
+
 function clearEmailSelection(historyMode = 'push') {
+    emailDetailRequestSequence += 1;
     remoteContentAllowedEmailID = null;
     state.currentEmail = null;
     renderEmailDetail();
@@ -1608,9 +1612,12 @@ async function loadEmailDetail(id, { historyMode = 'push' } = {}) {
         clearEmailSelection(historyMode);
         return;
     }
+    const requestSequence = ++emailDetailRequestSequence;
     try {
         showLoading();
         const email = await API.getEmail(id);
+        if (requestSequence !== emailDetailRequestSequence) return;
+        if (historyMode === 'none' && currentEmailIDFromLocation() !== id) return;
         remoteContentAllowedEmailID = null;
         state.currentEmail = email;
         renderEmailDetail();
@@ -1622,6 +1629,7 @@ async function loadEmailDetail(id, { historyMode = 'push' } = {}) {
             selected.scrollIntoView({ block: 'nearest' });
         }
     } catch (error) {
+        if (requestSequence !== emailDetailRequestSequence) return;
         console.error('Failed to load email detail:', error);
         const errorMsg = parseAPIError(error);
         alert(t('loadEmailDetailError', { error: errorMsg }));

--- a/web/app.js
+++ b/web/app.js
@@ -1630,6 +1630,9 @@ async function loadEmailDetail(id, { historyMode = 'push' } = {}) {
         }
     } catch (error) {
         if (requestSequence !== emailDetailRequestSequence) return;
+        if (historyMode === 'none' && currentEmailIDFromLocation() === id) {
+            clearEmailSelection('none');
+        }
         console.error('Failed to load email detail:', error);
         const errorMsg = parseAPIError(error);
         alert(t('loadEmailDetailError', { error: errorMsg }));
@@ -1916,7 +1919,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const initialEmailID = currentEmailIDFromLocation();
     const initialLoad = loadEmails();
     if (initialEmailID) {
-        void Promise.resolve(initialLoad).then(() => loadEmailDetail(initialEmailID, { historyMode: 'none' }));
+        void Promise.resolve(initialLoad).then(() => {
+            if (currentEmailIDFromLocation() !== initialEmailID) return;
+            return loadEmailDetail(initialEmailID, { historyMode: 'none' });
+        });
     }
 
     window.addEventListener('popstate', handleHistoryNavigation);

--- a/web/app.js
+++ b/web/app.js
@@ -771,6 +771,82 @@ let state = {
     ws: null
 };
 
+function currentEmailIDFromLocation() {
+    try {
+        const fallback = `${window.location.origin || ''}${window.location.pathname || '/'}${window.location.search || ''}`;
+        const url = new URL(window.location.href || fallback, window.location.origin || undefined);
+        return url.searchParams.get('email') || '';
+    } catch (_) {
+        return '';
+    }
+}
+
+function updateEmailLocation(emailID, mode = 'push') {
+    if (!window.history || typeof window.history.pushState !== 'function') return;
+    try {
+        const fallback = `${window.location.origin || ''}${window.location.pathname || '/'}${window.location.search || ''}`;
+        const url = new URL(window.location.href || fallback, window.location.origin || undefined);
+        if (emailID) url.searchParams.set('email', emailID);
+        else url.searchParams.delete('email');
+        const method = mode === 'replace' ? 'replaceState' : 'pushState';
+        window.history[method]({ emailID: emailID || null }, '', `${url.pathname}${url.search}${url.hash}`);
+    } catch (error) {
+        console.warn('Unable to update email navigation history:', error);
+    }
+}
+
+function clearEmailSelection(historyMode = 'push') {
+    remoteContentAllowedEmailID = null;
+    state.currentEmail = null;
+    renderEmailDetail();
+    renderEmailList();
+    if (historyMode !== 'none') updateEmailLocation('', historyMode);
+}
+
+function isEditableKeyboardTarget(target) {
+    if (!target) return false;
+    if (target.isContentEditable) return true;
+    const tagName = String(target.tagName || '').toLowerCase();
+    return tagName === 'input' || tagName === 'textarea' || tagName === 'select';
+}
+
+function handleMailboxKeydown(event) {
+    if (!event || event.defaultPrevented || event.altKey || event.ctrlKey || event.metaKey || isEditableKeyboardTarget(event.target)) {
+        return;
+    }
+    if (event.key === 'Escape' && state.currentEmail) {
+        event.preventDefault();
+        clearEmailSelection('push');
+        return;
+    }
+
+    let direction = 0;
+    if (event.key === 'ArrowDown' || event.key === 'j') direction = 1;
+    if (event.key === 'ArrowUp' || event.key === 'k') direction = -1;
+    if (direction === 0 || state.emails.length === 0) return;
+
+    const currentID = state.currentEmail && state.currentEmail.id;
+    const currentIndex = state.emails.findIndex((email) => email.id === currentID);
+    const nextIndex = currentIndex < 0
+        ? (direction > 0 ? 0 : state.emails.length - 1)
+        : Math.max(0, Math.min(state.emails.length - 1, currentIndex + direction));
+    const nextEmail = state.emails[nextIndex];
+    if (!nextEmail || nextEmail.id === currentID) return;
+
+    event.preventDefault();
+    return loadEmailDetail(nextEmail.id);
+}
+
+function handleHistoryNavigation() {
+    const emailID = currentEmailIDFromLocation();
+    if (!emailID) {
+        clearEmailSelection('none');
+        return;
+    }
+    if (state.currentEmail && state.currentEmail.id === emailID) return;
+    void loadEmailDetail(emailID, { historyMode: 'none' });
+}
+
 const EMAIL_VIEWPORT_PRESETS = Object.freeze([
     { key: '100%', label: '100%', width: '100%' },
     { key: '1440', label: '1440 px', width: '1440px' },
@@ -1153,8 +1229,7 @@ function handleWebSocketMessage(data) {
         renderEmailList();
         updateEmailCount();
         if (state.currentEmail && state.currentEmail.id === data.id) {
-            state.currentEmail = null;
-            renderEmailDetail();
+            clearEmailSelection('replace');
         }
     }
 }
@@ -1257,7 +1332,7 @@ function renderEmailList() {
             : (email.hasAttachment ? '<div class="email-item-attachments">📎</div>' : '');
 
         return `
-            <div class="email-item ${unreadClass} ${selectedClass}" data-id="${email.id}">
+            <div class="email-item ${unreadClass} ${selectedClass}" data-id="${email.id}" tabindex="0" role="button">
                 <div class="email-item-header">
                     <span class="email-item-from">${escapeHtml(from)}</span>
                     <span class="email-item-time">${time}</span>
@@ -1274,6 +1349,11 @@ function renderEmailList() {
         item.addEventListener('click', () => {
             const id = item.dataset.id;
             loadEmailDetail(id);
+        });
+        item.addEventListener('keydown', (event) => {
+            if (event.key !== 'Enter' && event.key !== ' ') return;
+            event.preventDefault();
+            loadEmailDetail(item.dataset.id);
         });
     });
 }
@@ -1523,7 +1603,11 @@ async function loadEmails() {
     }
 }
 
-async function loadEmailDetail(id) {
+async function loadEmailDetail(id, { historyMode = 'push' } = {}) {
+    if (!id) {
+        clearEmailSelection(historyMode);
+        return;
+    }
     try {
         showLoading();
         const email = await API.getEmail(id);
@@ -1531,6 +1615,12 @@ async function loadEmailDetail(id) {
         state.currentEmail = email;
         renderEmailDetail();
         renderEmailList(); // Update selected state
+        if (historyMode !== 'none') updateEmailLocation(id, historyMode);
+        const selected = Array.from(document.getElementById('emailList')?.querySelectorAll('.email-item') || [])
+            .find((item) => item.dataset.id === id);
+        if (selected && typeof selected.scrollIntoView === 'function') {
+            selected.scrollIntoView({ block: 'nearest' });
+        }
     } catch (error) {
         console.error('Failed to load email detail:', error);
         const errorMsg = parseAPIError(error);
@@ -1550,8 +1640,7 @@ async function deleteEmail(id) {
         state.emails = state.emails.filter(e => e.id !== id);
         state.total--;
         if (state.currentEmail && state.currentEmail.id === id) {
-            state.currentEmail = null;
-            renderEmailDetail();
+            clearEmailSelection('replace');
         }
         renderEmailList();
         updateEmailCount();
@@ -1572,9 +1661,8 @@ async function deleteAllEmails() {
         await API.deleteAllEmails();
         state.emails = [];
         state.total = 0;
-        state.currentEmail = null;
+        clearEmailSelection('replace');
         renderEmailList();
-        renderEmailDetail();
         updateEmailCount();
     } catch (error) {
         console.error('Failed to delete all emails:', error);
@@ -1815,12 +1903,16 @@ document.addEventListener('DOMContentLoaded', () => {
     // Initialize opt-in browser notifications without prompting on page load.
     initializeBrowserNotifications();
 
-    // Load initial emails, then honor a service-worker notification deep link.
-    const initialEmailID = new URLSearchParams(window.location.search || '').get('email');
+    // Load initial emails, then honor an email deep link without adding a
+    // duplicate browser-history entry.
+    const initialEmailID = currentEmailIDFromLocation();
     const initialLoad = loadEmails();
     if (initialEmailID) {
-        void Promise.resolve(initialLoad).then(() => loadEmailDetail(initialEmailID));
+        void Promise.resolve(initialLoad).then(() => loadEmailDetail(initialEmailID, { historyMode: 'none' }));
     }
+
+    window.addEventListener('popstate', handleHistoryNavigation);
+    document.addEventListener('keydown', handleMailboxKeydown);
 
     // Connect WebSocket
     connectWebSocket();


### PR DESCRIPTION
## Summary

- encode the selected email in the `?email=` URL and push browser history on selection
- restore or clear the selected message on back/forward navigation
- avoid duplicate history entries for initial deep links
- support Arrow Up/Down and `j`/`k` list navigation plus Escape to close
- ignore shortcuts while typing and make list rows keyboard-activatable with Enter/Space
- replace stale selected-message history when a message is deleted

## Validation

Extends the Bun browser harness with deterministic history behavior and covers selection, popstate restoration, shortcuts, editable-target suppression, and Escape.