### PR TITLE
security(api): isolate untrusted attachment content

### DIFF
--- a/internal/api/api_emails.go
+++ b/internal/api/api_emails.go
@@ -69,7 +69,7 @@ func (api *API) getAttachment(c fiber.Ctx) error {
 		return c.Status(fiber.StatusNotFound).JSON(ErrorResponse(ErrorCodeEmailNotFound, err.Error()))
 	}
 
-	c.Set("Content-Type", attachment.ContentType)
+	setAttachmentResponseHeaders(c, attachment.ContentType, filename)
 	maxInt := int64(^uint(0) >> 1)
 	if attachment.Size >= 0 && attachment.Size <= maxInt {
 		return c.SendStream(attachment.Body, int(attachment.Size))

--- a/internal/api/api_maildev_compat.go
+++ b/internal/api/api_maildev_compat.go
@@ -273,7 +273,7 @@ func (api *API) mailDevAttachment(c fiber.Ctx) error {
 	if contentType == "" {
 		contentType = "application/octet-stream"
 	}
-	c.Set(fiber.HeaderContentType, contentType)
+	setAttachmentResponseHeaders(c, contentType, c.Params("filename"))
 	maxInt := int64(^uint(0) >> 1)
 	if attachment.Size >= 0 && attachment.Size <= maxInt {
 		return c.SendStream(attachment.Body, int(attachment.Size))

--- a/internal/api/api_utils.go
+++ b/internal/api/api_utils.go
@@ -49,8 +49,14 @@ func isActiveAttachmentType(contentType string) bool {
 	if err != nil {
 		mediaType = strings.TrimSpace(strings.Split(contentType, ";")[0])
 	}
-	switch strings.ToLower(mediaType) {
-	case "text/html", "application/xhtml+xml", "image/svg+xml", "application/xml", "text/xml", "application/javascript", "text/javascript":
+	mediaType = strings.ToLower(mediaType)
+	if strings.HasSuffix(mediaType, "+xml") ||
+		strings.Contains(mediaType, "javascript") ||
+		strings.Contains(mediaType, "ecmascript") {
+		return true
+	}
+	switch mediaType {
+	case "text/html", "application/xml", "text/xml", "application/wasm":
 		return true
 	default:
 		return false

--- a/internal/api/api_utils.go
+++ b/internal/api/api_utils.go
@@ -1,6 +1,9 @@
 package api
 
-import "strings"
+import (
+	"mime"
+	"strings"
+)
 
 // sanitizeFilename sanitizes a filename for safe download
 func sanitizeFilename(filename string) string {
@@ -21,4 +24,35 @@ func sanitizeFilename(filename string) string {
 	}
 
 	return filename
+}
+
+// setAttachmentResponseHeaders prevents browsers from MIME-sniffing untrusted
+// message parts. Formats that can execute active content are downloads by
+// default; passive formats retain inline compatibility.
+func setAttachmentResponseHeaders(c interface{ Set(string, string) }, contentType, filename string) {
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	c.Set("Content-Type", contentType)
+	c.Set("X-Content-Type-Options", "nosniff")
+	if isActiveAttachmentType(contentType) {
+		name := sanitizeFilename(filename)
+		if name == "" {
+			name = "attachment"
+		}
+		c.Set("Content-Disposition", mime.FormatMediaType("attachment", map[string]string{"filename": name}))
+	}
+}
+
+func isActiveAttachmentType(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		mediaType = strings.TrimSpace(strings.Split(contentType, ";")[0])
+	}
+	switch strings.ToLower(mediaType) {
+	case "text/html", "application/xhtml+xml", "image/svg+xml", "application/xml", "text/xml", "application/javascript", "text/javascript":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/api/api_utils_test.go
+++ b/internal/api/api_utils_test.go
@@ -103,6 +103,9 @@ func TestSetAttachmentResponseHeaders(t *testing.T) {
 		wantDisposition bool
 	}{
 		{name: "svg is downloaded", contentType: "image/svg+xml", filename: "diagram.svg", wantType: "image/svg+xml", wantDisposition: true},
+		{name: "structured XML is downloaded", contentType: "application/atom+xml", filename: "feed.xml", wantType: "application/atom+xml", wantDisposition: true},
+		{name: "legacy JavaScript is downloaded", contentType: "application/x-javascript", filename: "payload.js", wantType: "application/x-javascript", wantDisposition: true},
+		{name: "ECMAScript is downloaded", contentType: "text/ecmascript", filename: "payload.es", wantType: "text/ecmascript", wantDisposition: true},
 		{name: "html parameters are recognized", contentType: "text/html; charset=utf-8", filename: "page.html", wantType: "text/html; charset=utf-8", wantDisposition: true},
 		{name: "png stays inline", contentType: "image/png", filename: "pixel.png", wantType: "image/png"},
 		{name: "empty type is safe", filename: "blob.bin", wantType: "application/octet-stream"},

--- a/internal/api/api_utils_test.go
+++ b/internal/api/api_utils_test.go
@@ -1,8 +1,15 @@
 package api
 
 import (
+	"net/http"
 	"testing"
 )
+
+type headerRecorder http.Header
+
+func (headers headerRecorder) Set(key, value string) {
+	http.Header(headers).Set(key, value)
+}
 
 func TestSanitizeFilename(t *testing.T) {
 	tests := []struct {
@@ -82,6 +89,36 @@ func TestSanitizeFilename(t *testing.T) {
 				}
 			} else if result != tt.expected {
 				t.Errorf("Expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestSetAttachmentResponseHeaders(t *testing.T) {
+	tests := []struct {
+		name            string
+		contentType     string
+		filename        string
+		wantType        string
+		wantDisposition bool
+	}{
+		{name: "svg is downloaded", contentType: "image/svg+xml", filename: "diagram.svg", wantType: "image/svg+xml", wantDisposition: true},
+		{name: "html parameters are recognized", contentType: "text/html; charset=utf-8", filename: "page.html", wantType: "text/html; charset=utf-8", wantDisposition: true},
+		{name: "png stays inline", contentType: "image/png", filename: "pixel.png", wantType: "image/png"},
+		{name: "empty type is safe", filename: "blob.bin", wantType: "application/octet-stream"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			headers := make(http.Header)
+			setAttachmentResponseHeaders(headerRecorder(headers), test.contentType, test.filename)
+			if got := headers.Get("Content-Type"); got != test.wantType {
+				t.Fatalf("Content-Type = %q, want %q", got, test.wantType)
+			}
+			if got := headers.Get("X-Content-Type-Options"); got != "nosniff" {
+				t.Fatalf("X-Content-Type-Options = %q", got)
+			}
+			if got := headers.Get("Content-Disposition"); (got != "") != test.wantDisposition {
+				t.Fatalf("Content-Disposition = %q, want present %t", got, test.wantDisposition)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- send `X-Content-Type-Options: nosniff` on native and MailDev-compatible attachment responses
- force HTML, XHTML, SVG, XML, and JavaScript attachments to download with a sanitized filename
- preserve inline behavior for passive formats such as PNG and PDF
- fall back to `application/octet-stream` when attachment metadata has no media type

## Tests

- `go test ./internal/api`
- `git diff --check`