### PR TITLE
feat(observability): add Prometheus metrics

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -203,6 +203,7 @@ docker buildx build \
 | `-web-ip` | `MAILDEV_WEB_IP` / `OWLMAIL_WEB_HOST` | localhost | Web-API-Host |
 | `-base-pathname` | `MAILDEV_BASE_PATHNAME` / `OWLMAIL_BASE_PATHNAME` | - | URL-Pfadpräfix wie `/owlmail`; standardmäßig wird der Root-Pfad verwendet |
 | `-maildev-rest-compat` | `OWLMAIL_MAILDEV_REST_COMPAT` | false | Aktiviert die optionale MailDev-REST-Fassade unter `/api`; Socket.IO bleibt inkompatibel |
+| `-metrics-enabled` | `OWLMAIL_METRICS_ENABLED` | false | Prometheus-Metriken am Basispfad-abhängigen Endpunkt `/metrics` bereitstellen; vorhandene Web-Basic-Auth gilt ebenfalls |
 | `-mcp-enabled` | `OWLMAIL_MCP_ENABLED` | false | Aktiviert den schreibgeschützten MCP-Streamable-HTTP-Endpunkt unter `/mcp` |
 | `-mcp-session-timeout` | `OWLMAIL_MCP_SESSION_TIMEOUT` | 30m | Schließt inaktive MCP-Sitzungen |
 | `-mcp-shutdown-timeout` | `OWLMAIL_MCP_SHUTDOWN_TIMEOUT` | 5s | Frist zum Schließen von MCP-Sitzungen beim Herunterfahren |

--- a/README.fr.md
+++ b/README.fr.md
@@ -204,6 +204,7 @@ docker buildx build \
 | `-web-ip` | `MAILDEV_WEB_IP` / `OWLMAIL_WEB_HOST` | localhost | Web API host |
 | `-base-pathname` | `MAILDEV_BASE_PATHNAME` / `OWLMAIL_BASE_PATHNAME` | - | Préfixe de chemin URL tel que `/owlmail`; la racine reste la valeur par défaut |
 | `-maildev-rest-compat` | `OWLMAIL_MAILDEV_REST_COMPAT` | false | Active explicitement la façade REST MailDev sous `/api` ; Socket.IO reste incompatible |
+| `-metrics-enabled` | `OWLMAIL_METRICS_ENABLED` | false | Expose les métriques Prometheus sur `/metrics` sous le chemin de base ; l’authentification Basic Web existante s’applique |
 | `-mcp-enabled` | `OWLMAIL_MCP_ENABLED` | false | Active le point d'accès MCP Streamable HTTP en lecture seule sous `/mcp` |
 | `-mcp-session-timeout` | `OWLMAIL_MCP_SESSION_TIMEOUT` | 30m | Ferme les sessions MCP inactives |
 | `-mcp-shutdown-timeout` | `OWLMAIL_MCP_SHUTDOWN_TIMEOUT` | 5s | Délai de fermeture des sessions MCP à l'arrêt |

--- a/README.it.md
+++ b/README.it.md
@@ -203,6 +203,7 @@ docker buildx build \
 | `-web-ip` | `MAILDEV_WEB_IP` / `OWLMAIL_WEB_HOST` | localhost | Host API Web |
 | `-base-pathname` | `MAILDEV_BASE_PATHNAME` / `OWLMAIL_BASE_PATHNAME` | - | Prefisso del percorso URL come `/owlmail`; la radice resta predefinita |
 | `-maildev-rest-compat` | `OWLMAIL_MAILDEV_REST_COMPAT` | false | Abilita esplicitamente il facade REST MailDev sotto `/api`; Socket.IO resta incompatibile |
+| `-metrics-enabled` | `OWLMAIL_METRICS_ENABLED` | false | Espone metriche Prometheus su `/metrics` rispettando il percorso base; usa la Basic Auth Web se configurata |
 | `-mcp-enabled` | `OWLMAIL_MCP_ENABLED` | false | Abilita l'endpoint MCP Streamable HTTP in sola lettura in `/mcp` |
 | `-mcp-session-timeout` | `OWLMAIL_MCP_SESSION_TIMEOUT` | 30m | Chiude le sessioni MCP inattive |
 | `-mcp-shutdown-timeout` | `OWLMAIL_MCP_SHUTDOWN_TIMEOUT` | 5s | Termine per chiudere le sessioni MCP durante l'arresto |

--- a/README.ja.md
+++ b/README.ja.md
@@ -203,6 +203,7 @@ docker buildx build \
 | `-web-ip` | `MAILDEV_WEB_IP` / `OWLMAIL_WEB_HOST` | localhost | Web API host |
 | `-base-pathname` | `MAILDEV_BASE_PATHNAME` / `OWLMAIL_BASE_PATHNAME` | - | `/owlmail` などの URL パス接頭辞。既定はルートパス |
 | `-maildev-rest-compat` | `OWLMAIL_MAILDEV_REST_COMPAT` | false | MailDev `/api` REST facade を明示的に有効化。Socket.IO は引き続き非互換 |
+| `-metrics-enabled` | `OWLMAIL_METRICS_ENABLED` | false | ベースパス配下の `/metrics` で Prometheus メトリクスを公開。Web Basic Auth 設定時は同じ認証で保護 |
 | `-mcp-enabled` | `OWLMAIL_MCP_ENABLED` | false | `/mcp` で読み取り専用 MCP Streamable HTTP エンドポイントを有効化 |
 | `-mcp-session-timeout` | `OWLMAIL_MCP_SESSION_TIMEOUT` | 30m | アイドル状態の MCP セッションを終了 |
 | `-mcp-shutdown-timeout` | `OWLMAIL_MCP_SHUTDOWN_TIMEOUT` | 5s | シャットダウン時に MCP セッションを終了する期限 |

--- a/README.ko.md
+++ b/README.ko.md
@@ -203,6 +203,7 @@ docker buildx build \
 | `-web-ip` | `MAILDEV_WEB_IP` / `OWLMAIL_WEB_HOST` | localhost | Web API host |
 | `-base-pathname` | `MAILDEV_BASE_PATHNAME` / `OWLMAIL_BASE_PATHNAME` | - | `/owlmail` 같은 URL 경로 접두사. 기본값은 루트 경로 |
 | `-maildev-rest-compat` | `OWLMAIL_MAILDEV_REST_COMPAT` | false | MailDev `/api` REST facade를 명시적으로 활성화하며 Socket.IO는 계속 호환되지 않음 |
+| `-metrics-enabled` | `OWLMAIL_METRICS_ENABLED` | false | 기본 경로를 따르는 `/metrics`에서 Prometheus 메트릭을 노출하며 Web Basic Auth 설정 시 동일하게 보호 |
 | `-mcp-enabled` | `OWLMAIL_MCP_ENABLED` | false | `/mcp`에서 읽기 전용 MCP Streamable HTTP 엔드포인트 활성화 |
 | `-mcp-session-timeout` | `OWLMAIL_MCP_SESSION_TIMEOUT` | 30m | 유휴 MCP 세션 종료 |
 | `-mcp-shutdown-timeout` | `OWLMAIL_MCP_SHUTDOWN_TIMEOUT` | 5s | 종료 시 MCP 세션 정리 제한 시간 |

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ the message body; clicking one focuses OwlMail and opens the message.
 | `-web-ip` | `MAILDEV_WEB_IP` / `OWLMAIL_WEB_HOST` | localhost | Web API host |
 | `-base-pathname` | `MAILDEV_BASE_PATHNAME` / `OWLMAIL_BASE_PATHNAME` | - | URL path prefix such as `/owlmail`; root remains the default |
 | `-maildev-rest-compat` | `OWLMAIL_MAILDEV_REST_COMPAT` | false | Enable the opt-in MailDev `/api` REST facade; Socket.IO remains unsupported |
+| `-metrics-enabled` | `OWLMAIL_METRICS_ENABLED` | false | Expose Prometheus metrics at the base-path-aware `/metrics` endpoint; protected by Web Basic Auth when configured |
 | `-mcp-enabled` | `OWLMAIL_MCP_ENABLED` | false | Enable the read-only MCP Streamable HTTP endpoint at `/mcp` |
 | `-mcp-session-timeout` | `OWLMAIL_MCP_SESSION_TIMEOUT` | 30m | Close idle MCP sessions |
 | `-mcp-shutdown-timeout` | `OWLMAIL_MCP_SHUTDOWN_TIMEOUT` | 5s | Deadline for closing MCP sessions during shutdown |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -220,6 +220,7 @@ Notifications API 需要 HTTPS，或 `http://localhost` 等受信任的本地来
 | `-web-ip` | `MAILDEV_WEB_IP` / `OWLMAIL_WEB_HOST` | localhost | Web API 主机 |
 | `-base-pathname` | `MAILDEV_BASE_PATHNAME` / `OWLMAIL_BASE_PATHNAME` | - | URL 子路径前缀，例如 `/owlmail`；默认仍为根路径 |
 | `-maildev-rest-compat` | `OWLMAIL_MAILDEV_REST_COMPAT` | false | 显式启用 MailDev `/api` REST 兼容 facade；仍不支持 Socket.IO |
+| `-metrics-enabled` | `OWLMAIL_METRICS_ENABLED` | false | 在跟随基础路径的 `/metrics` 端点暴露 Prometheus 指标；配置 Web Basic Auth 后同样受其保护 |
 | `-mcp-enabled` | `OWLMAIL_MCP_ENABLED` | false | 在 `/mcp` 启用只读 MCP Streamable HTTP 端点 |
 | `-mcp-session-timeout` | `OWLMAIL_MCP_SESSION_TIMEOUT` | 30m | 关闭空闲 MCP 会话 |
 | `-mcp-shutdown-timeout` | `OWLMAIL_MCP_SHUTDOWN_TIMEOUT` | 5s | 关闭时清理 MCP 会话的期限 |

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -439,6 +439,7 @@ func startAPIServer(server *mailserver.MailServer, cfg *config.Config) (*api.API
 
 	apiServer := api.NewAPIWithHTTPS(server, cfg.WebPort, cfg.WebHost, cfg.WebUser, cfg.WebPassword, cfg.HTTPSEnabled, cfg.HTTPSCertFile, cfg.HTTPSKeyFile)
 	apiServer.SetMailDevRESTCompat(cfg.MailDevRESTCompat)
+	apiServer.SetMetricsEnabled(cfg.MetricsEnabled)
 	if err := apiServer.SetBasePathname(cfg.BasePathname); err != nil {
 		return nil, err
 	}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -353,7 +353,6 @@ func (api *API) setupEventListeners() {
 	})
 
 	api.mailServer.On("delete", func(email *types.Email) {
-		api.metrics.deleted.Add(1)
 		api.broadcastMessage(fiber.Map{
 			"type": "delete",
 			"id":   email.ID,

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -39,6 +39,8 @@ type API struct {
 	externalScheme    string
 	basePathname      string
 	mailDevRESTCompat bool
+	metricsEnabled    bool
+	metrics           *prometheusMetrics
 	mcpHandler        http.Handler
 }
 
@@ -60,6 +62,7 @@ func NewAPIWithHTTPS(mailServer *mailserver.MailServer, port int, host, user, pa
 		port:          port,
 		host:          host,
 		wsClients:     make(map[*websocket.Conn]*sync.Mutex),
+		metrics:       newPrometheusMetrics(),
 		authUser:      user,
 		authPassword:  password,
 		httpsEnabled:  httpsEnabled,
@@ -113,6 +116,13 @@ func (api *API) SetBasePathname(basePathname string) error {
 func (api *API) SetMailDevRESTCompat(enabled bool) {
 	api.mailDevRESTCompat = enabled
 	api.mailServer.SetRetainAllHeaders(enabled)
+	api.setupRoutes()
+}
+
+// SetMetricsEnabled controls the opt-in Prometheus endpoint. The endpoint
+// follows the configured base pathname and existing HTTP Basic Auth policy.
+func (api *API) SetMetricsEnabled(enabled bool) {
+	api.metricsEnabled = enabled
 	api.setupRoutes()
 }
 
@@ -208,6 +218,9 @@ func (api *API) setupRoutes() {
 	// New improved RESTful API routes
 	// ============================================================================
 	api.setupImprovedAPIRoutes(app)
+	if api.metricsEnabled {
+		app.Get(api.route("/metrics"), api.prometheusMetrics)
+	}
 	if api.mcpHandler != nil {
 		app.All(api.route("/mcp"), adaptor.HTTPHandler(api.mcpHandler))
 	}
@@ -232,6 +245,7 @@ func (api *API) setupRoutes() {
 			strings.HasPrefix(path, "/readyz") ||
 			strings.HasPrefix(path, "/socket.io") ||
 			strings.HasPrefix(path, "/mcp") ||
+			strings.HasPrefix(path, "/metrics") ||
 			strings.HasPrefix(path, "/api/") ||
 			strings.HasPrefix(path, "/style.css") ||
 			strings.HasPrefix(path, "/app.js") ||
@@ -331,6 +345,7 @@ func (api *API) Start() error {
 // setupEventListeners sets up event listeners for WebSocket broadcasting
 func (api *API) setupEventListeners() {
 	api.mailServer.On("new", func(email *types.Email) {
+		api.metrics.received.Add(1)
 		api.broadcastMessage(fiber.Map{
 			"type":  "new",
 			"email": email,
@@ -338,6 +353,7 @@ func (api *API) setupEventListeners() {
 	})
 
 	api.mailServer.On("delete", func(email *types.Email) {
+		api.metrics.deleted.Add(1)
 		api.broadcastMessage(fiber.Map{
 			"type": "delete",
 			"id":   email.ID,

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -345,7 +345,6 @@ func (api *API) Start() error {
 // setupEventListeners sets up event listeners for WebSocket broadcasting
 func (api *API) setupEventListeners() {
 	api.mailServer.On("new", func(email *types.Email) {
-		api.metrics.received.Add(1)
 		api.broadcastMessage(fiber.Map{
 			"type":  "new",
 			"email": email,

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -20,35 +20,8 @@ func newPrometheusMetrics() *prometheusMetrics {
 	return &prometheusMetrics{startedAt: time.Now()}
 }
 
-func metricUint(value interface{}) uint64 {
-	switch typed := value.(type) {
-	case uint64:
-		return typed
-	case uint:
-		return uint64(typed)
-	case int:
-		if typed > 0 {
-			return uint64(typed)
-		}
-	case int64:
-		if typed > 0 {
-			return uint64(typed)
-		}
-	case float64:
-		if typed > 0 {
-			return uint64(typed)
-		}
-	}
-	return 0
-}
-
 func (api *API) prometheusMetrics(c fiber.Ctx) error {
-	stats := api.mailServer.GetEmailStats()
-	total := metricUint(stats["total"])
-	read := metricUint(stats["read"])
-	unread := metricUint(stats["unread"])
-
-	storage, _ := stats["storage"].(map[string]interface{})
+	stats := api.mailServer.GetMailboxMetrics()
 	api.wsClientsLock.RLock()
 	websocketClients := len(api.wsClients)
 	api.wsClientsLock.RUnlock()
@@ -56,9 +29,9 @@ func (api *API) prometheusMetrics(c fiber.Ctx) error {
 	var output strings.Builder
 	output.WriteString("# HELP owlmail_mailbox_messages Current messages stored in the mailbox.\n")
 	output.WriteString("# TYPE owlmail_mailbox_messages gauge\n")
-	fmt.Fprintf(&output, "owlmail_mailbox_messages{state=\"total\"} %d\n", total)
-	fmt.Fprintf(&output, "owlmail_mailbox_messages{state=\"read\"} %d\n", read)
-	fmt.Fprintf(&output, "owlmail_mailbox_messages{state=\"unread\"} %d\n", unread)
+	fmt.Fprintf(&output, "owlmail_mailbox_messages{state=\"total\"} %d\n", stats.Total)
+	fmt.Fprintf(&output, "owlmail_mailbox_messages{state=\"read\"} %d\n", stats.Read)
+	fmt.Fprintf(&output, "owlmail_mailbox_messages{state=\"unread\"} %d\n", stats.Unread)
 	output.WriteString("# HELP owlmail_emails_received_total Messages received since this process started.\n")
 	output.WriteString("# TYPE owlmail_emails_received_total counter\n")
 	fmt.Fprintf(&output, "owlmail_emails_received_total %d\n", api.metrics.received.Load())
@@ -70,13 +43,13 @@ func (api *API) prometheusMetrics(c fiber.Ctx) error {
 	fmt.Fprintf(&output, "owlmail_websocket_connections %d\n", websocketClients)
 	output.WriteString("# HELP owlmail_storage_cleanup_runs_total Mailbox retention cleanup runs.\n")
 	output.WriteString("# TYPE owlmail_storage_cleanup_runs_total counter\n")
-	fmt.Fprintf(&output, "owlmail_storage_cleanup_runs_total %d\n", metricUint(storage["cleanupRuns"]))
+	fmt.Fprintf(&output, "owlmail_storage_cleanup_runs_total %d\n", stats.Storage.CleanupRuns)
 	output.WriteString("# HELP owlmail_storage_deleted_messages_total Messages deleted by retention cleanup.\n")
 	output.WriteString("# TYPE owlmail_storage_deleted_messages_total counter\n")
-	fmt.Fprintf(&output, "owlmail_storage_deleted_messages_total %d\n", metricUint(storage["deletedMessages"]))
+	fmt.Fprintf(&output, "owlmail_storage_deleted_messages_total %d\n", stats.Storage.DeletedMessages)
 	output.WriteString("# HELP owlmail_storage_reclaimed_bytes_total Bytes reclaimed by retention cleanup.\n")
 	output.WriteString("# TYPE owlmail_storage_reclaimed_bytes_total counter\n")
-	fmt.Fprintf(&output, "owlmail_storage_reclaimed_bytes_total %d\n", metricUint(storage["reclaimedBytes"]))
+	fmt.Fprintf(&output, "owlmail_storage_reclaimed_bytes_total %d\n", stats.Storage.ReclaimedBytes)
 	output.WriteString("# HELP owlmail_uptime_seconds Process uptime in seconds.\n")
 	output.WriteString("# TYPE owlmail_uptime_seconds gauge\n")
 	fmt.Fprintf(&output, "owlmail_uptime_seconds %.3f\n", time.Since(api.metrics.startedAt).Seconds())

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/gofiber/fiber/v3"
@@ -12,7 +11,6 @@ import (
 
 type prometheusMetrics struct {
 	startedAt time.Time
-	received  atomic.Uint64
 }
 
 func newPrometheusMetrics() *prometheusMetrics {
@@ -33,7 +31,7 @@ func (api *API) prometheusMetrics(c fiber.Ctx) error {
 	fmt.Fprintf(&output, "owlmail_mailbox_messages{state=\"unread\"} %d\n", stats.Unread)
 	output.WriteString("# HELP owlmail_emails_received_total Messages received since this process started.\n")
 	output.WriteString("# TYPE owlmail_emails_received_total counter\n")
-	fmt.Fprintf(&output, "owlmail_emails_received_total %d\n", api.metrics.received.Load())
+	fmt.Fprintf(&output, "owlmail_emails_received_total %d\n", stats.ReceivedMessages)
 	output.WriteString("# HELP owlmail_emails_deleted_total Messages deleted since this process started.\n")
 	output.WriteString("# TYPE owlmail_emails_deleted_total counter\n")
 	fmt.Fprintf(&output, "owlmail_emails_deleted_total %d\n", stats.DeletedMessages)

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -9,12 +9,14 @@ import (
 	"github.com/gofiber/fiber/v3"
 )
 
+var processStartedAt = time.Now()
+
 type prometheusMetrics struct {
 	startedAt time.Time
 }
 
 func newPrometheusMetrics() *prometheusMetrics {
-	return &prometheusMetrics{startedAt: time.Now()}
+	return &prometheusMetrics{startedAt: processStartedAt}
 }
 
 func (api *API) prometheusMetrics(c fiber.Ctx) error {

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -13,7 +13,6 @@ import (
 type prometheusMetrics struct {
 	startedAt time.Time
 	received  atomic.Uint64
-	deleted   atomic.Uint64
 }
 
 func newPrometheusMetrics() *prometheusMetrics {
@@ -37,7 +36,7 @@ func (api *API) prometheusMetrics(c fiber.Ctx) error {
 	fmt.Fprintf(&output, "owlmail_emails_received_total %d\n", api.metrics.received.Load())
 	output.WriteString("# HELP owlmail_emails_deleted_total Messages deleted since this process started.\n")
 	output.WriteString("# TYPE owlmail_emails_deleted_total counter\n")
-	fmt.Fprintf(&output, "owlmail_emails_deleted_total %d\n", api.metrics.deleted.Load())
+	fmt.Fprintf(&output, "owlmail_emails_deleted_total %d\n", stats.DeletedMessages)
 	output.WriteString("# HELP owlmail_websocket_connections Current WebSocket clients.\n")
 	output.WriteString("# TYPE owlmail_websocket_connections gauge\n")
 	fmt.Fprintf(&output, "owlmail_websocket_connections %d\n", websocketClients)

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+)
+
+type prometheusMetrics struct {
+	startedAt time.Time
+	received  atomic.Uint64
+	deleted   atomic.Uint64
+}
+
+func newPrometheusMetrics() *prometheusMetrics {
+	return &prometheusMetrics{startedAt: time.Now()}
+}
+
+func metricUint(value interface{}) uint64 {
+	switch typed := value.(type) {
+	case uint64:
+		return typed
+	case uint:
+		return uint64(typed)
+	case int:
+		if typed > 0 {
+			return uint64(typed)
+		}
+	case int64:
+		if typed > 0 {
+			return uint64(typed)
+		}
+	case float64:
+		if typed > 0 {
+			return uint64(typed)
+		}
+	}
+	return 0
+}
+
+func (api *API) prometheusMetrics(c fiber.Ctx) error {
+	stats := api.mailServer.GetEmailStats()
+	total := metricUint(stats["total"])
+	read := metricUint(stats["read"])
+	unread := metricUint(stats["unread"])
+
+	storage, _ := stats["storage"].(map[string]interface{})
+	api.wsClientsLock.RLock()
+	websocketClients := len(api.wsClients)
+	api.wsClientsLock.RUnlock()
+
+	var output strings.Builder
+	output.WriteString("# HELP owlmail_mailbox_messages Current messages stored in the mailbox.\n")
+	output.WriteString("# TYPE owlmail_mailbox_messages gauge\n")
+	fmt.Fprintf(&output, "owlmail_mailbox_messages{state=\"total\"} %d\n", total)
+	fmt.Fprintf(&output, "owlmail_mailbox_messages{state=\"read\"} %d\n", read)
+	fmt.Fprintf(&output, "owlmail_mailbox_messages{state=\"unread\"} %d\n", unread)
+	output.WriteString("# HELP owlmail_emails_received_total Messages received since this process started.\n")
+	output.WriteString("# TYPE owlmail_emails_received_total counter\n")
+	fmt.Fprintf(&output, "owlmail_emails_received_total %d\n", api.metrics.received.Load())
+	output.WriteString("# HELP owlmail_emails_deleted_total Messages deleted since this process started.\n")
+	output.WriteString("# TYPE owlmail_emails_deleted_total counter\n")
+	fmt.Fprintf(&output, "owlmail_emails_deleted_total %d\n", api.metrics.deleted.Load())
+	output.WriteString("# HELP owlmail_websocket_connections Current WebSocket clients.\n")
+	output.WriteString("# TYPE owlmail_websocket_connections gauge\n")
+	fmt.Fprintf(&output, "owlmail_websocket_connections %d\n", websocketClients)
+	output.WriteString("# HELP owlmail_storage_cleanup_runs_total Mailbox retention cleanup runs.\n")
+	output.WriteString("# TYPE owlmail_storage_cleanup_runs_total counter\n")
+	fmt.Fprintf(&output, "owlmail_storage_cleanup_runs_total %d\n", metricUint(storage["cleanupRuns"]))
+	output.WriteString("# HELP owlmail_storage_deleted_messages_total Messages deleted by retention cleanup.\n")
+	output.WriteString("# TYPE owlmail_storage_deleted_messages_total counter\n")
+	fmt.Fprintf(&output, "owlmail_storage_deleted_messages_total %d\n", metricUint(storage["deletedMessages"]))
+	output.WriteString("# HELP owlmail_storage_reclaimed_bytes_total Bytes reclaimed by retention cleanup.\n")
+	output.WriteString("# TYPE owlmail_storage_reclaimed_bytes_total counter\n")
+	fmt.Fprintf(&output, "owlmail_storage_reclaimed_bytes_total %d\n", metricUint(storage["reclaimedBytes"]))
+	output.WriteString("# HELP owlmail_uptime_seconds Process uptime in seconds.\n")
+	output.WriteString("# TYPE owlmail_uptime_seconds gauge\n")
+	fmt.Fprintf(&output, "owlmail_uptime_seconds %.3f\n", time.Since(api.metrics.startedAt).Seconds())
+
+	c.Set(fiber.HeaderContentType, "text/plain; version=0.0.4; charset=utf-8")
+	c.Set(fiber.HeaderCacheControl, "no-store")
+	return c.Status(http.StatusOK).SendString(output.String())
+}

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/soulteary/owlmail/internal/types"
@@ -12,7 +13,11 @@ import (
 
 func TestPrometheusMetricsAreOptIn(t *testing.T) {
 	api, server, tmpDir := setupTestAPI(t)
-	defer server.Close()
+	defer func() {
+		if err := server.Close(); err != nil {
+			t.Errorf("close mail server: %v", err)
+		}
+	}()
 
 	req, _ := http.NewRequest(http.MethodGet, "/metrics", nil)
 	resp, err := api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
@@ -62,7 +67,11 @@ func TestPrometheusMetricsAreOptIn(t *testing.T) {
 
 func TestPrometheusMetricsUseBasePathAndBasicAuth(t *testing.T) {
 	_, server, _ := setupTestAPI(t)
-	defer server.Close()
+	defer func() {
+		if err := server.Close(); err != nil {
+			t.Errorf("close mail server: %v", err)
+		}
+	}()
 	api := NewAPIWithAuth(server, 1080, "localhost", "metrics", "secret")
 	if err := api.SetBasePathname("/owlmail"); err != nil {
 		t.Fatal(err)
@@ -88,5 +97,35 @@ func TestPrometheusMetricsUseBasePathAndBasicAuth(t *testing.T) {
 	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("authenticated metrics status = %d", resp.StatusCode)
+	}
+}
+
+
+func TestPrometheusMetricsCountDeleteAll(t *testing.T) {
+	api, server, _ := setupTestAPI(t)
+	defer func() {
+		if err := server.Close(); err != nil {
+			t.Errorf("close mail server: %v", err)
+		}
+	}()
+	api.SetMetricsEnabled(true)
+
+	for _, id := range []string{"delete-all-1", "delete-all-2"} {
+		email := &types.Email{ID: id, Subject: id}
+		envelope := &types.Envelope{From: "sender@example.test", To: []string{"recipient@example.test"}}
+		if err := server.SaveEmailToStore(id, false, envelope, email); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := server.DeleteAllEmail(); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for api.metrics.deleted.Load() != 2 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := api.metrics.deleted.Load(); got != 2 {
+		t.Fatalf("deleted metric after delete-all = %d, want 2", got)
 	}
 }

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/soulteary/owlmail/internal/mailserver"
 	"github.com/soulteary/owlmail/internal/types"
 )
 
@@ -53,7 +54,7 @@ func TestPrometheusMetricsAreOptIn(t *testing.T) {
 	for _, sample := range []string{
 		"owlmail_mailbox_messages{state=\"total\"} 1",
 		"owlmail_mailbox_messages{state=\"unread\"} 1",
-		"owlmail_emails_received_total",
+		"owlmail_emails_received_total 1",
 		"owlmail_websocket_connections 0",
 		"owlmail_storage_cleanup_runs_total",
 		"owlmail_uptime_seconds",
@@ -61,6 +62,37 @@ func TestPrometheusMetricsAreOptIn(t *testing.T) {
 		if !strings.Contains(string(body), sample) {
 			t.Errorf("metrics output missing %q:\n%s", sample, body)
 		}
+	}
+}
+
+func TestPrometheusMetricsCountMessagesStoredBeforeAPI(t *testing.T) {
+	server, err := mailserver.NewMailServer(1025, "localhost", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := server.Close(); err != nil {
+			t.Errorf("close mail server: %v", err)
+		}
+	}()
+
+	email := &types.Email{ID: "before-api", Subject: "Before API"}
+	envelope := &types.Envelope{From: "sender@example.test", To: []string{"recipient@example.test"}}
+	if err := server.SaveEmailToStore(email.ID, false, envelope, email); err != nil {
+		t.Fatal(err)
+	}
+
+	api := NewAPI(server, 1080, "localhost")
+	api.SetMetricsEnabled(true)
+	req, _ := http.NewRequest(http.MethodGet, "/metrics", nil)
+	resp, err := api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if !strings.Contains(string(body), "owlmail_emails_received_total 1\n") {
+		t.Fatalf("pre-API receive was not counted:\n%s", body)
 	}
 }
 

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -100,7 +100,6 @@ func TestPrometheusMetricsUseBasePathAndBasicAuth(t *testing.T) {
 	}
 }
 
-
 func TestPrometheusMetricsCountDeleteAll(t *testing.T) {
 	api, server, _ := setupTestAPI(t)
 	defer func() {

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/soulteary/owlmail/internal/types"
@@ -120,11 +119,7 @@ func TestPrometheusMetricsCountDeleteAll(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	deadline := time.Now().Add(time.Second)
-	for api.metrics.deleted.Load() != 2 && time.Now().Before(deadline) {
-		time.Sleep(time.Millisecond)
-	}
-	if got := api.metrics.deleted.Load(); got != 2 {
+	if got := server.GetMailboxMetrics().DeletedMessages; got != 2 {
 		t.Fatalf("deleted metric after delete-all = %d, want 2", got)
 	}
 }

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/soulteary/owlmail/internal/types"
+)
+
+func TestPrometheusMetricsAreOptIn(t *testing.T) {
+	api, server, tmpDir := setupTestAPI(t)
+	defer server.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, "/metrics", nil)
+	resp, err := api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound || strings.Contains(string(body), "<!DOCTYPE html>") {
+		t.Fatalf("disabled metrics status/body = %d %q", resp.StatusCode, body)
+	}
+
+	api.SetMetricsEnabled(true)
+	email := &types.Email{ID: "metrics-message", Subject: "Metrics"}
+	envelope := &types.Envelope{From: "sender@example.test", To: []string{"recipient@example.test"}}
+	if err := server.SaveEmailToStore("metrics-message", false, envelope, email); err != nil {
+		t.Fatal(err)
+	}
+	_ = tmpDir
+
+	req, _ = http.NewRequest(http.MethodGet, "/metrics", nil)
+	resp, err = api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("metrics status = %d, body = %s", resp.StatusCode, body)
+	}
+	if contentType := resp.Header.Get("Content-Type"); !strings.HasPrefix(contentType, "text/plain; version=0.0.4") {
+		t.Fatalf("metrics content type = %q", contentType)
+	}
+	for _, sample := range []string{
+		"owlmail_mailbox_messages{state=\"total\"} 1",
+		"owlmail_mailbox_messages{state=\"unread\"} 1",
+		"owlmail_emails_received_total",
+		"owlmail_websocket_connections 0",
+		"owlmail_storage_cleanup_runs_total",
+		"owlmail_uptime_seconds",
+	} {
+		if !strings.Contains(string(body), sample) {
+			t.Errorf("metrics output missing %q:\n%s", sample, body)
+		}
+	}
+}
+
+func TestPrometheusMetricsUseBasePathAndBasicAuth(t *testing.T) {
+	_, server, _ := setupTestAPI(t)
+	defer server.Close()
+	api := NewAPIWithAuth(server, 1080, "localhost", "metrics", "secret")
+	if err := api.SetBasePathname("/owlmail"); err != nil {
+		t.Fatal(err)
+	}
+	api.SetMetricsEnabled(true)
+
+	req, _ := http.NewRequest(http.MethodGet, "/owlmail/metrics", nil)
+	resp, err := api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated metrics status = %d", resp.StatusCode)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, "/owlmail/metrics", nil)
+	req.SetBasicAuth("metrics", "secret")
+	resp, err = api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("authenticated metrics status = %d", resp.StatusCode)
+	}
+}

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -65,6 +65,13 @@ func TestPrometheusMetricsAreOptIn(t *testing.T) {
 	}
 }
 
+func TestPrometheusMetricsUseProcessStartTime(t *testing.T) {
+	metrics := newPrometheusMetrics()
+	if !metrics.startedAt.Equal(processStartedAt) {
+		t.Fatalf("metrics start = %v, process start = %v", metrics.startedAt, processStartedAt)
+	}
+}
+
 func TestPrometheusMetricsCountMessagesStoredBeforeAPI(t *testing.T) {
 	server, err := mailserver.NewMailServer(1025, "localhost", t.TempDir())
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -233,6 +233,7 @@ type Config struct {
 	WebExternalScheme  string
 	BasePathname       string
 	MailDevRESTCompat  bool
+	MetricsEnabled     bool
 	MCPEnabled         bool
 	MCPSessionTimeout  string
 	MCPShutdownTimeout string
@@ -310,6 +311,7 @@ func DefaultConfig() *Config {
 		WebExternalScheme:      "",
 		BasePathname:           "",
 		MailDevRESTCompat:      false,
+		MetricsEnabled:         false,
 		MCPEnabled:             false,
 		MCPSessionTimeout:      DefaultMCPSessionTimeout,
 		MCPShutdownTimeout:     DefaultMCPShutdownTimeout,
@@ -369,6 +371,7 @@ type FlagRefs struct {
 	WebPassword            *string
 	BasePathname           *string
 	MailDevRESTCompat      *bool
+	MetricsEnabled         *bool
 	MCPEnabled             *bool
 	MCPSessionTimeout      *string
 	MCPShutdownTimeout     *string
@@ -430,6 +433,7 @@ func DefineFlags(fs *flag.FlagSet) *FlagRefs {
 		WebPassword:            fs.String("web-password", cfg.WebPassword, "HTTP Basic Auth password"),
 		BasePathname:           fs.String("base-pathname", cfg.BasePathname, "Browser-visible URL path prefix (for example /owlmail)"),
 		MailDevRESTCompat:      fs.Bool("maildev-rest-compat", cfg.MailDevRESTCompat, "Enable the optional MailDev REST compatibility facade under /api"),
+		MetricsEnabled:         fs.Bool("metrics-enabled", cfg.MetricsEnabled, "Expose Prometheus metrics at /metrics"),
 		MCPEnabled:             fs.Bool("mcp-enabled", cfg.MCPEnabled, "Enable the read-only MCP Streamable HTTP endpoint"),
 		MCPSessionTimeout:      fs.String("mcp-session-timeout", cfg.MCPSessionTimeout, "Idle timeout for MCP sessions"),
 		MCPShutdownTimeout:     fs.String("mcp-shutdown-timeout", cfg.MCPShutdownTimeout, "Maximum time to close MCP sessions during shutdown"),
@@ -494,6 +498,7 @@ func ResolveConfig(fs *flag.FlagSet, refs *FlagRefs) *Config {
 		WebExternalScheme:  ResolveString(nil, "", "OWLMAIL_WEB_EXTERNAL_SCHEME", ""),
 		BasePathname:       resolveStringWithFlag(fs, "base-pathname", "OWLMAIL_BASE_PATHNAME", *refs.BasePathname),
 		MailDevRESTCompat:  resolveBoolWithFlag(fs, "maildev-rest-compat", "OWLMAIL_MAILDEV_REST_COMPAT", *refs.MailDevRESTCompat),
+		MetricsEnabled:     resolveBoolWithFlag(fs, "metrics-enabled", "OWLMAIL_METRICS_ENABLED", *refs.MetricsEnabled),
 		MCPEnabled:         resolveBoolWithFlag(fs, "mcp-enabled", "OWLMAIL_MCP_ENABLED", *refs.MCPEnabled),
 		MCPSessionTimeout:  resolveStringWithFlag(fs, "mcp-session-timeout", "OWLMAIL_MCP_SESSION_TIMEOUT", *refs.MCPSessionTimeout),
 		MCPShutdownTimeout: resolveStringWithFlag(fs, "mcp-shutdown-timeout", "OWLMAIL_MCP_SHUTDOWN_TIMEOUT", *refs.MCPShutdownTimeout),

--- a/internal/mailserver/mailserver_store_test.go
+++ b/internal/mailserver/mailserver_store_test.go
@@ -375,6 +375,9 @@ func TestMailServerDeleteAllEmail(t *testing.T) {
 	if got := server.GetMailboxMetrics().DeletedMessages; got != 2 {
 		t.Fatalf("deleted messages = %d, want 2", got)
 	}
+	if got := server.GetMailboxMetrics().ReceivedMessages; got != 2 {
+		t.Fatalf("received messages = %d, want 2", got)
+	}
 	select {
 	case <-deleteEvents:
 		t.Fatal("delete-all emitted per-message notifications")

--- a/internal/mailserver/mailserver_store_test.go
+++ b/internal/mailserver/mailserver_store_test.go
@@ -350,6 +350,13 @@ func TestMailServerDeleteAllEmail(t *testing.T) {
 	if err := os.WriteFile(quarantinePath, []byte("recoverable"), 0600); err != nil {
 		t.Fatal(err)
 	}
+	deleteEvents := make(chan struct{}, 1)
+	server.On("delete", func(*Email) {
+		select {
+		case deleteEvents <- struct{}{}:
+		default:
+		}
+	})
 
 	// Delete all
 	err = server.DeleteAllEmail()
@@ -364,6 +371,14 @@ func TestMailServerDeleteAllEmail(t *testing.T) {
 	}
 	if content, err := os.ReadFile(quarantinePath); err != nil || string(content) != "recoverable" {
 		t.Fatalf("quarantine was removed by DeleteAllEmail: content=%q err=%v", content, err)
+	}
+	if got := server.GetMailboxMetrics().DeletedMessages; got != 2 {
+		t.Fatalf("deleted messages = %d, want 2", got)
+	}
+	select {
+	case <-deleteEvents:
+		t.Fatal("delete-all emitted per-message notifications")
+	case <-time.After(50 * time.Millisecond):
 	}
 }
 

--- a/internal/mailserver/storage_governance.go
+++ b/internal/mailserver/storage_governance.go
@@ -42,11 +42,12 @@ type StorageMetrics struct {
 
 // MailboxMetrics is a disk-I/O-free snapshot for runtime monitoring.
 type MailboxMetrics struct {
-	Total           int
-	Read            int
-	Unread          int
-	DeletedMessages uint64
-	Storage         StorageMetrics
+	Total            int
+	Read             int
+	Unread           int
+	ReceivedMessages uint64
+	DeletedMessages  uint64
+	Storage          StorageMetrics
 }
 
 // GetMailboxMetrics returns current mailbox counts and retention counters
@@ -67,11 +68,12 @@ func (ms *MailServer) GetMailboxMetrics() MailboxMetrics {
 	ms.storageMetricsMutex.RUnlock()
 
 	return MailboxMetrics{
-		Total:           total,
-		Read:            total - unread,
-		Unread:          unread,
-		DeletedMessages: ms.deletedMessages.Load(),
-		Storage:         storage,
+		Total:            total,
+		Read:             total - unread,
+		Unread:           unread,
+		ReceivedMessages: ms.receivedMessages.Load(),
+		DeletedMessages:  ms.deletedMessages.Load(),
+		Storage:          storage,
 	}
 }
 

--- a/internal/mailserver/storage_governance.go
+++ b/internal/mailserver/storage_governance.go
@@ -42,10 +42,11 @@ type StorageMetrics struct {
 
 // MailboxMetrics is a disk-I/O-free snapshot for runtime monitoring.
 type MailboxMetrics struct {
-	Total   int
-	Read    int
-	Unread  int
-	Storage StorageMetrics
+	Total           int
+	Read            int
+	Unread          int
+	DeletedMessages uint64
+	Storage         StorageMetrics
 }
 
 // GetMailboxMetrics returns current mailbox counts and retention counters
@@ -66,10 +67,11 @@ func (ms *MailServer) GetMailboxMetrics() MailboxMetrics {
 	ms.storageMetricsMutex.RUnlock()
 
 	return MailboxMetrics{
-		Total:   total,
-		Read:    total - unread,
-		Unread:  unread,
-		Storage: storage,
+		Total:           total,
+		Read:            total - unread,
+		Unread:          unread,
+		DeletedMessages: ms.deletedMessages.Load(),
+		Storage:         storage,
 	}
 }
 

--- a/internal/mailserver/storage_governance.go
+++ b/internal/mailserver/storage_governance.go
@@ -40,6 +40,39 @@ type StorageMetrics struct {
 	LastCleanupError string    `json:"lastCleanupError,omitempty"`
 }
 
+// MailboxMetrics is a disk-I/O-free snapshot for runtime monitoring.
+type MailboxMetrics struct {
+	Total   int
+	Read    int
+	Unread  int
+	Storage StorageMetrics
+}
+
+// GetMailboxMetrics returns current mailbox counts and retention counters
+// without calculating on-disk usage.
+func (ms *MailServer) GetMailboxMetrics() MailboxMetrics {
+	ms.storeMutex.RLock()
+	total := len(ms.storeByID)
+	unread := 0
+	for _, email := range ms.storeByID {
+		if !email.Read {
+			unread++
+		}
+	}
+	ms.storeMutex.RUnlock()
+
+	ms.storageMetricsMutex.RLock()
+	storage := ms.storageMetrics
+	ms.storageMetricsMutex.RUnlock()
+
+	return MailboxMetrics{
+		Total:   total,
+		Read:    total - unread,
+		Unread:  unread,
+		Storage: storage,
+	}
+}
+
 type emailMetadata struct {
 	Version     int                  `json:"version"`
 	ID          string               `json:"id"`

--- a/internal/mailserver/store.go
+++ b/internal/mailserver/store.go
@@ -310,6 +310,7 @@ func (ms *MailServer) DeleteAllEmail() error {
 	}
 	var deletionErrors []error
 	for _, id := range ids {
+		email, _ := ms.GetEmail(id)
 		if err := ms.ensureDeletionFence(id); err != nil {
 			deletionErrors = append(deletionErrors, fmt.Errorf("fence deletion for %s: %w", id, err))
 			continue
@@ -319,6 +320,11 @@ func (ms *MailServer) DeleteAllEmail() error {
 			continue
 		}
 		ms.removeEmailFromMemory(id)
+		if email != nil {
+			if err := ms.emit("delete", email); err != nil {
+				common.Error("Failed to emit delete event: %v", err)
+			}
+		}
 	}
 	if err := errors.Join(deletionErrors...); err != nil {
 		return err

--- a/internal/mailserver/store.go
+++ b/internal/mailserver/store.go
@@ -129,6 +129,9 @@ func (ms *MailServer) saveEmailToStore(id string, isRead bool, envelope *Envelop
 	}
 	ms.receivedAtByID[id] = receivedAt
 	ms.storeByID[id] = storedEmail
+	if persistMetadata {
+		ms.receivedMessages.Add(1)
+	}
 	ms.storeMutex.Unlock()
 
 	common.Log("Saving email: %s, id: %s", parsedEmail.Subject, id)

--- a/internal/mailserver/store.go
+++ b/internal/mailserver/store.go
@@ -287,6 +287,7 @@ func (ms *MailServer) DeleteEmail(id string) error {
 	}
 
 	ms.removeEmailFromMemory(id)
+	ms.deletedMessages.Add(1)
 
 	common.Log("Deleting email - %s, id: %s", email.Subject, email.ID)
 
@@ -310,7 +311,6 @@ func (ms *MailServer) DeleteAllEmail() error {
 	}
 	var deletionErrors []error
 	for _, id := range ids {
-		email, _ := ms.GetEmail(id)
 		if err := ms.ensureDeletionFence(id); err != nil {
 			deletionErrors = append(deletionErrors, fmt.Errorf("fence deletion for %s: %w", id, err))
 			continue
@@ -320,11 +320,7 @@ func (ms *MailServer) DeleteAllEmail() error {
 			continue
 		}
 		ms.removeEmailFromMemory(id)
-		if email != nil {
-			if err := ms.emit("delete", email); err != nil {
-				common.Error("Failed to emit delete event: %v", err)
-			}
-		}
+		ms.deletedMessages.Add(1)
 	}
 	if err := errors.Join(deletionErrors...); err != nil {
 		return err

--- a/internal/mailserver/types.go
+++ b/internal/mailserver/types.go
@@ -123,6 +123,7 @@ type MailServer struct {
 	cleanupWG           sync.WaitGroup
 	storageMetricsMutex sync.RWMutex
 	storageMetrics      StorageMetrics
+	deletedMessages     atomic.Uint64
 
 	// Storage hooks are intentionally unexported and nil in production. They
 	// provide deterministic fault injection for transaction boundary tests.

--- a/internal/mailserver/types.go
+++ b/internal/mailserver/types.go
@@ -123,6 +123,7 @@ type MailServer struct {
 	cleanupWG           sync.WaitGroup
 	storageMetricsMutex sync.RWMutex
 	storageMetrics      StorageMetrics
+	receivedMessages    atomic.Uint64
 	deletedMessages     atomic.Uint64
 
 	// Storage hooks are intentionally unexported and nil in production. They


### PR DESCRIPTION
## Summary

- add a default-off, base-path-aware Prometheus endpoint at `/metrics`
- expose mailbox state, process-local receive/delete counters, WebSocket clients, retention counters, reclaimed bytes, and uptime
- reuse the existing Web Basic Auth boundary when credentials are configured
- prevent disabled `/metrics` requests from falling through to the browser SPA
- document the CLI/environment switch in every root README

## Configuration

`-metrics-enabled` / `OWLMAIL_METRICS_ENABLED=true`

No external Prometheus client dependency is added; the handler emits the Prometheus 0.0.4 text exposition format with bounded metric names and labels.

## Validation

Covers opt-in behavior, exposition content type and samples, base pathname routing, and HTTP Basic Auth protection.