### PR TITLE
feat(observability): add structured JSON logging

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -262,6 +262,7 @@ docker buildx build \
 | `-tls-cert` | `MAILDEV_INCOMING_CERT` / `OWLMAIL_TLS_CERT` | - | SMTP TLS-Zertifikatsdatei |
 | `-tls-key` | `MAILDEV_INCOMING_KEY` / `OWLMAIL_TLS_KEY` | - | SMTP TLS-Private-Key-Datei |
 | `-log-level` | `MAILDEV_VERBOSE` / `MAILDEV_SILENT` / `OWLMAIL_LOG_LEVEL` | normal | Protokollierungsstufe |
+| `-log-format` | `OWLMAIL_LOG_FORMAT` | console | Protokollformat: `console` oder `json` |
 | `-use-uuid-for-email-id` | `OWLMAIL_USE_UUID_FOR_EMAIL_ID` | false | UUID für E-Mail-IDs verwenden (Standard: 8-Zeichen-Zufallszeichenfolge) |
 
 When TLS terminates at a reverse proxy, set `OWLMAIL_WEB_EXTERNAL_SCHEME` to `https`.

--- a/README.fr.md
+++ b/README.fr.md
@@ -263,6 +263,7 @@ docker buildx build \
 | `-tls-cert` | `MAILDEV_INCOMING_CERT` / `OWLMAIL_TLS_CERT` | - | SMTP TLS certificate file |
 | `-tls-key` | `MAILDEV_INCOMING_KEY` / `OWLMAIL_TLS_KEY` | - | SMTP TLS private key file |
 | `-log-level` | `MAILDEV_VERBOSE` / `MAILDEV_SILENT` / `OWLMAIL_LOG_LEVEL` | normal | Log level |
+| `-log-format` | `OWLMAIL_LOG_FORMAT` | console | Format des journaux : `console` ou `json` |
 | `-use-uuid-for-email-id` | `OWLMAIL_USE_UUID_FOR_EMAIL_ID` | false | Use UUID for email IDs (default: 8-character random string) |
 
 When TLS terminates at a reverse proxy, set `OWLMAIL_WEB_EXTERNAL_SCHEME` to `https`.

--- a/README.it.md
+++ b/README.it.md
@@ -262,6 +262,7 @@ docker buildx build \
 | `-tls-cert` | `MAILDEV_INCOMING_CERT` / `OWLMAIL_TLS_CERT` | - | File certificato TLS SMTP |
 | `-tls-key` | `MAILDEV_INCOMING_KEY` / `OWLMAIL_TLS_KEY` | - | File chiave privata TLS SMTP |
 | `-log-level` | `MAILDEV_VERBOSE` / `MAILDEV_SILENT` / `OWLMAIL_LOG_LEVEL` | normal | Livello di log |
+| `-log-format` | `OWLMAIL_LOG_FORMAT` | console | Formato dei log: `console` o `json` |
 | `-use-uuid-for-email-id` | `OWLMAIL_USE_UUID_FOR_EMAIL_ID` | false | Usa UUID per ID email (predefinito: stringa casuale di 8 caratteri) |
 
 When TLS terminates at a reverse proxy, set `OWLMAIL_WEB_EXTERNAL_SCHEME` to `https`.

--- a/README.ja.md
+++ b/README.ja.md
@@ -262,6 +262,7 @@ docker buildx build \
 | `-tls-cert` | `MAILDEV_INCOMING_CERT` / `OWLMAIL_TLS_CERT` | - | SMTP TLS certificate file |
 | `-tls-key` | `MAILDEV_INCOMING_KEY` / `OWLMAIL_TLS_KEY` | - | SMTP TLS private key file |
 | `-log-level` | `MAILDEV_VERBOSE` / `MAILDEV_SILENT` / `OWLMAIL_LOG_LEVEL` | normal | Log level |
+| `-log-format` | `OWLMAIL_LOG_FORMAT` | console | ログ出力形式：`console` または `json` |
 | `-use-uuid-for-email-id` | `OWLMAIL_USE_UUID_FOR_EMAIL_ID` | false | Use UUID for email IDs (default: 8-character random string) |
 
 When TLS terminates at a reverse proxy, set `OWLMAIL_WEB_EXTERNAL_SCHEME` to `https`.

--- a/README.ko.md
+++ b/README.ko.md
@@ -262,6 +262,7 @@ docker buildx build \
 | `-tls-cert` | `MAILDEV_INCOMING_CERT` / `OWLMAIL_TLS_CERT` | - | SMTP TLS certificate file |
 | `-tls-key` | `MAILDEV_INCOMING_KEY` / `OWLMAIL_TLS_KEY` | - | SMTP TLS private key file |
 | `-log-level` | `MAILDEV_VERBOSE` / `MAILDEV_SILENT` / `OWLMAIL_LOG_LEVEL` | normal | Log level |
+| `-log-format` | `OWLMAIL_LOG_FORMAT` | console | 로그 출력 형식: `console` 또는 `json` |
 | `-use-uuid-for-email-id` | `OWLMAIL_USE_UUID_FOR_EMAIL_ID` | false | Use UUID for email IDs (default: 8-character random string) |
 
 When TLS terminates at a reverse proxy, set `OWLMAIL_WEB_EXTERNAL_SCHEME` to `https`.

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ the message body; clicking one focuses OwlMail and opens the message.
 | `-tls-cert` | `MAILDEV_INCOMING_CERT` / `OWLMAIL_TLS_CERT` | - | SMTP TLS certificate file |
 | `-tls-key` | `MAILDEV_INCOMING_KEY` / `OWLMAIL_TLS_KEY` | - | SMTP TLS private key file |
 | `-log-level` | `MAILDEV_VERBOSE` / `MAILDEV_SILENT` / `OWLMAIL_LOG_LEVEL` | normal | Log level |
+| `-log-format` | `OWLMAIL_LOG_FORMAT` | console | Log output format: `console` or `json` |
 | `-use-uuid-for-email-id` | `OWLMAIL_USE_UUID_FOR_EMAIL_ID` | false | Use UUID for email IDs (default: 8-character random string) |
 
 When TLS terminates at a reverse proxy, set `OWLMAIL_WEB_EXTERNAL_SCHEME` to `https`.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -279,6 +279,7 @@ Notifications API 需要 HTTPS，或 `http://localhost` 等受信任的本地来
 | `-tls-cert` | `MAILDEV_INCOMING_CERT` / `OWLMAIL_TLS_CERT` | - | SMTP TLS 证书文件 |
 | `-tls-key` | `MAILDEV_INCOMING_KEY` / `OWLMAIL_TLS_KEY` | - | SMTP TLS 私钥文件 |
 | `-log-level` | `MAILDEV_VERBOSE` / `MAILDEV_SILENT` / `OWLMAIL_LOG_LEVEL` | normal | 日志级别 |
+| `-log-format` | `OWLMAIL_LOG_FORMAT` | console | 日志输出格式：`console` 或 `json` |
 | `-use-uuid-for-email-id` | `OWLMAIL_USE_UUID_FOR_EMAIL_ID` | false | 使用 UUID 作为邮件 ID（默认使用 8 字符随机字符串） |
 
 若 TLS 在反向代理终止，请将 `OWLMAIL_WEB_EXTERNAL_SCHEME` 设置为 `https`。

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -597,7 +597,7 @@ func initializeApplication(cfg *config.Config) error {
 		return fmt.Errorf("config is nil")
 	}
 	level := parseLogLevel(cfg.LogLevel)
-	common.InitLogger(level)
+	common.InitLoggerWithFormat(level, cfg.LogFormat)
 	basePathname, err := config.NormalizeBasePathname(cfg.BasePathname)
 	if err != nil {
 		return err

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -71,14 +71,28 @@ func reportWebAuthCompletion(cfg *config.Config, completion webAuthCompletion, o
 		if output == nil {
 			return fmt.Errorf("print generated HTTP Basic Auth password: output is nil")
 		}
-		if _, err := fmt.Fprintf(output, "OwlMail generated a temporary HTTP Basic Auth password for user %q: %s (set -web-password or OWLMAIL_WEB_PASSWORD for a stable password)\n", cfg.WebUser, cfg.WebPassword); err != nil {
+		message := fmt.Sprintf("OwlMail generated a temporary HTTP Basic Auth password for user %q: %s (set -web-password or OWLMAIL_WEB_PASSWORD for a stable password)", cfg.WebUser, cfg.WebPassword)
+		if err := writeStartupNotice(output, cfg.LogFormat, message); err != nil {
 			return fmt.Errorf("print generated HTTP Basic Auth password: %w", err)
 		}
 	}
 	if completion.defaultedUsername && output != nil {
-		_, _ = fmt.Fprintln(output, "OwlMail defaulted the HTTP Basic Auth username to \"admin\" because only a password was configured")
+		_ = writeStartupNotice(output, cfg.LogFormat, "OwlMail defaulted the HTTP Basic Auth username to \"admin\" because only a password was configured")
 	}
 	return nil
+}
+
+func writeStartupNotice(output io.Writer, format, message string) error {
+	if strings.EqualFold(strings.TrimSpace(format), "json") {
+		encoded, err := json.Marshal(map[string]string{"level": "info", "service": "owlmail", "message": message})
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprintln(output, string(encoded))
+		return err
+	}
+	_, err := fmt.Fprintln(output, message)
+	return err
 }
 
 // parseLogLevel parses log level string and returns LogLevel

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -596,6 +596,12 @@ func initializeApplication(cfg *config.Config) error {
 	if cfg == nil {
 		return fmt.Errorf("config is nil")
 	}
+	if cfg.LogFormat == "" {
+		cfg.LogFormat = "console"
+	}
+	if err := config.ValidateLogFormat(cfg.LogFormat); err != nil {
+		return err
+	}
 	level := parseLogLevel(cfg.LogLevel)
 	common.InitLoggerWithFormat(level, cfg.LogFormat)
 	basePathname, err := config.NormalizeBasePathname(cfg.BasePathname)

--- a/cmd/owlmail/main_test.go
+++ b/cmd/owlmail/main_test.go
@@ -182,6 +182,21 @@ func TestReportWebAuthCompletion(t *testing.T) {
 			t.Fatalf("default username was not reported: %q", output.String())
 		}
 	})
+
+	t.Run("JSON format emits one structured notice", func(t *testing.T) {
+		cfg := &config.Config{WebUser: "operator", WebPassword: "generated-secret", LogFormat: "JSON"}
+		var output bytes.Buffer
+		if err := reportWebAuthCompletion(cfg, webAuthCompletion{generatedPassword: true}, &output); err != nil {
+			t.Fatal(err)
+		}
+		var notice map[string]string
+		if err := json.Unmarshal(output.Bytes(), &notice); err != nil {
+			t.Fatalf("notice is not JSON: %q: %v", output.String(), err)
+		}
+		if notice["level"] != "info" || notice["service"] != "owlmail" || !strings.Contains(notice["message"], "generated-secret") {
+			t.Fatalf("unexpected JSON notice: %#v", notice)
+		}
+	})
 }
 
 func TestSetupMailboxIndexRejectsMetadataCollision(t *testing.T) {

--- a/cmd/owlmail/main_test.go
+++ b/cmd/owlmail/main_test.go
@@ -898,6 +898,14 @@ func TestInitializeApplicationNormalizesBasePathname(t *testing.T) {
 	}
 }
 
+func TestInitializeApplicationRejectsInvalidLogFormat(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogFormat = "jsno"
+	if err := initializeApplication(cfg); err == nil {
+		t.Fatal("initializeApplication accepted an invalid log format")
+	}
+}
+
 // TestCreateMailServer tests the createMailServer function
 func TestCreateMailServer(t *testing.T) {
 	// Test with nil config

--- a/internal/common/error_handler.go
+++ b/internal/common/error_handler.go
@@ -2,7 +2,7 @@ package common
 
 import (
 	"fmt"
-	"log"
+	"os"
 )
 
 // ErrorHandler defines the error handling interface
@@ -13,12 +13,13 @@ type ErrorHandler interface {
 // DefaultErrorHandler is the default error handler for production environments
 type DefaultErrorHandler struct{}
 
+var exitProcess = os.Exit
+
 func (h *DefaultErrorHandler) Fatal(format string, v ...interface{}) error {
 	msg := fmt.Sprintf(format, v...)
-	Error("%s", msg)
-	log.Fatalf("[FATAL] %s", msg)
-	// This line will never execute, but satisfies the interface requirement
-	return fmt.Errorf("%s", msg)
+	exitProcess(1)
+	// Test substitutes may return; production os.Exit never does.
+	return fmt.Errorf("[FATAL] %s", msg)
 }
 
 // TestErrorHandler is a test error handler for testing environments

--- a/internal/common/error_handler_test.go
+++ b/internal/common/error_handler_test.go
@@ -7,22 +7,23 @@ import (
 
 func TestDefaultErrorHandlerFatal(t *testing.T) {
 	handler := &DefaultErrorHandler{}
-
-	// Test that DefaultErrorHandler can be created and implements the interface
-	// Note: We cannot directly test DefaultErrorHandler.Fatal because it calls log.Fatalf
-	// which will exit the process. The function is tested indirectly through other tests
-	// that use SetErrorHandler and ResetErrorHandler.
-
-	// Verify it implements the ErrorHandler interface
 	var _ ErrorHandler = handler
 
-	// Verify handler can be used (type check)
-	_ = handler
+	previousExit := exitProcess
+	defer func() { exitProcess = previousExit }()
+	exitCode := 0
+	exitProcess = func(code int) { exitCode = code }
+	err := handler.Fatal("fatal %s", "failure")
+	if exitCode != 1 {
+		t.Fatalf("exit code = %d, want 1", exitCode)
+	}
+	if err == nil || err.Error() != "[FATAL] fatal failure" {
+		t.Fatalf("Fatal() error = %v", err)
+	}
 }
 
-// TestDefaultErrorHandlerFatalFormatting tests the formatting logic of DefaultErrorHandler.Fatal
-// by verifying that fmt.Sprintf produces the expected output. We cannot test log.Fatalf
-// directly as it exits the process, but we can verify the formatting logic is correct.
+// TestDefaultErrorHandlerFatalFormatting tests the formatting contract shared
+// with test handlers without invoking the process exit path.
 func TestDefaultErrorHandlerFatalFormatting(t *testing.T) {
 	handler := &DefaultErrorHandler{}
 

--- a/internal/common/logger.go
+++ b/internal/common/logger.go
@@ -3,6 +3,7 @@ package common
 import (
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 
 	logger "github.com/soulteary/logger-kit/v2"
@@ -59,7 +60,7 @@ func InitLoggerWithFormat(level LogLevel, format string) {
 	defer defaultLogMu.Unlock()
 	kitLevel := owlmailToLoggerLevel(level)
 	kitFormat := logger.FormatConsole
-	if format == "json" {
+	if strings.EqualFold(strings.TrimSpace(format), "json") {
 		kitFormat = logger.FormatJSON
 	}
 	l := logger.New(logger.Config{

--- a/internal/common/logger.go
+++ b/internal/common/logger.go
@@ -50,13 +50,22 @@ func getLoggerUnsafe() *logger.Logger {
 // InitLogger initializes the global logger. Holds the lock for the whole call so it does
 // not race with Log/Verbose/Error: logger.New() writes zerolog globals, and Msg() reads them.
 func InitLogger(level LogLevel) {
+	InitLoggerWithFormat(level, "console")
+}
+
+// InitLoggerWithFormat initializes the global logger in console or JSON form.
+func InitLoggerWithFormat(level LogLevel, format string) {
 	defaultLogMu.Lock()
 	defer defaultLogMu.Unlock()
 	kitLevel := owlmailToLoggerLevel(level)
+	kitFormat := logger.FormatConsole
+	if format == "json" {
+		kitFormat = logger.FormatJSON
+	}
 	l := logger.New(logger.Config{
 		Level:       kitLevel,
 		Output:      os.Stdout,
-		Format:      logger.FormatConsole,
+		Format:      kitFormat,
 		ServiceName: "owlmail",
 	})
 	defaultLog = l

--- a/internal/common/logger_test.go
+++ b/internal/common/logger_test.go
@@ -17,6 +17,8 @@ func TestInitLogger(t *testing.T) {
 	InitLogger(LogLevelSilent)
 	InitLogger(LogLevelNormal)
 	InitLogger(LogLevelVerbose)
+	InitLoggerWithFormat(LogLevelNormal, "json")
+	InitLoggerWithFormat(LogLevelNormal, "console")
 }
 
 func TestLog(t *testing.T) {

--- a/internal/common/logger_test.go
+++ b/internal/common/logger_test.go
@@ -18,6 +18,7 @@ func TestInitLogger(t *testing.T) {
 	InitLogger(LogLevelNormal)
 	InitLogger(LogLevelVerbose)
 	InitLoggerWithFormat(LogLevelNormal, "json")
+	InitLoggerWithFormat(LogLevelNormal, "JSON")
 	InitLoggerWithFormat(LogLevelNormal, "console")
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -314,7 +314,8 @@ type Config struct {
 	TLSKeyFile  string
 
 	// Logging configuration
-	LogLevel string
+	LogLevel  string
+	LogFormat string
 
 	// Email ID configuration
 	UseUUIDForEmailID bool
@@ -396,6 +397,7 @@ func DefaultConfig() *Config {
 		TLSCertFile:                 "",
 		TLSKeyFile:                  "",
 		LogLevel:                    "normal",
+		LogFormat:                   "console",
 		UseUUIDForEmailID:           false,
 		S3Enabled:                   false,
 		S3Endpoint:                  "",
@@ -469,6 +471,7 @@ type FlagRefs struct {
 	TLSCertFile                 *string
 	TLSKeyFile                  *string
 	LogLevel                    *string
+	LogFormat                   *string
 	UseUUIDForEmailID           *bool
 	S3Enabled                   *bool
 	S3Endpoint                  *string
@@ -544,6 +547,7 @@ func DefineFlags(fs *flag.FlagSet) *FlagRefs {
 		TLSCertFile:                 fs.String("tls-cert", cfg.TLSCertFile, "TLS certificate file path"),
 		TLSKeyFile:                  fs.String("tls-key", cfg.TLSKeyFile, "TLS private key file path"),
 		LogLevel:                    fs.String("log-level", cfg.LogLevel, "Log level: silent, normal, or verbose"),
+		LogFormat:                   fs.String("log-format", cfg.LogFormat, "Log format: console or json"),
 		UseUUIDForEmailID:           fs.Bool("use-uuid-for-email-id", cfg.UseUUIDForEmailID, "Use UUID instead of random string for email IDs"),
 		S3Enabled:                   fs.Bool("s3-enabled", cfg.S3Enabled, "Store decoded attachments in S3-compatible object storage"),
 		S3Endpoint:                  fs.String("s3-endpoint", cfg.S3Endpoint, "S3-compatible endpoint URL (empty uses AWS S3)"),
@@ -627,7 +631,8 @@ func ResolveConfig(fs *flag.FlagSet, refs *FlagRefs) *Config {
 		TLSCertFile: resolveStringWithFlag(fs, "tls-cert", "OWLMAIL_TLS_CERT", *refs.TLSCertFile),
 		TLSKeyFile:  resolveStringWithFlag(fs, "tls-key", "OWLMAIL_TLS_KEY", *refs.TLSKeyFile),
 
-		LogLevel: resolveLogLevelWithFlag(fs, "log-level", *refs.LogLevel),
+		LogLevel:  resolveLogLevelWithFlag(fs, "log-level", *refs.LogLevel),
+		LogFormat: resolveStringWithFlag(fs, "log-format", "OWLMAIL_LOG_FORMAT", *refs.LogFormat),
 
 		UseUUIDForEmailID:      resolveBoolWithFlag(fs, "use-uuid-for-email-id", "OWLMAIL_USE_UUID_FOR_EMAIL_ID", *refs.UseUUIDForEmailID),
 		S3Enabled:              resolveBoolWithFlag(fs, "s3-enabled", "OWLMAIL_S3_ENABLED", *refs.S3Enabled),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -587,6 +587,26 @@ func TestDefineAndResolveConfig(t *testing.T) {
 		if cfg.LogLevel != "normal" {
 			t.Errorf("ResolveConfig().LogLevel = %q, want %q", cfg.LogLevel, "normal")
 		}
+		if cfg.LogFormat != "console" {
+			t.Errorf("ResolveConfig().LogFormat = %q, want %q", cfg.LogFormat, "console")
+		}
+	})
+
+	t.Run("log format precedence", func(t *testing.T) {
+		t.Setenv("OWLMAIL_LOG_FORMAT", "json")
+		fs := flag.NewFlagSet("test-log-format-env", flag.ContinueOnError)
+		refs := DefineFlags(fs)
+		_ = fs.Parse(nil)
+		if got := ResolveConfig(fs, refs).LogFormat; got != "json" {
+			t.Fatalf("environment log format = %q", got)
+		}
+
+		fs = flag.NewFlagSet("test-log-format-cli", flag.ContinueOnError)
+		refs = DefineFlags(fs)
+		_ = fs.Parse([]string{"-log-format", "console"})
+		if got := ResolveConfig(fs, refs).LogFormat; got != "console" {
+			t.Fatalf("CLI log format = %q", got)
+		}
 	})
 
 	t.Run("CLI flags override defaults", func(t *testing.T) {

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -16,6 +16,14 @@ var ValidLogLevels = []string{"silent", "normal", "verbose"}
 // ValidLogFormats defines the supported output encodings.
 var ValidLogFormats = []string{"console", "json"}
 
+// ValidateLogFormat rejects unsupported logger encodings.
+func ValidateLogFormat(format string) error {
+	if err := validator.ValidateEnum(format, ValidLogFormats, false); err != nil {
+		return fmt.Errorf("invalid log format: %w", err)
+	}
+	return nil
+}
+
 // ValidateConfig validates all configuration values and returns an error if any are invalid.
 func ValidateConfig(cfg *Config) error {
 	if cfg == nil {
@@ -131,8 +139,8 @@ func ValidateConfig(cfg *Config) error {
 	if err := ValidateLogLevel(cfg.LogLevel); err != nil {
 		return err
 	}
-	if err := validator.ValidateEnum(cfg.LogFormat, ValidLogFormats, false); err != nil {
-		return fmt.Errorf("invalid log format: %w", err)
+	if err := ValidateLogFormat(cfg.LogFormat); err != nil {
+		return err
 	}
 
 	// Validate TLS configuration

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -13,6 +13,9 @@ import (
 // ValidLogLevels defines the allowed log level values
 var ValidLogLevels = []string{"silent", "normal", "verbose"}
 
+// ValidLogFormats defines the supported output encodings.
+var ValidLogFormats = []string{"console", "json"}
+
 // ValidateConfig validates all configuration values and returns an error if any are invalid.
 func ValidateConfig(cfg *Config) error {
 	if cfg == nil {
@@ -127,6 +130,9 @@ func ValidateConfig(cfg *Config) error {
 	// Validate log level
 	if err := ValidateLogLevel(cfg.LogLevel); err != nil {
 		return err
+	}
+	if err := validator.ValidateEnum(cfg.LogFormat, ValidLogFormats, false); err != nil {
+		return fmt.Errorf("invalid log format: %w", err)
 	}
 
 	// Validate TLS configuration

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -60,6 +60,18 @@ func TestValidateLogLevel(t *testing.T) {
 	}
 }
 
+func TestValidateConfigLogFormat(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.LogFormat = "json"
+	if err := ValidateConfig(cfg); err != nil {
+		t.Fatalf("json log format rejected: %v", err)
+	}
+	cfg.LogFormat = "xml"
+	if err := ValidateConfig(cfg); err == nil {
+		t.Fatal("unsupported log format was accepted")
+	}
+}
+
 func TestValidatePath(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Summary

- add `-log-format console|json` with `OWLMAIL_LOG_FORMAT` support
- preserve human-readable console output as the default
- select logger-kit's structured JSON formatter without changing existing log levels
- validate unsupported formats at startup and document the new option

## Tests

- `go test ./...`
- `git diff --check`