### PR TITLE
fix(relay): make runtime configuration lifecycle-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ All notable changes to OwlMail are documented in this file. The format follows
 
 ### Changed
 
+- Runtime outgoing relay configuration now uses immutable snapshots, starts
+  workers when relay is enabled dynamically, atomically applies updates, and
+  coordinates queue submission with idempotent shutdown without exposing SMTP
+  passwords through settings responses.
 - HTML email previews now combine server-side sanitization with a zero-permission
   iframe sandbox, a no-referrer policy, and a restrictive per-preview CSP.
   Remote images, fonts, stylesheets, and media are blocked by default and can

--- a/internal/api/api_config.go
+++ b/internal/api/api_config.go
@@ -23,7 +23,7 @@ func (api *API) getConfig(c fiber.Ctx) error {
 	}
 
 	outgoingConfig := api.mailServer.GetOutgoingConfig()
-	if outgoingConfig != nil {
+	if outgoingConfig != nil && outgoingConfig.Host != "" {
 		config["outgoing"] = fiber.Map{
 			"host":          outgoingConfig.Host,
 			"port":          outgoingConfig.Port,
@@ -65,7 +65,7 @@ func (api *API) getConfig(c fiber.Ctx) error {
 // getOutgoingConfig handles GET /api/v1/settings/outgoing
 func (api *API) getOutgoingConfig(c fiber.Ctx) error {
 	outgoingConfig := api.mailServer.GetOutgoingConfig()
-	if outgoingConfig == nil {
+	if outgoingConfig == nil || outgoingConfig.Host == "" {
 		return c.JSON(fiber.Map{
 			"enabled": false,
 			"message": "Outgoing mail not configured",
@@ -87,6 +87,8 @@ func (api *API) getOutgoingConfig(c fiber.Ctx) error {
 
 // updateOutgoingConfig handles PUT /api/v1/settings/outgoing
 func (api *API) updateOutgoingConfig(c fiber.Ctx) error {
+	// PUT is a complete replacement: omitting or clearing password disables
+	// authentication for relay tasks accepted after this update.
 	var config outgoing.OutgoingConfig
 	if err := c.Bind().Body(&config); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse(ErrorCodeInvalidRequest, "Invalid request: "+err.Error()))
@@ -100,7 +102,9 @@ func (api *API) updateOutgoingConfig(c fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse(ErrorCodePortOutOfRange, "Port must be between 1 and 65535"))
 	}
 
-	api.mailServer.SetOutgoingConfig(&config)
+	if err := api.mailServer.SetOutgoingConfig(&config); err != nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(ErrorResponse(ErrorCodeConfigUpdateFailed, err.Error()))
+	}
 
 	return c.JSON(fiber.Map{
 		"code":    SuccessCodeConfigUpdated,
@@ -139,6 +143,8 @@ func (api *API) patchOutgoingConfig(c fiber.Ctx) error {
 	if user, ok := updates["user"].(string); ok {
 		currentConfig.User = user
 	}
+	// PATCH preserves the current password unless the field is present. An
+	// explicit empty string clears it for subsequently accepted relay tasks.
 	if password, ok := updates["password"].(string); ok {
 		currentConfig.Password = password
 	}
@@ -176,7 +182,9 @@ func (api *API) patchOutgoingConfig(c fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse(ErrorCodePortOutOfRange, "Port must be between 1 and 65535"))
 	}
 
-	api.mailServer.SetOutgoingConfig(currentConfig)
+	if err := api.mailServer.SetOutgoingConfig(currentConfig); err != nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(ErrorResponse(ErrorCodeConfigUpdateFailed, err.Error()))
+	}
 
 	return c.JSON(fiber.Map{
 		"code":    SuccessCodeConfigUpdated,

--- a/internal/api/api_config_test.go
+++ b/internal/api/api_config_test.go
@@ -97,7 +97,9 @@ func TestAPIGetOutgoingConfigWithConfig(t *testing.T) {
 		AllowRules:    []string{"allow@example.com"},
 		DenyRules:     []string{"deny@example.com"},
 	}
-	server.SetOutgoingConfig(outgoingConfig)
+	if err := server.SetOutgoingConfig(outgoingConfig); err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("GET", "/api/v1/settings/outgoing", nil)
 	resp, err := api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
@@ -225,7 +227,9 @@ func TestAPIGetConfigWithOutgoing(t *testing.T) {
 		Port:     587,
 		Password: "top-secret",
 	}
-	server.SetOutgoingConfig(outgoingConfig)
+	if err := server.SetOutgoingConfig(outgoingConfig); err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("GET", "/api/v1/settings", nil)
 	resp, err := api.app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})

--- a/internal/api/api_config_test.go
+++ b/internal/api/api_config_test.go
@@ -90,6 +90,7 @@ func TestAPIGetOutgoingConfigWithConfig(t *testing.T) {
 		Host:          "smtp.example.com",
 		Port:          587,
 		User:          "user",
+		Password:      "top-secret",
 		Secure:        true,
 		AutoRelay:     true,
 		AutoRelayAddr: "relay@example.com",
@@ -122,6 +123,9 @@ func TestAPIGetOutgoingConfigWithConfig(t *testing.T) {
 	if response["host"] != "smtp.example.com" {
 		t.Errorf("Expected host smtp.example.com, got %v", response["host"])
 	}
+	if _, exposed := response["password"]; exposed {
+		t.Fatal("outgoing settings response exposed password")
+	}
 }
 
 func TestAPIUpdateOutgoingConfig(t *testing.T) {
@@ -133,10 +137,11 @@ func TestAPIUpdateOutgoingConfig(t *testing.T) {
 	}()
 
 	config := map[string]interface{}{
-		"host":   "smtp.example.com",
-		"port":   587,
-		"user":   "user",
-		"secure": true,
+		"host":     "smtp.example.com",
+		"port":     587,
+		"user":     "user",
+		"password": "top-secret",
+		"secure":   true,
 	}
 	jsonBody, _ := json.Marshal(config)
 
@@ -153,6 +158,9 @@ func TestAPIUpdateOutgoingConfig(t *testing.T) {
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+	if bytes.Contains(body, []byte("password")) || bytes.Contains(body, []byte("top-secret")) {
+		t.Fatal("outgoing update response exposed password")
 	}
 }
 
@@ -213,8 +221,9 @@ func TestAPIGetConfigWithOutgoing(t *testing.T) {
 
 	// Set outgoing config
 	outgoingConfig := &outgoing.OutgoingConfig{
-		Host: "smtp.example.com",
-		Port: 587,
+		Host:     "smtp.example.com",
+		Port:     587,
+		Password: "top-secret",
 	}
 	server.SetOutgoingConfig(outgoingConfig)
 
@@ -238,6 +247,10 @@ func TestAPIGetConfigWithOutgoing(t *testing.T) {
 	}
 	if response["outgoing"] == nil {
 		t.Error("Response should have outgoing field")
+	}
+	outgoingResponse := response["outgoing"].(map[string]interface{})
+	if _, exposed := outgoingResponse["password"]; exposed {
+		t.Fatal("settings response exposed outgoing password")
 	}
 }
 
@@ -273,7 +286,6 @@ func TestAPIGetConfigWithAuth(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("Expected status 200, got %d", resp.StatusCode)
 	}
-
 	var response map[string]interface{}
 	if err := json.Unmarshal(body, &response); err != nil {
 		t.Fatalf("Failed to unmarshal response: %v", err)
@@ -335,7 +347,6 @@ func TestAPIGetConfigWithTLS(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("Expected status 200, got %d", resp.StatusCode)
 	}
-
 	var response map[string]interface{}
 	if err := json.Unmarshal(body, &response); err != nil {
 		t.Fatalf("Failed to unmarshal response: %v", err)
@@ -530,6 +541,9 @@ func TestAPIPatchOutgoingConfigAllFields(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("Expected status 200, got %d", resp.StatusCode)
 	}
+	if bytes.Contains(body, []byte("password")) || bytes.Contains(body, []byte("\"pass\"")) {
+		t.Fatal("outgoing patch response exposed password")
+	}
 }
 
 func TestAPIPatchOutgoingConfigMissingHostAfterPatch(t *testing.T) {
@@ -571,9 +585,10 @@ func TestAPIPatchOutgoingConfigWithExistingConfig(t *testing.T) {
 
 	// First set a config
 	config := map[string]interface{}{
-		"host": "smtp.example.com",
-		"port": 587,
-		"user": "user",
+		"host":     "smtp.example.com",
+		"port":     587,
+		"user":     "user",
+		"password": "old-secret",
 	}
 	jsonBody, _ := json.Marshal(config)
 
@@ -622,6 +637,24 @@ func TestAPIPatchOutgoingConfigWithExistingConfig(t *testing.T) {
 	}
 	if configResp["host"] != "smtp.example.com" {
 		t.Errorf("Expected host to remain smtp.example.com, got %v", configResp["host"])
+	}
+	if got := server.GetOutgoingConfig().Password; got != "old-secret" {
+		t.Fatalf("PATCH without password changed it to %q", got)
+	}
+
+	clearBody, _ := json.Marshal(map[string]interface{}{"password": ""})
+	clearReq, _ := http.NewRequest("PATCH", "/api/v1/settings/outgoing", bytes.NewBuffer(clearBody))
+	clearReq.Header.Set("Content-Type", "application/json")
+	clearResp, clearErr := api.app.Test(clearReq, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
+	if clearErr != nil {
+		t.Fatalf("Clear password request failed: %v", clearErr)
+	}
+	defer func() { _ = clearResp.Body.Close() }()
+	if clearResp.StatusCode != http.StatusOK {
+		t.Fatalf("Clear password status = %d, want 200", clearResp.StatusCode)
+	}
+	if got := server.GetOutgoingConfig().Password; got != "" {
+		t.Fatalf("explicit empty PATCH password was not cleared: %q", got)
 	}
 }
 

--- a/internal/api/api_maildev_compat_test.go
+++ b/internal/api/api_maildev_compat_test.go
@@ -217,7 +217,9 @@ func TestMailDevRESTFacadeOperationsAndErrors(t *testing.T) {
 	assertMailDevError(t, resp, http.StatusNotFound, "Email was not found")
 	resp = compatRequest(t, api, http.MethodPost, "/api/email/three/relay", nil, "")
 	assertMailDevError(t, resp, http.StatusInternalServerError, "Outgoing mail not configured")
-	server.SetOutgoingConfig(&outgoing.OutgoingConfig{Host: "smtp.example", Port: 25})
+	if err := server.SetOutgoingConfig(&outgoing.OutgoingConfig{Host: "smtp.example", Port: 25}); err != nil {
+		t.Fatal(err)
+	}
 	resp = compatRequest(t, api, http.MethodPost, "/api/email/three/relay/not-an-address", nil, "")
 	assertMailDevError(t, resp, http.StatusBadRequest, "Incorrect email address provided: not-an-address")
 

--- a/internal/api/error_codes.go
+++ b/internal/api/error_codes.go
@@ -17,6 +17,7 @@ const (
 	ErrorCodeHostRequired        = "HOST_REQUIRED"
 	ErrorCodePortOutOfRange      = "PORT_OUT_OF_RANGE"
 	ErrorCodeInvalidPort         = "INVALID_PORT"
+	ErrorCodeConfigUpdateFailed  = "CONFIG_UPDATE_FAILED"
 
 	// Relay errors
 	ErrorCodeRelayFailed = "RELAY_FAILED"

--- a/internal/mailserver/lifecycle.go
+++ b/internal/mailserver/lifecycle.go
@@ -64,6 +64,14 @@ func (ms *MailServer) Listen() error {
 // Close stops the SMTP server
 func (ms *MailServer) Close() error {
 	var closeErrors []error
+	// Reject new relay configuration and queue submissions from the start of
+	// shutdown while allowing the current relay instance to drain below.
+	ms.outgoingMutex.Lock()
+	outgoingRelay := ms.outgoing
+	shouldCloseOutgoing := !ms.outgoingClosed
+	ms.outgoingClosed = true
+	ms.outgoingMutex.Unlock()
+
 	// Stop accepting SMTP data before draining dependent delivery services.
 	if ms.smtpsServer != nil {
 		if err := ms.smtpsServer.Close(); err != nil {
@@ -86,8 +94,8 @@ func (ms *MailServer) Close() error {
 			closeErrors = append(closeErrors, err)
 		}
 	}
-	if ms.outgoing != nil {
-		ms.outgoing.Close()
+	if shouldCloseOutgoing && outgoingRelay != nil {
+		outgoingRelay.Close()
 	}
 
 	// Safely close eventChan, handling the case where it's already closed

--- a/internal/mailserver/mailserver_relay_test.go
+++ b/internal/mailserver/mailserver_relay_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/soulteary/owlmail/internal/outgoing"
@@ -216,6 +217,53 @@ func TestSetOutgoingConfigUpdate(t *testing.T) {
 	}
 	if retrieved.Port != config2.Port {
 		t.Errorf("Expected port %d, got %d", config2.Port, retrieved.Port)
+	}
+}
+
+func TestOutgoingConfigRelayAndCloseAreConcurrentSafe(t *testing.T) {
+	server, err := NewMailServer(1025, "localhost", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.SetOutgoingConfig(&outgoing.OutgoingConfig{Host: "smtp.example.test", Port: 25}); err != nil {
+		t.Fatal(err)
+	}
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			config := &outgoing.OutgoingConfig{}
+			if i%2 == 0 {
+				config = &outgoing.OutgoingConfig{Host: "smtp.example.test", Port: 25, Password: "secret"}
+			}
+			_ = server.SetOutgoingConfig(config)
+		}(i)
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = server.RelayMailTo(&Email{ID: "missing"}, "to@example.test", func(error) {})
+			_ = server.GetOutgoingConfig()
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		_ = server.Close()
+	}()
+
+	close(start)
+	wg.Wait()
+
+	if err := server.SetOutgoingConfig(&outgoing.OutgoingConfig{Host: "smtp.example.test", Port: 25}); !errors.Is(err, outgoing.ErrClosed) {
+		t.Fatalf("SetOutgoingConfig() after Close error = %v, want %v", err, outgoing.ErrClosed)
+	}
+	if err := server.RelayMailTo(&Email{ID: "missing"}, "to@example.test", nil); !errors.Is(err, outgoing.ErrClosed) {
+		t.Fatalf("RelayMailTo() after Close error = %v, want %v", err, outgoing.ErrClosed)
 	}
 }
 

--- a/internal/mailserver/mailserver_relay_test.go
+++ b/internal/mailserver/mailserver_relay_test.go
@@ -32,7 +32,9 @@ func TestMailServerSetOutgoingConfig(t *testing.T) {
 		Password: "pass",
 	}
 
-	server.SetOutgoingConfig(config)
+	if err := server.SetOutgoingConfig(config); err != nil {
+		t.Fatal(err)
+	}
 
 	// Get config
 	retrieved := server.GetOutgoingConfig()
@@ -87,7 +89,9 @@ func TestRelayMail(t *testing.T) {
 		Host: "smtp.example.com",
 		Port: 587,
 	}
-	server.SetOutgoingConfig(outgoingConfig)
+	if err := server.SetOutgoingConfig(outgoingConfig); err != nil {
+		t.Fatal(err)
+	}
 
 	// RelayMail will queue the task, but actual relay will fail in test
 	// We can test that it doesn't panic
@@ -141,7 +145,9 @@ func TestRelayMailTo(t *testing.T) {
 		Host: "smtp.example.com",
 		Port: 587,
 	}
-	server.SetOutgoingConfig(outgoingConfig)
+	if err := server.SetOutgoingConfig(outgoingConfig); err != nil {
+		t.Fatal(err)
+	}
 
 	// RelayMailTo will queue the task, but actual relay will fail in test
 	// We can test that it doesn't panic
@@ -196,7 +202,9 @@ func TestSetOutgoingConfigUpdate(t *testing.T) {
 		User:     "user1",
 		Password: "pass1",
 	}
-	server.SetOutgoingConfig(config1)
+	if err := server.SetOutgoingConfig(config1); err != nil {
+		t.Fatal(err)
+	}
 
 	// Update config (test the else branch in SetOutgoingConfig)
 	config2 := &outgoing.OutgoingConfig{
@@ -205,7 +213,9 @@ func TestSetOutgoingConfigUpdate(t *testing.T) {
 		User:     "user2",
 		Password: "pass2",
 	}
-	server.SetOutgoingConfig(config2)
+	if err := server.SetOutgoingConfig(config2); err != nil {
+		t.Fatal(err)
+	}
 
 	// Verify config was updated
 	retrieved := server.GetOutgoingConfig()

--- a/internal/mailserver/relay.go
+++ b/internal/mailserver/relay.go
@@ -10,24 +10,36 @@ import (
 
 // RelayMail relays an email to the configured SMTP server
 func (ms *MailServer) RelayMail(email *Email, isAutoRelay bool, callback func(error)) error {
-	if ms.outgoing == nil {
-		return fmt.Errorf("outgoing mail not configured")
+	ms.outgoingMutex.RLock()
+	outgoingRelay := ms.outgoing
+	closed := ms.outgoingClosed
+	ms.outgoingMutex.RUnlock()
+	if closed {
+		return outgoing.ErrClosed
+	}
+	if outgoingRelay == nil {
+		return outgoing.ErrNotConfigured
 	}
 
 	emlPath := filepath.Join(ms.mailDir, email.ID+".eml")
-	ms.outgoing.RelayMail(email, emlPath, "", isAutoRelay, callback)
-	return nil
+	return outgoingRelay.RelayMail(email, emlPath, "", isAutoRelay, callback)
 }
 
 // RelayMailTo relays an email to a specific address
 func (ms *MailServer) RelayMailTo(email *Email, relayTo string, callback func(error)) error {
-	if ms.outgoing == nil {
-		return fmt.Errorf("outgoing mail not configured")
+	ms.outgoingMutex.RLock()
+	outgoingRelay := ms.outgoing
+	closed := ms.outgoingClosed
+	ms.outgoingMutex.RUnlock()
+	if closed {
+		return outgoing.ErrClosed
+	}
+	if outgoingRelay == nil {
+		return outgoing.ErrNotConfigured
 	}
 
 	emlPath := filepath.Join(ms.mailDir, email.ID+".eml")
-	ms.outgoing.RelayMail(email, emlPath, relayTo, false, callback)
-	return nil
+	return outgoingRelay.RelayMail(email, emlPath, relayTo, false, callback)
 }
 
 // RelayMailAndWait relays one message and waits for the outgoing worker's
@@ -38,15 +50,24 @@ func (ms *MailServer) RelayMailAndWait(ctx context.Context, email *Email, relayT
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if ms.outgoing == nil {
-		return fmt.Errorf("outgoing mail not configured")
+	ms.outgoingMutex.RLock()
+	outgoingRelay := ms.outgoing
+	closed := ms.outgoingClosed
+	ms.outgoingMutex.RUnlock()
+	if closed {
+		return outgoing.ErrClosed
+	}
+	if outgoingRelay == nil {
+		return outgoing.ErrNotConfigured
 	}
 	result := make(chan error, 1)
 	callback := func(err error) {
 		result <- err
 	}
 	emlPath := filepath.Join(ms.mailDir, email.ID+".eml")
-	ms.outgoing.RelayMailContext(ctx, email, emlPath, relayTo, false, callback)
+	if err := outgoingRelay.RelayMailContext(ctx, email, emlPath, relayTo, false, callback); err != nil {
+		return err
+	}
 	return waitRelayResult(ctx, result)
 }
 
@@ -60,21 +81,44 @@ func waitRelayResult(ctx context.Context, result <-chan error) error {
 }
 
 // SetOutgoingConfig sets the outgoing mail configuration
-func (ms *MailServer) SetOutgoingConfig(config *outgoing.OutgoingConfig) {
-	if ms.outgoing == nil {
-		ms.outgoing = outgoing.NewOutgoingMail(config)
-	} else {
-		ms.outgoing.UpdateConfig(config)
+func (ms *MailServer) SetOutgoingConfig(config *outgoing.OutgoingConfig) error {
+	ms.outgoingMutex.Lock()
+	defer ms.outgoingMutex.Unlock()
+	if ms.outgoingClosed {
+		return outgoing.ErrClosed
 	}
+	if ms.outgoing == nil {
+		outgoingRelay := outgoing.NewOutgoingMail(nil)
+		if err := outgoingRelay.UpdateConfig(config); err != nil {
+			outgoingRelay.Close()
+			return err
+		}
+		ms.outgoing = outgoingRelay
+		return nil
+	}
+	return ms.outgoing.UpdateConfig(config)
 }
 
 // GetOutgoingConfig returns the outgoing mail configuration
 func (ms *MailServer) GetOutgoingConfig() *outgoing.OutgoingConfig {
-	if ms.outgoing == nil {
+	ms.outgoingMutex.RLock()
+	outgoingRelay := ms.outgoing
+	ms.outgoingMutex.RUnlock()
+	if outgoingRelay == nil {
 		return nil
 	}
-	if config, ok := ms.outgoing.GetConfig().(*outgoing.OutgoingConfig); ok {
+	if config, ok := outgoingRelay.GetConfig().(*outgoing.OutgoingConfig); ok {
 		return config
 	}
 	return nil
+}
+
+// IsAutoRelayEnabled reports whether the current immutable configuration
+// enables automatic relay without exposing the relay implementation pointer.
+func (ms *MailServer) IsAutoRelayEnabled() bool {
+	ms.outgoingMutex.RLock()
+	outgoingRelay := ms.outgoing
+	closed := ms.outgoingClosed
+	ms.outgoingMutex.RUnlock()
+	return !closed && outgoingRelay != nil && outgoingRelay.IsAutoRelayEnabled()
 }

--- a/internal/mailserver/store.go
+++ b/internal/mailserver/store.go
@@ -142,7 +142,7 @@ func (ms *MailServer) saveEmailToStore(id string, isRead bool, envelope *Envelop
 	ms.emitAsynchronous("new", storedEmail)
 
 	// Auto relay if enabled
-	if ms.outgoing != nil && ms.outgoing.IsAutoRelayEnabled() {
+	if ms.IsAutoRelayEnabled() {
 		if err := ms.RelayMail(cloneEmail(storedEmail), true, func(err error) {
 			if err != nil {
 				common.Error("Error when auto-relaying email: %v", err)

--- a/internal/mailserver/types.go
+++ b/internal/mailserver/types.go
@@ -119,13 +119,15 @@ type MailServer struct {
 	closers                 []io.Closer
 	closersMutex            sync.Mutex
 	outgoing                interface {
-		RelayMail(email *types.Email, emlPath, relayTo string, isAutoRelay bool, callback func(error))
-		RelayMailContext(ctx context.Context, email *types.Email, emlPath, relayTo string, isAutoRelay bool, callback func(error))
-		UpdateConfig(config interface{})
+		RelayMail(email *types.Email, emlPath, relayTo string, isAutoRelay bool, callback func(error)) error
+		RelayMailContext(ctx context.Context, email *types.Email, emlPath, relayTo string, isAutoRelay bool, callback func(error)) error
+		UpdateConfig(config interface{}) error
 		GetConfig() interface{}
 		IsAutoRelayEnabled() bool
 		Close()
 	}
+	outgoingMutex       sync.RWMutex
+	outgoingClosed      bool
 	authConfig          *SMTPAuthConfig
 	authVerifier        *credentialVerifier
 	authRequireTLS      bool

--- a/internal/outgoing/lifecycle_test.go
+++ b/internal/outgoing/lifecycle_test.go
@@ -1,6 +1,7 @@
 package outgoing
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -190,4 +191,27 @@ func TestOutgoingMailConcurrentUpdateEnqueueAndClose(t *testing.T) {
 	if callbackErr := <-callback; !errors.Is(callbackErr, ErrClosed) {
 		t.Fatalf("callback after Close error = %v, want %v", callbackErr, ErrClosed)
 	}
+}
+
+func TestRejectedRelayCallbackCanClose(t *testing.T) {
+	om := NewOutgoingMail(&OutgoingConfig{Host: "smtp.example.test", Port: 25})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	done := make(chan error, 1)
+
+	go func() {
+		done <- om.RelayMailContext(ctx, &types.Email{}, "/missing", "to@example.test", false, func(error) {
+			om.Close()
+		})
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("RelayMailContext() error = %v, want context cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("rejection callback deadlocked while closing relay")
+	}
+	om.Close()
 }

--- a/internal/outgoing/lifecycle_test.go
+++ b/internal/outgoing/lifecycle_test.go
@@ -1,0 +1,193 @@
+package outgoing
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/soulteary/owlmail/internal/types"
+)
+
+func TestOutgoingMailDynamicEnableStartsWorker(t *testing.T) {
+	om := NewOutgoingMail(nil)
+	defer om.Close()
+
+	if err := om.UpdateConfig(&OutgoingConfig{Host: "smtp.example.test", Port: 25}); err != nil {
+		t.Fatal(err)
+	}
+	result := make(chan error, 1)
+	err := om.RelayMail(&types.Email{
+		Envelope: &types.Envelope{To: []string{"to@example.test"}},
+	}, "/missing", "", false, func(err error) { result <- err })
+	if err != nil {
+		t.Fatalf("RelayMail() error = %v", err)
+	}
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("worker returned nil for a missing message file")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("worker did not consume task after dynamic enable")
+	}
+}
+
+func TestOutgoingMailConfigSnapshotsAndDisableSemantics(t *testing.T) {
+	source := &OutgoingConfig{
+		Host:       "old.example.test",
+		Port:       25,
+		Password:   "old-secret",
+		AllowRules: []string{"*@example.test"},
+	}
+	copyingRelay := NewOutgoingMail(source)
+
+	// Neither constructor/update inputs nor returned snapshots may alias the
+	// relay's immutable internal configuration.
+	source.Host = "mutated.example.test"
+	source.AllowRules[0] = "mutated"
+	got := copyingRelay.GetConfig().(*OutgoingConfig)
+	got.Host = "escaped.example.test"
+	got.AllowRules[0] = "escaped"
+	again := copyingRelay.GetConfig().(*OutgoingConfig)
+	if again.Host != "old.example.test" || again.AllowRules[0] != "*@example.test" {
+		t.Fatalf("internal config was mutated through an external pointer: %#v", again)
+	}
+	copyingRelay.Close()
+
+	om := &OutgoingMail{
+		config:         cloneConfig(again),
+		queue:          make(chan *RelayTask, 2),
+		workerCount:    1,
+		enqueueTimeout: time.Second,
+		enabled:        true,
+		workerStarted:  true,
+		closing:        make(chan struct{}),
+		stop:           make(chan struct{}),
+	}
+	defer om.Close()
+
+	if err := om.RelayMail(&types.Email{}, "/missing", "to@example.test", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := om.UpdateConfig(&OutgoingConfig{
+		Host:       "new.example.test",
+		Port:       587,
+		Password:   "new-secret",
+		AllowRules: []string{"*@new.example.test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	queued := <-om.queue
+	if queued.config.Host != "old.example.test" || queued.config.Password != "old-secret" {
+		t.Fatalf("queued task config = %#v, want original atomic snapshot", queued.config)
+	}
+
+	if err := om.UpdateConfig(&OutgoingConfig{}); err != nil {
+		t.Fatal(err)
+	}
+	callback := make(chan error, 1)
+	err := om.RelayMail(&types.Email{}, "/missing", "to@example.test", false, func(err error) {
+		callback <- err
+	})
+	if !errors.Is(err, ErrNotConfigured) {
+		t.Fatalf("disabled RelayMail() error = %v, want %v", err, ErrNotConfigured)
+	}
+	if callbackErr := <-callback; !errors.Is(callbackErr, ErrNotConfigured) {
+		t.Fatalf("disabled callback error = %v, want %v", callbackErr, ErrNotConfigured)
+	}
+}
+
+func TestOutgoingMailRejectedUpdatePreservesConfig(t *testing.T) {
+	om := NewOutgoingMail(&OutgoingConfig{Host: "smtp.example.test", Port: 25, Password: "secret"})
+	defer om.Close()
+
+	if err := om.UpdateConfig(&OutgoingConfig{Host: "invalid.example.test", Port: 0}); err == nil {
+		t.Fatal("UpdateConfig() accepted an invalid enabled configuration")
+	}
+	got := om.GetConfig().(*OutgoingConfig)
+	if got.Host != "smtp.example.test" || got.Port != 25 || got.Password != "secret" {
+		t.Fatalf("failed update changed config: %#v", got)
+	}
+}
+
+func TestOutgoingMailQueueFull(t *testing.T) {
+	om := &OutgoingMail{
+		config:         &OutgoingConfig{Host: "smtp.example.test", Port: 25},
+		queue:          make(chan *RelayTask, 1),
+		workerCount:    1,
+		enqueueTimeout: 10 * time.Millisecond,
+		enabled:        true,
+		workerStarted:  true,
+		closing:        make(chan struct{}),
+		stop:           make(chan struct{}),
+	}
+	defer om.Close()
+
+	if err := om.RelayMail(&types.Email{}, "/missing", "to@example.test", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	callback := make(chan error, 1)
+	err := om.RelayMail(&types.Email{}, "/missing", "to@example.test", false, func(err error) {
+		callback <- err
+	})
+	if !errors.Is(err, ErrQueueFull) {
+		t.Fatalf("RelayMail() error = %v, want %v", err, ErrQueueFull)
+	}
+	if callbackErr := <-callback; !errors.Is(callbackErr, ErrQueueFull) {
+		t.Fatalf("callback error = %v, want %v", callbackErr, ErrQueueFull)
+	}
+}
+
+func TestOutgoingMailConcurrentUpdateEnqueueAndClose(t *testing.T) {
+	om := NewOutgoingMail(nil)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := 0; i < 32; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			config := &OutgoingConfig{}
+			if i%3 != 0 {
+				config = &OutgoingConfig{Host: "smtp.example.test", Port: 25, Password: "secret"}
+			}
+			_ = om.UpdateConfig(config)
+		}(i)
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = om.RelayMail(&types.Email{}, "/missing", "to@example.test", false, func(error) {})
+		}()
+	}
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		om.Close()
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		om.Close()
+	}()
+
+	close(start)
+	wg.Wait()
+	om.Close()
+
+	if err := om.UpdateConfig(&OutgoingConfig{Host: "smtp.example.test", Port: 25}); !errors.Is(err, ErrClosed) {
+		t.Fatalf("UpdateConfig() after Close error = %v, want %v", err, ErrClosed)
+	}
+	callback := make(chan error, 1)
+	err := om.RelayMail(&types.Email{}, "/missing", "to@example.test", false, func(err error) {
+		callback <- err
+	})
+	if !errors.Is(err, ErrClosed) {
+		t.Fatalf("RelayMail() after Close error = %v, want %v", err, ErrClosed)
+	}
+	if callbackErr := <-callback; !errors.Is(callbackErr, ErrClosed) {
+		t.Fatalf("callback after Close error = %v, want %v", callbackErr, ErrClosed)
+	}
+}

--- a/internal/outgoing/outgoing.go
+++ b/internal/outgoing/outgoing.go
@@ -337,7 +337,15 @@ func (om *OutgoingMail) enqueueRelay(ctx context.Context, contextAware bool, ema
 	config := cloneConfig(om.config)
 	om.enqueueWG.Add(1)
 	om.mu.Unlock()
-	defer om.enqueueWG.Done()
+	finishEnqueue := func(err error) error {
+		// Release the lifecycle slot before invoking callbacks. A callback is
+		// allowed to close the relay, and Close waits for these slots to drain.
+		om.enqueueWG.Done()
+		if err != nil {
+			return relayRejected(callback, err)
+		}
+		return nil
+	}
 
 	task := &RelayTask{
 		Email:       email,
@@ -350,7 +358,7 @@ func (om *OutgoingMail) enqueueRelay(ctx context.Context, contextAware bool, ema
 	if contextAware {
 		task.Context = ctx
 		if err := ctx.Err(); err != nil {
-			return relayRejected(callback, err)
+			return finishEnqueue(err)
 		}
 	}
 
@@ -362,13 +370,13 @@ func (om *OutgoingMail) enqueueRelay(ctx context.Context, contextAware bool, ema
 	}
 	select {
 	case om.queue <- task:
-		return nil
+		return finishEnqueue(nil)
 	case <-timer.C:
-		return relayRejected(callback, ErrQueueFull)
+		return finishEnqueue(ErrQueueFull)
 	case <-om.closing:
-		return relayRejected(callback, ErrClosed)
+		return finishEnqueue(ErrClosed)
 	case <-canceled:
-		return relayRejected(callback, ctx.Err())
+		return finishEnqueue(ctx.Err())
 	}
 }
 

--- a/internal/outgoing/outgoing.go
+++ b/internal/outgoing/outgoing.go
@@ -3,6 +3,7 @@ package outgoing
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -15,6 +16,17 @@ import (
 	"github.com/soulteary/owlmail/internal/common"
 	"github.com/soulteary/owlmail/internal/types"
 )
+
+var (
+	// ErrNotConfigured is returned when relay is disabled because no host is set.
+	ErrNotConfigured = errors.New("outgoing mail not configured")
+	// ErrQueueFull is returned when a relay task cannot be queued before the timeout.
+	ErrQueueFull = errors.New("relay queue is full")
+	// ErrClosed is returned when work is submitted after the relay has begun closing.
+	ErrClosed = errors.New("outgoing mail is closed")
+)
+
+const defaultEnqueueTimeout = 5 * time.Second
 
 // OutgoingConfig represents the configuration for outgoing mail
 type OutgoingConfig struct {
@@ -31,12 +43,19 @@ type OutgoingConfig struct {
 
 // OutgoingMail handles outgoing email relay
 type OutgoingMail struct {
-	config      *OutgoingConfig
-	queue       chan *RelayTask
-	workerCount int
-	wg          sync.WaitGroup
-	mu          sync.RWMutex
-	enabled     bool
+	config         *OutgoingConfig
+	queue          chan *RelayTask
+	workerCount    int
+	enqueueTimeout time.Duration
+	wg             sync.WaitGroup
+	enqueueWG      sync.WaitGroup
+	mu             sync.RWMutex
+	enabled        bool
+	workerStarted  bool
+	closed         bool
+	closing        chan struct{}
+	stop           chan struct{}
+	closeOnce      sync.Once
 }
 
 // RelayTask represents a task to relay an email
@@ -47,27 +66,25 @@ type RelayTask struct {
 	IsAutoRelay bool
 	Callback    func(error)
 	Context     context.Context
+	config      *OutgoingConfig
 }
 
 // NewOutgoingMail creates a new outgoing mail handler
 func NewOutgoingMail(config *OutgoingConfig) *OutgoingMail {
-	if config == nil {
-		config = &OutgoingConfig{}
-	}
+	config = cloneConfig(config)
 
 	om := &OutgoingMail{
-		config:      config,
-		queue:       make(chan *RelayTask, 100),
-		workerCount: 1,
-		enabled:     config.Host != "",
+		config:         config,
+		queue:          make(chan *RelayTask, 100),
+		workerCount:    1,
+		enqueueTimeout: defaultEnqueueTimeout,
+		enabled:        config.Host != "",
+		closing:        make(chan struct{}),
+		stop:           make(chan struct{}),
 	}
 
 	if om.enabled {
-		// Start worker goroutines
-		for i := 0; i < om.workerCount; i++ {
-			om.wg.Add(1)
-			go om.worker()
-		}
+		om.startWorkersLocked()
 	}
 
 	return om
@@ -77,11 +94,40 @@ func NewOutgoingMail(config *OutgoingConfig) *OutgoingMail {
 func (om *OutgoingMail) worker() {
 	defer om.wg.Done()
 
-	for task := range om.queue {
-		err := om.relayEmail(task)
-		if task.Callback != nil {
-			task.Callback(err)
+	for {
+		select {
+		case task := <-om.queue:
+			om.processTask(task)
+		case <-om.stop:
+			// Close waits for active enqueue operations before signaling stop,
+			// so the queue is stable and can be drained without closing it.
+			for {
+				select {
+				case task := <-om.queue:
+					om.processTask(task)
+				default:
+					return
+				}
+			}
 		}
+	}
+}
+
+func (om *OutgoingMail) processTask(task *RelayTask) {
+	err := om.relayEmail(task)
+	if task.Callback != nil {
+		task.Callback(err)
+	}
+}
+
+func (om *OutgoingMail) startWorkersLocked() {
+	if om.workerStarted || om.closed {
+		return
+	}
+	om.workerStarted = true
+	for i := 0; i < om.workerCount; i++ {
+		om.wg.Add(1)
+		go om.worker()
 	}
 }
 
@@ -92,12 +138,16 @@ func (om *OutgoingMail) relayEmail(task *RelayTask) error {
 			return err
 		}
 	}
-	if !om.enabled {
-		return fmt.Errorf("outgoing mail not configured")
+	config := task.config
+	if config == nil {
+		config = om.configSnapshot()
+	}
+	if config.Host == "" {
+		return ErrNotConfigured
 	}
 
 	// Determine recipients
-	recipients := om.getRecipients(task)
+	recipients := getRecipients(task, config)
 	if len(recipients) == 0 {
 		return fmt.Errorf("email had no recipients")
 	}
@@ -130,16 +180,16 @@ func (om *OutgoingMail) relayEmail(task *RelayTask) error {
 
 	// Prepare SMTP auth
 	var auth smtp.Auth
-	if om.config.User != "" && om.config.Password != "" {
-		auth = smtp.PlainAuth("", om.config.User, om.config.Password, om.config.Host)
+	if config.User != "" && config.Password != "" {
+		auth = smtp.PlainAuth("", config.User, config.Password, config.Host)
 	}
 
 	// Send email using net/smtp
-	addr := fmt.Sprintf("%s:%d", om.config.Host, om.config.Port)
+	addr := fmt.Sprintf("%s:%d", config.Host, config.Port)
 
 	if task.Context != nil {
-		err = sendMailContext(task.Context, addr, auth, sender, recipients, emailData, om.config.Secure)
-	} else if om.config.Secure {
+		err = sendMailContext(task.Context, addr, auth, sender, recipients, emailData, config.Secure)
+	} else if config.Secure {
 		// Use TLS
 		err = sendMailTLS(addr, auth, sender, recipients, emailData)
 	} else {
@@ -157,6 +207,14 @@ func (om *OutgoingMail) relayEmail(task *RelayTask) error {
 
 // getRecipients determines the recipients for relay
 func (om *OutgoingMail) getRecipients(task *RelayTask) []string {
+	config := task.config
+	if config == nil {
+		config = om.configSnapshot()
+	}
+	return getRecipients(task, config)
+}
+
+func getRecipients(task *RelayTask, config *OutgoingConfig) []string {
 	var recipients []string
 
 	// If manual relay with specific address
@@ -165,8 +223,8 @@ func (om *OutgoingMail) getRecipients(task *RelayTask) []string {
 	}
 
 	// If auto relay mode with specific address
-	if task.IsAutoRelay && om.config.AutoRelayAddr != "" {
-		return []string{om.config.AutoRelayAddr}
+	if task.IsAutoRelay && config.AutoRelayAddr != "" {
+		return []string{config.AutoRelayAddr}
 	}
 
 	// Get recipients from envelope
@@ -175,8 +233,8 @@ func (om *OutgoingMail) getRecipients(task *RelayTask) []string {
 	}
 
 	// Apply allow/deny rules
-	if len(om.config.AllowRules) > 0 || len(om.config.DenyRules) > 0 {
-		recipients = om.filterRecipients(recipients)
+	if len(config.AllowRules) > 0 || len(config.DenyRules) > 0 {
+		recipients = filterRecipients(recipients, config)
 	}
 
 	return recipients
@@ -185,23 +243,27 @@ func (om *OutgoingMail) getRecipients(task *RelayTask) []string {
 // filterRecipients applies allow/deny rules to recipients
 // Rules are processed in order, and the last matching rule wins (like MailDev)
 func (om *OutgoingMail) filterRecipients(recipients []string) []string {
+	return filterRecipients(recipients, om.configSnapshot())
+}
+
+func filterRecipients(recipients []string, config *OutgoingConfig) []string {
 	filtered := make([]string, 0)
 
 	for _, recipient := range recipients {
 		// Process all rules in order to find the last matching rule
 		// Start with default: allow if no allow rules, deny if allow rules exist
-		result := len(om.config.AllowRules) == 0
+		result := len(config.AllowRules) == 0
 
 		// Process deny rules
-		for _, rule := range om.config.DenyRules {
-			if om.matchesRule(recipient, rule) {
+		for _, rule := range config.DenyRules {
+			if matchesRule(recipient, rule) {
 				result = false // Deny if matched
 			}
 		}
 
 		// Process allow rules (can override deny)
-		for _, rule := range om.config.AllowRules {
-			if om.matchesRule(recipient, rule) {
+		for _, rule := range config.AllowRules {
+			if matchesRule(recipient, rule) {
 				result = true // Allow if matched
 			}
 		}
@@ -216,6 +278,10 @@ func (om *OutgoingMail) filterRecipients(recipients []string) []string {
 
 // matchesRule checks if an address matches a rule pattern
 func (om *OutgoingMail) matchesRule(address, rule string) bool {
+	return matchesRule(address, rule)
+}
+
+func matchesRule(address, rule string) bool {
 	// Simple pattern matching: supports * wildcard
 	pattern := strings.ToLower(rule)
 	addr := strings.ToLower(address)
@@ -245,26 +311,33 @@ func (om *OutgoingMail) matchesRule(address, rule string) bool {
 }
 
 // RelayMail queues an email for relay
-func (om *OutgoingMail) RelayMail(email *types.Email, emailPath string, relayTo string, isAutoRelay bool, callback func(error)) {
-	om.enqueueRelay(context.Background(), false, email, emailPath, relayTo, isAutoRelay, callback)
+func (om *OutgoingMail) RelayMail(email *types.Email, emailPath string, relayTo string, isAutoRelay bool, callback func(error)) error {
+	return om.enqueueRelay(context.Background(), false, email, emailPath, relayTo, isAutoRelay, callback)
 }
 
 // RelayMailContext queues an email relay that is canceled if the caller's
 // context expires while the task is queued or in progress.
-func (om *OutgoingMail) RelayMailContext(ctx context.Context, email *types.Email, emailPath string, relayTo string, isAutoRelay bool, callback func(error)) {
+func (om *OutgoingMail) RelayMailContext(ctx context.Context, email *types.Email, emailPath string, relayTo string, isAutoRelay bool, callback func(error)) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	om.enqueueRelay(ctx, true, email, emailPath, relayTo, isAutoRelay, callback)
+	return om.enqueueRelay(ctx, true, email, emailPath, relayTo, isAutoRelay, callback)
 }
 
-func (om *OutgoingMail) enqueueRelay(ctx context.Context, contextAware bool, email *types.Email, emailPath string, relayTo string, isAutoRelay bool, callback func(error)) {
-	if !om.enabled {
-		if callback != nil {
-			callback(fmt.Errorf("outgoing mail not configured"))
-		}
-		return
+func (om *OutgoingMail) enqueueRelay(ctx context.Context, contextAware bool, email *types.Email, emailPath string, relayTo string, isAutoRelay bool, callback func(error)) error {
+	om.mu.Lock()
+	if om.closed {
+		om.mu.Unlock()
+		return relayRejected(callback, ErrClosed)
 	}
+	if !om.enabled {
+		om.mu.Unlock()
+		return relayRejected(callback, ErrNotConfigured)
+	}
+	config := cloneConfig(om.config)
+	om.enqueueWG.Add(1)
+	om.mu.Unlock()
+	defer om.enqueueWG.Done()
 
 	task := &RelayTask{
 		Email:       email,
@@ -272,18 +345,16 @@ func (om *OutgoingMail) enqueueRelay(ctx context.Context, contextAware bool, ema
 		RelayTo:     relayTo,
 		IsAutoRelay: isAutoRelay,
 		Callback:    callback,
+		config:      config,
 	}
 	if contextAware {
 		task.Context = ctx
 		if err := ctx.Err(); err != nil {
-			if callback != nil {
-				callback(err)
-			}
-			return
+			return relayRejected(callback, err)
 		}
 	}
 
-	timer := time.NewTimer(5 * time.Second)
+	timer := time.NewTimer(om.enqueueTimeout)
 	defer timer.Stop()
 	var canceled <-chan struct{}
 	if contextAware {
@@ -291,17 +362,21 @@ func (om *OutgoingMail) enqueueRelay(ctx context.Context, contextAware bool, ema
 	}
 	select {
 	case om.queue <- task:
-		// Task queued successfully
+		return nil
 	case <-timer.C:
-		// Queue full, call callback with error
-		if callback != nil {
-			callback(fmt.Errorf("relay queue is full"))
-		}
+		return relayRejected(callback, ErrQueueFull)
+	case <-om.closing:
+		return relayRejected(callback, ErrClosed)
 	case <-canceled:
-		if callback != nil {
-			callback(ctx.Err())
-		}
+		return relayRejected(callback, ctx.Err())
 	}
+}
+
+func relayRejected(callback func(error), err error) error {
+	if callback != nil {
+		callback(err)
+	}
+	return err
 }
 
 // IsAutoRelayEnabled checks if auto relay is enabled
@@ -311,28 +386,70 @@ func (om *OutgoingMail) IsAutoRelayEnabled() bool {
 	return om.enabled && om.config.AutoRelay
 }
 
-// UpdateConfig updates the outgoing mail configuration
-func (om *OutgoingMail) UpdateConfig(config interface{}) {
+// UpdateConfig atomically replaces the outgoing mail configuration. An empty
+// host disables new submissions; already queued tasks retain the snapshot they
+// were accepted with. Re-enabling starts the worker once, and an empty password
+// explicitly disables authentication for subsequently accepted tasks.
+func (om *OutgoingMail) UpdateConfig(config interface{}) error {
+	cfg, ok := config.(*OutgoingConfig)
+	if !ok {
+		return fmt.Errorf("invalid outgoing mail configuration type %T", config)
+	}
+	next := cloneConfig(cfg)
+	if next.Host != "" && (next.Port <= 0 || next.Port > 65535) {
+		return fmt.Errorf("outgoing mail port must be between 1 and 65535")
+	}
+
 	om.mu.Lock()
 	defer om.mu.Unlock()
-
-	if cfg, ok := config.(*OutgoingConfig); ok {
-		om.config = cfg
-		om.enabled = cfg.Host != ""
+	if om.closed {
+		return ErrClosed
 	}
+	om.config = next
+	om.enabled = next.Host != ""
+	if om.enabled {
+		om.startWorkersLocked()
+	}
+	return nil
 }
 
 // GetConfig returns the current configuration
 func (om *OutgoingMail) GetConfig() interface{} {
-	om.mu.RLock()
-	defer om.mu.RUnlock()
-	return om.config
+	return om.configSnapshot()
 }
 
-// Close stops the outgoing mail handler
+func (om *OutgoingMail) configSnapshot() *OutgoingConfig {
+	om.mu.RLock()
+	defer om.mu.RUnlock()
+	return cloneConfig(om.config)
+}
+
+func cloneConfig(config *OutgoingConfig) *OutgoingConfig {
+	if config == nil {
+		return &OutgoingConfig{}
+	}
+	clone := *config
+	clone.AllowRules = append([]string(nil), config.AllowRules...)
+	clone.DenyRules = append([]string(nil), config.DenyRules...)
+	return &clone
+}
+
+// Close rejects new work, lets accepted enqueue operations finish, drains the
+// stable queue, and stops the worker. It is safe to call more than once.
 func (om *OutgoingMail) Close() {
-	close(om.queue)
-	om.wg.Wait()
+	om.closeOnce.Do(func() {
+		om.mu.Lock()
+		om.closed = true
+		om.enabled = false
+		close(om.closing)
+		om.mu.Unlock()
+
+		// No new enqueue operation can increment enqueueWG after closed is set.
+		// Waiting here guarantees that workers see a stable queue before draining.
+		om.enqueueWG.Wait()
+		close(om.stop)
+		om.wg.Wait()
+	})
 }
 
 // sendMailTLS sends email using TLS

--- a/internal/outgoing/outgoing_test.go
+++ b/internal/outgoing/outgoing_test.go
@@ -30,9 +30,12 @@ func TestRelayMailContextDoesNotQueueCanceledTask(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	called := make(chan error, 1)
-	om.RelayMailContext(ctx, &types.Email{}, "/missing", "", false, func(err error) {
+	err := om.RelayMailContext(ctx, &types.Email{}, "/missing", "", false, func(err error) {
 		called <- err
 	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("RelayMailContext() error = %v, want context cancellation", err)
+	}
 	if len(om.queue) != 0 {
 		t.Fatal("canceled relay task was queued")
 	}
@@ -211,17 +214,21 @@ func TestOutgoingMailIsAutoRelayEnabled(t *testing.T) {
 	}
 
 	// Test with AutoRelay disabled
-	om.UpdateConfig(&OutgoingConfig{
+	if err := om.UpdateConfig(&OutgoingConfig{
 		Host:      "smtp.example.com",
 		Port:      587,
 		AutoRelay: false,
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 	if om.IsAutoRelayEnabled() {
 		t.Error("IsAutoRelayEnabled should return false when AutoRelay is disabled")
 	}
 
 	// Test with no host
-	om.UpdateConfig(&OutgoingConfig{})
+	if err := om.UpdateConfig(&OutgoingConfig{}); err != nil {
+		t.Fatal(err)
+	}
 	if om.IsAutoRelayEnabled() {
 		t.Error("IsAutoRelayEnabled should return false when host is empty")
 	}
@@ -243,7 +250,9 @@ func TestOutgoingMailUpdateConfig(t *testing.T) {
 		DenyRules:     []string{"*@test.com"},
 	}
 
-	om.UpdateConfig(newConfig)
+	if err := om.UpdateConfig(newConfig); err != nil {
+		t.Fatal(err)
+	}
 	config := om.GetConfig()
 	cfg, ok := config.(*OutgoingConfig)
 	if !ok {
@@ -495,13 +504,15 @@ func TestOutgoingMailRelayMail(t *testing.T) {
 	}
 
 	callbackCalled := make(chan bool, 1)
-	om.RelayMail(email, "/path/to/email.eml", "", false, func(err error) {
+	if err := om.RelayMail(email, "/path/to/email.eml", "", false, func(err error) {
 		callbackCalled <- true
 		// Should fail because file doesn't exist
 		if err == nil {
 			t.Error("Expected error when file doesn't exist")
 		}
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	// Wait for callback
 	select {
@@ -520,13 +531,15 @@ func TestOutgoingMailRelayMail(t *testing.T) {
 		},
 	}
 	callbackCalled2 := make(chan bool, 1)
-	om.RelayMail(emailNoRecipients, "/path/to/email.eml", "", false, func(err error) {
+	if err := om.RelayMail(emailNoRecipients, "/path/to/email.eml", "", false, func(err error) {
 		callbackCalled2 <- true
 		// Should fail because no recipients
 		if err == nil {
 			t.Error("Expected error when no recipients")
 		}
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 	select {
 	case <-callbackCalled2:
 		// Callback was called
@@ -537,18 +550,20 @@ func TestOutgoingMailRelayMail(t *testing.T) {
 	// Test queue full scenario
 	// Fill the queue
 	for i := 0; i < 110; i++ {
-		om.RelayMail(email, "/path/to/email.eml", "", false, nil)
+		_ = om.RelayMail(email, "/path/to/email.eml", "", false, nil)
 	}
 	time.Sleep(200 * time.Millisecond)
 
 	// Test with callback on queue full
 	callbackCalled3 := make(chan bool, 1)
-	om.RelayMail(email, "/path/to/email.eml", "", false, func(err error) {
+	if err := om.RelayMail(email, "/path/to/email.eml", "", false, func(err error) {
 		callbackCalled3 <- true
 		if err == nil {
 			t.Error("Expected error when queue is full")
 		}
-	})
+	}); err != nil && !errors.Is(err, ErrQueueFull) {
+		t.Fatal(err)
+	}
 	select {
 	case <-callbackCalled3:
 		// Callback was called
@@ -719,12 +734,15 @@ func TestOutgoingMailRelayMailDisabled(t *testing.T) {
 	}
 
 	callbackCalled := make(chan bool, 1)
-	om.RelayMail(email, "/path/to/email.eml", "", false, func(err error) {
+	err := om.RelayMail(email, "/path/to/email.eml", "", false, func(err error) {
 		callbackCalled <- true
 		if err == nil {
 			t.Error("Expected error when outgoing mail is disabled")
 		}
 	})
+	if !errors.Is(err, ErrNotConfigured) {
+		t.Fatalf("RelayMail() error = %v, want %v", err, ErrNotConfigured)
+	}
 
 	// Wait for callback
 	select {
@@ -792,7 +810,9 @@ func TestUpdateConfigWithInvalidType(t *testing.T) {
 	originalConfig := om.GetConfig().(*OutgoingConfig)
 
 	// Try to update with wrong type
-	om.UpdateConfig("not a config")
+	if err := om.UpdateConfig("not a config"); err == nil {
+		t.Fatal("UpdateConfig() accepted an invalid type")
+	}
 
 	// Config should remain unchanged
 	currentConfig := om.GetConfig().(*OutgoingConfig)
@@ -1078,7 +1098,9 @@ func TestRelayMailWithNilCallback(t *testing.T) {
 	}
 
 	// Test with nil callback - should not panic
-	om.RelayMail(email, "/path/to/email.eml", "", false, nil)
+	if err := om.RelayMail(email, "/path/to/email.eml", "", false, nil); err != nil {
+		t.Fatal(err)
+	}
 	time.Sleep(100 * time.Millisecond) // Give worker time to process
 }
 


### PR DESCRIPTION
## Summary

- deep-copy outgoing configuration inputs and getters, and capture an immutable configuration snapshot for every accepted relay task
- start the relay worker exactly once when runtime configuration transitions from disabled to enabled
- define disable/update semantics: an empty host rejects new submissions while already accepted tasks drain with their original snapshot
- coordinate configuration updates, queue submissions, and shutdown with lifecycle locks and active-enqueue tracking
- make outgoing shutdown idempotent, avoid closing the producer queue, and return stable errors for disabled, full, and closed states
- protect the MailServer outgoing pointer across RelayMail, SetOutgoingConfig, auto-relay checks, and Close
- keep failed updates atomic and preserve the previous configuration
- keep passwords out of all outgoing settings responses; PUT is replacement semantics, PATCH preserves an omitted password and clears an explicitly empty password
- update the changelog without adding persistence or retry behavior

## Tests

- dynamic disabled-to-enabled worker startup
- enabled-to-disabled submission rejection and queued-task snapshot behavior
- input/getter deep-copy isolation and password updates
- invalid update rollback
- deterministic queue-full behavior
- concurrent update/enqueue/close and repeated close
- MailServer RelayMail/SetOutgoingConfig/Close races
- settings response password redaction

## Verification

- `go test -race -coverprofile=/tmp/owlmail-coverage-final.out -covermode=atomic ./...`
- `go vet ./...`
- `CGO_ENABLED=0 go build -o /tmp/owlmail-final ./cmd/owlmail`
- `golangci-lint run --timeout=5m`
- `git diff --check`