### PR TITLE
feat(web): add email content view tabs

### DIFF
--- a/tests/web/app.test.js
+++ b/tests/web/app.test.js
@@ -364,12 +364,13 @@ test('email detail offers HTML, text, headers, and source tabs', () => {
     for (const tab of ['HTML', 'Plain text', 'Headers', 'Source']) {
         assert.equal(markup.includes(tab), true);
     }
-    assert.match(markup, /role="tablist"/);
+    assert.match(markup, /role="tablist" aria-label="Email content views"/);
     assert.match(markup, /role="tabpanel"/);
     assert.match(markup, /tabindex="0"/);
     assert.match(markup, /onclick="setEmailContentTab\('source', true\)"/);
     for (const locale of ['zh-CN', 'en', 'de', 'it', 'fr', 'ko', 'ja']) {
         assert.equal(harness.run(`Boolean(i18n[${JSON.stringify(locale)}].contentSource)`), true);
+        assert.equal(harness.run(`Boolean(i18n[${JSON.stringify(locale)}].emailContentViews)`), true);
     }
 });
 

--- a/tests/web/app.test.js
+++ b/tests/web/app.test.js
@@ -400,6 +400,35 @@ test('source load failures replace the loading placeholder', async () => {
     assert.equal(harness.emailDetail.innerHTML.includes('source unavailable'), true);
 });
 
+test('source retry clears the prior error before rendering loading state', async () => {
+    let attempt = 0;
+    let resolveRetry;
+    const retryResponse = new Promise((resolve) => { resolveRetry = resolve; });
+    const harness = createHarness({
+        fetchImpl: async () => {
+            attempt++;
+            if (attempt === 1) {
+                return {
+                    ok: false,
+                    status: 500,
+                    headers: { get: () => 'application/json' },
+                    async json() { return { message: 'source unavailable' }; },
+                    async text() { return '{"message":"source unavailable"}'; }
+                };
+            }
+            return retryResponse;
+        }
+    });
+    harness.run(`state.currentEmail = { id: 'mail-1', size: 128, html: '', text: 'hello', headers: {}, attachments: [] }`);
+    await harness.run(`setEmailContentTab('source')`);
+
+    const retry = harness.run(`setEmailContentTab('source')`);
+    assert.equal(harness.emailDetail.innerHTML.includes('source unavailable'), false);
+    assert.equal(harness.emailDetail.innerHTML.includes('Loading source'), true);
+    resolveRetry({ ok: true, status: 200, body: null, headers: { get: () => null }, async text() { return 'source'; } });
+    await retry;
+});
+
 test('source requests are deduplicated and keyboard focus survives completion', async () => {
     let resolveFetch;
     const response = new Promise((resolve) => { resolveFetch = resolve; });

--- a/tests/web/app.test.js
+++ b/tests/web/app.test.js
@@ -35,8 +35,10 @@ function createElement({ dataset = {} } = {}) {
         scrollTop: 0,
         hidden: true,
         disabled: false,
+        focused: false,
         title: '',
         addEventListener(name, handler) { listeners.set(name, handler); },
+        focus() { this.focused = true; },
         setAttribute(name, value) { attributes.set(name, value); },
         querySelectorAll() { return []; }
     };
@@ -80,6 +82,7 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
     const emailList = createElement();
     const emailViewportFrame = createElement();
     const emailViewportStage = createElement();
+    const emailSourceTab = createElement();
     const emailViewportButtons = ['100%', '1440', '1024', '768', '425', '375', '320']
         .map((width) => createElement({ dataset: { viewportWidth: width } }));
     const elements = new Map([
@@ -88,7 +91,8 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
         ['emailDetail', emailDetail],
         ['emailList', emailList],
         ['emailViewportFrame', emailViewportFrame],
-        ['emailViewportStage', emailViewportStage]
+        ['emailViewportStage', emailViewportStage],
+        ['email-content-tab-source', emailSourceTab]
     ]);
     const notifications = [];
     const fetchRequests = [];
@@ -208,6 +212,7 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
         emailViewportButtons,
         emailViewportFrame,
         emailViewportStage,
+        emailSourceTab,
         fetchRequests,
         historyCalls,
         notificationStatus,
@@ -391,6 +396,41 @@ test('source load failures replace the loading placeholder', async () => {
     await harness.run(`setEmailContentTab('source')`);
     assert.equal(harness.emailDetail.innerHTML.includes('Loading source'), false);
     assert.equal(harness.emailDetail.innerHTML.includes('source unavailable'), true);
+});
+
+test('source requests are deduplicated and keyboard focus survives completion', async () => {
+    let resolveFetch;
+    const response = new Promise((resolve) => { resolveFetch = resolve; });
+    const harness = createHarness({ fetchImpl: async () => response });
+    harness.run(`state.currentEmail = { id: 'mail-1', size: 128, html: '', text: 'hello', headers: {}, attachments: [] }`);
+
+    const first = harness.run(`setEmailContentTab('source', true)`);
+    const second = harness.run(`setEmailContentTab('source', true)`);
+    assert.equal(harness.fetchRequests.length, 1);
+    resolveFetch({
+        ok: true,
+        status: 200,
+        body: null,
+        headers: { get: () => null },
+        async text() { return 'Subject: hello\r\n\r\nbody'; }
+    });
+    await Promise.all([first, second]);
+
+    assert.equal(harness.run(`emailSourceCache.get('mail-1')`), 'Subject: hello\r\n\r\nbody');
+    assert.equal(harness.run('emailSourceRequests.size'), 0);
+    assert.equal(harness.emailSourceTab.focused, true);
+});
+
+test('large sources use the standalone view without an inline fetch', async () => {
+    const harness = createHarness();
+    harness.run(`state.currentEmail = { id: 'large-mail', size: EMAIL_SOURCE_INLINE_MAX_BYTES + 1, html: '', text: '', headers: {}, attachments: [] }`);
+
+    await harness.run(`setEmailContentTab('source')`);
+
+    assert.equal(harness.fetchRequests.length, 0);
+    assert.equal(harness.run(`emailSourceOversized.has('large-mail')`), true);
+    assert.match(harness.emailDetail.innerHTML, /too large to display safely inline/);
+    assert.match(harness.emailDetail.innerHTML, /View Source/);
 });
 
 test('changing the viewport resizes the existing frame without reloading or losing stage scroll', () => {

--- a/tests/web/app.test.js
+++ b/tests/web/app.test.js
@@ -363,7 +363,7 @@ test('email detail offers HTML, text, headers, and source tabs', () => {
     assert.match(markup, /role="tabpanel"/);
     assert.match(markup, /tabindex="0"/);
     for (const locale of ['zh-CN', 'en', 'de', 'it', 'fr', 'ko', 'ja']) {
-        assert.equal(harness.run(`Boolean(translations[${JSON.stringify(locale)}].contentSource)`), true);
+        assert.equal(harness.run(`Boolean(i18n[${JSON.stringify(locale)}].contentSource)`), true);
     }
 });
 

--- a/tests/web/app.test.js
+++ b/tests/web/app.test.js
@@ -353,6 +353,16 @@ test('HTML previews expose every responsive viewport preset', () => {
     assert.match(preview, /referrerpolicy="no-referrer"/);
 });
 
+test('email detail offers HTML, text, headers, and source tabs', () => {
+    const harness = createHarness();
+    const markup = harness.run(`renderEmailContentTabs({ id: 'mail-1', html: '<p>hello</p>', text: 'hello', headers: { subject: 'hello' }, attachments: [] })`);
+    for (const tab of ['HTML', 'Plain text', 'Headers', 'Source']) {
+        assert.equal(markup.includes(tab), true);
+    }
+    assert.match(markup, /role="tablist"/);
+    assert.match(markup, /role="tabpanel"/);
+});
+
 test('changing the viewport resizes the existing frame without reloading or losing stage scroll', () => {
     const harness = createHarness();
     const preview = harness.run(`renderHTML('<p>Keep me</p>', 'mail-42', [])`);

--- a/tests/web/app.test.js
+++ b/tests/web/app.test.js
@@ -367,6 +367,7 @@ test('email detail offers HTML, text, headers, and source tabs', () => {
     assert.match(markup, /role="tablist"/);
     assert.match(markup, /role="tabpanel"/);
     assert.match(markup, /tabindex="0"/);
+    assert.match(markup, /onclick="setEmailContentTab\('source', true\)"/);
     for (const locale of ['zh-CN', 'en', 'de', 'it', 'fr', 'ko', 'ja']) {
         assert.equal(harness.run(`Boolean(i18n[${JSON.stringify(locale)}].contentSource)`), true);
     }

--- a/tests/web/app.test.js
+++ b/tests/web/app.test.js
@@ -361,6 +361,36 @@ test('email detail offers HTML, text, headers, and source tabs', () => {
     }
     assert.match(markup, /role="tablist"/);
     assert.match(markup, /role="tabpanel"/);
+    assert.match(markup, /tabindex="0"/);
+    for (const locale of ['zh-CN', 'en', 'de', 'it', 'fr', 'ko', 'ja']) {
+        assert.equal(harness.run(`Boolean(translations[${JSON.stringify(locale)}].contentSource)`), true);
+    }
+});
+
+test('email content tabs support arrow-key navigation', () => {
+    const harness = createHarness();
+    harness.run(`state.currentEmail = { id: 'mail-1', html: '', text: 'hello', headers: {}, attachments: [] }; emailContentTab = 'text'`);
+    let prevented = false;
+    harness.run(`handleEmailContentTabKeydown({ key: 'ArrowRight', preventDefault() { globalThis.prevented = true; } }, 'text')`);
+    prevented = harness.run('globalThis.prevented');
+    assert.equal(prevented, true);
+    assert.equal(harness.run('emailContentTab'), 'headers');
+});
+
+test('source load failures replace the loading placeholder', async () => {
+    const harness = createHarness({
+        fetchImpl: async () => ({
+            ok: false,
+            status: 500,
+            headers: { get: () => 'application/json' },
+            async json() { return { message: 'source unavailable' }; },
+            async text() { return '{"message":"source unavailable"}'; }
+        })
+    });
+    harness.run(`state.currentEmail = { id: 'mail-1', html: '', text: 'hello', headers: {}, attachments: [] }`);
+    await harness.run(`setEmailContentTab('source')`);
+    assert.equal(harness.emailDetail.innerHTML.includes('Loading source'), false);
+    assert.equal(harness.emailDetail.innerHTML.includes('source unavailable'), true);
 });
 
 test('changing the viewport resizes the existing frame without reloading or losing stage scroll', () => {

--- a/tests/web/app.test.js
+++ b/tests/web/app.test.js
@@ -150,6 +150,7 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
     };
     const document = {
         title: '',
+		activeElement: null,
         documentElement: { lang: '', dataset: {} },
         body: { classList: createClassList() },
         addEventListener(name, handler) { documentListeners.set(name, handler); },
@@ -162,6 +163,12 @@ function createHarness({ permission = 'default', secure = true, savedPreference 
         },
         createElement() { return createElement(); }
     };
+	for (const element of elements.values()) {
+		element.focus = function focus() {
+			this.focused = true;
+			document.activeElement = this;
+		};
+	}
     const navigator = { language: 'en-US' };
     if (serviceWorker) {
 		const activeRegistration = {
@@ -450,6 +457,28 @@ test('source requests are deduplicated and keyboard focus survives completion', 
     assert.equal(harness.run(`emailSourceCache.get('mail-1')`), 'Subject: hello\r\n\r\nbody');
     assert.equal(harness.run('emailSourceRequests.size'), 0);
     assert.equal(harness.emailSourceTab.focused, true);
+});
+
+test('source completion does not steal focus moved to another control', async () => {
+	let resolveFetch;
+	const response = new Promise((resolve) => { resolveFetch = resolve; });
+	const harness = createHarness({ fetchImpl: async () => response });
+	harness.run(`state.currentEmail = { id: 'mail-1', size: 128, html: '', text: 'hello', headers: {}, attachments: [] }`);
+
+	const loading = harness.run(`setEmailContentTab('source', true)`);
+	harness.emailSourceTab.focused = false;
+	harness.run(`document.activeElement = { id: 'another-control' }`);
+	resolveFetch({
+		ok: true,
+		status: 200,
+		body: null,
+		headers: { get: () => null },
+		async text() { return 'Subject: hello\r\n\r\nbody'; }
+	});
+	await loading;
+
+	assert.equal(harness.emailSourceTab.focused, false);
+	assert.equal(harness.run(`document.activeElement.id`), 'another-control');
 });
 
 test('large sources use the standalone view without an inline fetch', async () => {

--- a/web/app.js
+++ b/web/app.js
@@ -61,6 +61,7 @@ const i18n = {
         contentHeaders: '邮件头',
         contentSource: '源码',
         sourceLoading: '正在加载源码…',
+        sourceTooLarge: '邮件源码过大，无法在页面内安全显示。',
         // API Error Codes
         'EMAIL_NOT_FOUND': '邮件未找到',
         'EMAIL_FILE_NOT_FOUND': '邮件文件未找到',
@@ -147,6 +148,7 @@ const i18n = {
         contentHeaders: 'Headers',
         contentSource: 'Source',
         sourceLoading: 'Loading source…',
+        sourceTooLarge: 'This message source is too large to display safely inline.',
         // API Error Codes
         'EMAIL_NOT_FOUND': 'Email not found',
         'EMAIL_FILE_NOT_FOUND': 'Email file not found',
@@ -227,6 +229,7 @@ const i18n = {
         contentHeaders: 'Kopfzeilen',
         contentSource: 'Quelltext',
         sourceLoading: 'Quelltext wird geladen…',
+        sourceTooLarge: 'Der Nachrichtenquelltext ist zu groß für eine sichere Anzeige auf dieser Seite.',
         // API Error Codes
         'EMAIL_NOT_FOUND': 'E-Mail nicht gefunden',
         'EMAIL_FILE_NOT_FOUND': 'E-Mail-Datei nicht gefunden',
@@ -307,6 +310,7 @@ const i18n = {
         contentHeaders: 'Intestazioni',
         contentSource: 'Sorgente',
         sourceLoading: 'Caricamento sorgente…',
+        sourceTooLarge: 'Il sorgente del messaggio è troppo grande per essere visualizzato in modo sicuro nella pagina.',
         // API Error Codes
         'EMAIL_NOT_FOUND': 'Email non trovata',
         'EMAIL_FILE_NOT_FOUND': 'File email non trovato',
@@ -387,6 +391,7 @@ const i18n = {
         contentHeaders: 'En-têtes',
         contentSource: 'Source',
         sourceLoading: 'Chargement de la source…',
+        sourceTooLarge: 'La source du message est trop volumineuse pour être affichée en toute sécurité dans la page.',
         // API Error Codes
         'EMAIL_NOT_FOUND': 'Email introuvable',
         'EMAIL_FILE_NOT_FOUND': 'Fichier email introuvable',
@@ -467,6 +472,7 @@ const i18n = {
         contentHeaders: '헤더',
         contentSource: '원본',
         sourceLoading: '원본을 불러오는 중…',
+        sourceTooLarge: '메시지 원본이 너무 커서 페이지 안에 안전하게 표시할 수 없습니다.',
         // API Error Codes
         'EMAIL_NOT_FOUND': '이메일을 찾을 수 없습니다',
         'EMAIL_FILE_NOT_FOUND': '이메일 파일을 찾을 수 없습니다',
@@ -547,6 +553,7 @@ const i18n = {
         contentHeaders: 'ヘッダー',
         contentSource: 'ソース',
         sourceLoading: 'ソースを読み込み中…',
+        sourceTooLarge: 'メッセージのソースが大きすぎるため、ページ内に安全に表示できません。',
         // API Error Codes
         'EMAIL_NOT_FOUND': 'メールが見つかりません',
         'EMAIL_FILE_NOT_FOUND': 'メールファイルが見つかりません',
@@ -838,6 +845,8 @@ function clearEmailSelection(historyMode = 'push') {
     remoteContentAllowedEmailID = null;
     emailSourceCache.clear();
     emailSourceErrors.clear();
+    emailSourceOversized.clear();
+    emailSourceRequests.clear();
     state.currentEmail = null;
     renderEmailDetail();
     renderEmailList();
@@ -899,8 +908,11 @@ const EMAIL_VIEWPORT_PRESETS = Object.freeze([
 ]);
 let emailViewportPreset = '100%';
 let emailContentTab = 'html';
+const EMAIL_SOURCE_INLINE_MAX_BYTES = 1024 * 1024;
 const emailSourceCache = new Map();
 const emailSourceErrors = new Map();
+const emailSourceOversized = new Set();
+const emailSourceRequests = new Map();
 
 // Remote resources are enabled only for the currently rendered message after
 // an explicit user action. The choice is intentionally not persisted.
@@ -1188,9 +1200,33 @@ const API = {
         return await handleAPIResponse(response);
     },
 
-    async getEmailSource(id) {
+    async getEmailSource(id, maximumBytes = EMAIL_SOURCE_INLINE_MAX_BYTES) {
         const response = await fetch(`${API_BASE}/emails/${id}/source`);
-        return await handleAPIResponse(response);
+        if (!response.ok) return await handleAPIResponse(response);
+        const contentLength = Number(response.headers.get('content-length'));
+        if (Number.isFinite(contentLength) && contentLength > maximumBytes) {
+            return { oversized: true, source: '' };
+        }
+        if (!response.body || typeof response.body.getReader !== 'function') {
+            const source = await response.text();
+            return new Blob([source]).size > maximumBytes
+                ? { oversized: true, source: '' }
+                : { oversized: false, source };
+        }
+        const reader = response.body.getReader();
+        const chunks = [];
+        let received = 0;
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            received += value.byteLength;
+            if (received > maximumBytes) {
+                await reader.cancel();
+                return { oversized: true, source: '' };
+            }
+            chunks.push(value);
+        }
+        return { oversized: false, source: await new Blob(chunks).text() };
     },
 
     async deleteEmail(id) {
@@ -1486,6 +1522,9 @@ function renderEmailContentPanel(email) {
     case 'headers':
         return `<pre class="email-detail-source">${escapeHtml(JSON.stringify(email.headers || {}, null, 2))}</pre>`;
     case 'source': {
+        if (emailSourceOversized.has(email.id)) {
+            return `<div class="email-detail-source-notice">${escapeHtml(t('sourceTooLarge'))} <button type="button" class="btn btn-secondary" onclick="viewEmailSource('${email.id}')">${t('viewSource')}</button></div>`;
+        }
         const source = emailSourceCache.get(email.id);
         const sourceError = emailSourceErrors.get(email.id);
         if (sourceError !== undefined) {
@@ -1509,19 +1548,42 @@ async function setEmailContentTab(tab, restoreFocus = false) {
     if (restoreFocus) {
         document.getElementById(`email-content-tab-${tab}`)?.focus?.();
     }
-    if (tab !== 'source' || emailSourceCache.has(email.id)) return;
-    emailSourceErrors.delete(email.id);
-    try {
-        const source = await API.getEmailSource(email.id);
-        emailSourceCache.set(email.id, source);
-        emailSourceErrors.delete(email.id);
-        if (state.currentEmail && state.currentEmail.id === email.id && emailContentTab === 'source') renderEmailDetail();
-    } catch (error) {
-        console.error('Failed to load email source:', error);
-        emailSourceErrors.set(email.id, parseAPIError(error));
-        if (state.currentEmail && state.currentEmail.id === email.id && emailContentTab === 'source') renderEmailDetail();
-        alert(t('loadEmailDetailError', { error: parseAPIError(error) }));
+    if (tab !== 'source' || emailSourceCache.has(email.id) || emailSourceOversized.has(email.id)) return;
+    if (Number(email.size) > EMAIL_SOURCE_INLINE_MAX_BYTES) {
+        emailSourceOversized.add(email.id);
+        renderEmailDetail();
+        if (restoreFocus) document.getElementById(`email-content-tab-${tab}`)?.focus?.();
+        return;
     }
+    emailSourceErrors.delete(email.id);
+    let request = emailSourceRequests.get(email.id);
+    if (!request) {
+        request = { restoreFocus: false };
+        request.promise = API.getEmailSource(email.id, EMAIL_SOURCE_INLINE_MAX_BYTES)
+            .then((result) => {
+                if (emailSourceRequests.get(email.id) !== request) return;
+                if (result.oversized) emailSourceOversized.add(email.id);
+                else emailSourceCache.set(email.id, result.source);
+                emailSourceErrors.delete(email.id);
+            })
+            .catch((error) => {
+                if (emailSourceRequests.get(email.id) !== request) return;
+                console.error('Failed to load email source:', error);
+                const message = parseAPIError(error);
+                emailSourceErrors.set(email.id, message);
+                alert(t('loadEmailDetailError', { error: message }));
+            })
+            .finally(() => {
+                if (emailSourceRequests.get(email.id) === request) emailSourceRequests.delete(email.id);
+                if (state.currentEmail && state.currentEmail.id === email.id && emailContentTab === 'source') {
+                    renderEmailDetail();
+                    if (request.restoreFocus) document.getElementById('email-content-tab-source')?.focus?.();
+                }
+            });
+        emailSourceRequests.set(email.id, request);
+    }
+    if (restoreFocus) request.restoreFocus = true;
+    await request.promise;
 }
 
 function handleEmailContentTabKeydown(event, tab) {
@@ -1747,6 +1809,8 @@ async function loadEmailDetail(id, { historyMode = 'push' } = {}) {
         remoteContentAllowedEmailID = null;
         emailSourceCache.clear();
         emailSourceErrors.clear();
+        emailSourceOversized.clear();
+        emailSourceRequests.clear();
         emailContentTab = email.html ? 'html' : 'text';
         state.currentEmail = email;
         renderEmailDetail();

--- a/web/app.js
+++ b/web/app.js
@@ -56,6 +56,11 @@ const i18n = {
         emailPreviewTitle: '隔离的邮件 HTML 预览',
         emailViewportPresets: '预览宽度',
         emailViewportWidth: '邮件预览宽度：{width}',
+        contentHTML: 'HTML',
+        contentText: '纯文本',
+        contentHeaders: '邮件头',
+        contentSource: '源码',
+        sourceLoading: '正在加载源码…',
         // API Error Codes
         'EMAIL_NOT_FOUND': '邮件未找到',
         'EMAIL_FILE_NOT_FOUND': '邮件文件未找到',
@@ -137,6 +142,11 @@ const i18n = {
         emailPreviewTitle: 'Isolated email HTML preview',
         emailViewportPresets: 'Preview width',
         emailViewportWidth: 'Email preview width: {width}',
+        contentHTML: 'HTML',
+        contentText: 'Plain text',
+        contentHeaders: 'Headers',
+        contentSource: 'Source',
+        sourceLoading: 'Loading source…',
         // API Error Codes
         'EMAIL_NOT_FOUND': 'Email not found',
         'EMAIL_FILE_NOT_FOUND': 'Email file not found',
@@ -801,6 +811,7 @@ let emailDetailRequestSequence = 0;
 function clearEmailSelection(historyMode = 'push') {
     emailDetailRequestSequence += 1;
     remoteContentAllowedEmailID = null;
+    emailSourceCache.clear();
     state.currentEmail = null;
     renderEmailDetail();
     renderEmailList();
@@ -861,6 +872,8 @@ const EMAIL_VIEWPORT_PRESETS = Object.freeze([
     { key: '320', label: '320 px', width: '320px' }
 ]);
 let emailViewportPreset = '100%';
+let emailContentTab = 'html';
+const emailSourceCache = new Map();
 
 // Remote resources are enabled only for the currently rendered message after
 // an explicit user action. The choice is intentionally not persisted.
@@ -1148,6 +1161,11 @@ const API = {
         return await handleAPIResponse(response);
     },
 
+    async getEmailSource(id) {
+        const response = await fetch(`${API_BASE}/emails/${id}/source`);
+        return await handleAPIResponse(response);
+    },
+
     async deleteEmail(id) {
         const response = await fetch(`${API_BASE}/emails/${id}`, {
             method: 'DELETE'
@@ -1407,11 +1425,61 @@ function renderEmailDetail() {
                 <span>${time}</span>
             </div>
         </div>
-        <div class="email-detail-body">
-            ${email.html ? renderHTML(email.html, email.id, email.attachments || []) : renderText(email.text || '')}
-        </div>
+        ${renderEmailContentTabs(email)}
         ${attachments}
     `;
+}
+
+function renderEmailContentTabs(email) {
+    const availableTabs = ['html', 'text', 'headers', 'source'];
+    if (!availableTabs.includes(emailContentTab) || (emailContentTab === 'html' && !email.html)) {
+        emailContentTab = email.html ? 'html' : 'text';
+    }
+    const labels = { html: 'contentHTML', text: 'contentText', headers: 'contentHeaders', source: 'contentSource' };
+    return `
+        <div class="email-content-tabs" role="tablist" aria-label="${t('emailList')}">
+            ${availableTabs.map((tab) => `
+                <button type="button" role="tab" class="email-content-tab"
+                    aria-selected="${emailContentTab === tab}" ${tab === 'html' && !email.html ? 'disabled' : ''}
+                    onclick="setEmailContentTab('${tab}')">${t(labels[tab])}</button>
+            `).join('')}
+        </div>
+        <div class="email-detail-body" role="tabpanel">${renderEmailContentPanel(email)}</div>
+    `;
+}
+
+function renderEmailContentPanel(email) {
+    switch (emailContentTab) {
+    case 'html':
+        return renderHTML(email.html || '', email.id, email.attachments || []);
+    case 'headers':
+        return `<pre class="email-detail-source">${escapeHtml(JSON.stringify(email.headers || {}, null, 2))}</pre>`;
+    case 'source': {
+        const source = emailSourceCache.get(email.id);
+        return source === undefined
+            ? `<div class="loading">${t('sourceLoading')}</div>`
+            : `<pre class="email-detail-source">${escapeHtml(source)}</pre>`;
+    }
+    default:
+        return renderText(email.text || '');
+    }
+}
+
+async function setEmailContentTab(tab) {
+    const email = state.currentEmail;
+    if (!email || !['html', 'text', 'headers', 'source'].includes(tab)) return;
+    if (tab === 'html' && !email.html) return;
+    emailContentTab = tab;
+    renderEmailDetail();
+    if (tab !== 'source' || emailSourceCache.has(email.id)) return;
+    try {
+        const source = await API.getEmailSource(email.id);
+        emailSourceCache.set(email.id, source);
+        if (state.currentEmail && state.currentEmail.id === email.id && emailContentTab === 'source') renderEmailDetail();
+    } catch (error) {
+        console.error('Failed to load email source:', error);
+        alert(t('loadEmailDetailError', { error: parseAPIError(error) }));
+    }
 }
 
 function hasRemoteEmailResources(html) {
@@ -1619,6 +1687,8 @@ async function loadEmailDetail(id, { historyMode = 'push' } = {}) {
         if (requestSequence !== emailDetailRequestSequence) return;
         if (historyMode === 'none' && currentEmailIDFromLocation() !== id) return;
         remoteContentAllowedEmailID = null;
+        emailSourceCache.clear();
+        emailContentTab = email.html ? 'html' : 'text';
         state.currentEmail = email;
         renderEmailDetail();
         renderEmailList(); // Update selected state
@@ -1968,4 +2038,5 @@ document.addEventListener('DOMContentLoaded', () => {
 window.deleteEmail = deleteEmail;
 window.downloadEmail = downloadEmail;
 window.viewEmailSource = viewEmailSource;
+window.setEmailContentTab = setEmailContentTab;
 window.t = t; // Make translation function available globally

--- a/web/app.js
+++ b/web/app.js
@@ -1551,18 +1551,19 @@ async function setEmailContentTab(tab, restoreFocus = false) {
     if (!email || !['html', 'text', 'headers', 'source'].includes(tab)) return;
     if (tab === 'html' && !email.html) return;
     emailContentTab = tab;
+    const shouldLoadSource = tab === 'source' && !emailSourceCache.has(email.id) && !emailSourceOversized.has(email.id);
+    if (shouldLoadSource) emailSourceErrors.delete(email.id);
     renderEmailDetail();
     if (restoreFocus) {
         document.getElementById(`email-content-tab-${tab}`)?.focus?.();
     }
-    if (tab !== 'source' || emailSourceCache.has(email.id) || emailSourceOversized.has(email.id)) return;
+    if (!shouldLoadSource) return;
     if (Number(email.size) > EMAIL_SOURCE_INLINE_MAX_BYTES) {
         emailSourceOversized.add(email.id);
         renderEmailDetail();
         if (restoreFocus) document.getElementById(`email-content-tab-${tab}`)?.focus?.();
         return;
     }
-    emailSourceErrors.delete(email.id);
     let request = emailSourceRequests.get(email.id);
     if (!request) {
         request = { restoreFocus: false };

--- a/web/app.js
+++ b/web/app.js
@@ -1584,8 +1584,10 @@ async function setEmailContentTab(tab, restoreFocus = false) {
             .finally(() => {
                 if (emailSourceRequests.get(email.id) === request) emailSourceRequests.delete(email.id);
                 if (state.currentEmail && state.currentEmail.id === email.id && emailContentTab === 'source') {
+					const sourceTab = document.getElementById('email-content-tab-source');
+					const shouldRestoreFocus = request.restoreFocus && document.activeElement === sourceTab;
                     renderEmailDetail();
-                    if (request.restoreFocus) document.getElementById('email-content-tab-source')?.focus?.();
+					if (shouldRestoreFocus) document.getElementById('email-content-tab-source')?.focus?.();
                 }
             });
         emailSourceRequests.set(email.id, request);

--- a/web/app.js
+++ b/web/app.js
@@ -13,6 +13,7 @@ const i18n = {
         searchPlaceholder: '搜索邮件...',
         search: '搜索',
         emailList: '邮件列表',
+        emailContentViews: '邮件内容视图',
         emailCount: '{count} 封邮件',
         loading: '加载中...',
         noEmails: '暂无邮件',
@@ -94,6 +95,7 @@ const i18n = {
         searchPlaceholder: 'Search emails...',
         search: 'Search',
         emailList: 'Email List',
+        emailContentViews: 'Email content views',
         emailCount: '{count} emails',
         emailCount_one: '{count} email',
         loading: 'Loading...',
@@ -181,6 +183,7 @@ const i18n = {
         searchPlaceholder: 'E-Mails suchen...',
         search: 'Suchen',
         emailList: 'E-Mail-Liste',
+        emailContentViews: 'E-Mail-Inhaltsansichten',
         emailCount: '{count} E-Mails',
         loading: 'Laden...',
         noEmails: 'Keine E-Mails',
@@ -262,6 +265,7 @@ const i18n = {
         searchPlaceholder: 'Cerca email...',
         search: 'Cerca',
         emailList: 'Elenco Email',
+        emailContentViews: 'Visualizzazioni contenuto email',
         emailCount: '{count} email',
         loading: 'Caricamento...',
         noEmails: 'Nessuna email',
@@ -343,6 +347,7 @@ const i18n = {
         searchPlaceholder: 'Rechercher des emails...',
         search: 'Rechercher',
         emailList: 'Liste des Emails',
+        emailContentViews: 'Vues du contenu de l\'email',
         emailCount: '{count} emails',
         loading: 'Chargement...',
         noEmails: 'Aucun email',
@@ -424,6 +429,7 @@ const i18n = {
         searchPlaceholder: '이메일 검색...',
         search: '검색',
         emailList: '이메일 목록',
+        emailContentViews: '이메일 콘텐츠 보기',
         emailCount: '{count}개의 이메일',
         loading: '로딩 중...',
         noEmails: '이메일 없음',
@@ -505,6 +511,7 @@ const i18n = {
         searchPlaceholder: 'メールを検索...',
         search: '検索',
         emailList: 'メール一覧',
+        emailContentViews: 'メール内容表示',
         emailCount: '{count}通のメール',
         loading: '読み込み中...',
         noEmails: 'メールなし',
@@ -1500,7 +1507,7 @@ function renderEmailContentTabs(email) {
     }
     const labels = { html: 'contentHTML', text: 'contentText', headers: 'contentHeaders', source: 'contentSource' };
     return `
-        <div class="email-content-tabs" role="tablist" aria-label="${t('emailList')}">
+        <div class="email-content-tabs" role="tablist" aria-label="${t('emailContentViews')}">
             ${availableTabs.map((tab) => `
                 <button type="button" role="tab" class="email-content-tab"
                     id="email-content-tab-${tab}" aria-controls="email-content-panel"

--- a/web/app.js
+++ b/web/app.js
@@ -222,6 +222,11 @@ const i18n = {
         emailPreviewTitle: 'Isolierte HTML-E-Mail-Vorschau',
         emailViewportPresets: 'Vorschaubreite',
         emailViewportWidth: 'Breite der E-Mail-Vorschau: {width}',
+        contentHTML: 'HTML',
+        contentText: 'Klartext',
+        contentHeaders: 'Kopfzeilen',
+        contentSource: 'Quelltext',
+        sourceLoading: 'Quelltext wird geladen…',
         // API Error Codes
         'EMAIL_NOT_FOUND': 'E-Mail nicht gefunden',
         'EMAIL_FILE_NOT_FOUND': 'E-Mail-Datei nicht gefunden',
@@ -297,6 +302,11 @@ const i18n = {
         emailPreviewTitle: 'Anteprima HTML email isolata',
         emailViewportPresets: 'Larghezza anteprima',
         emailViewportWidth: 'Larghezza anteprima email: {width}',
+        contentHTML: 'HTML',
+        contentText: 'Testo semplice',
+        contentHeaders: 'Intestazioni',
+        contentSource: 'Sorgente',
+        sourceLoading: 'Caricamento sorgente…',
         // API Error Codes
         'EMAIL_NOT_FOUND': 'Email non trovata',
         'EMAIL_FILE_NOT_FOUND': 'File email non trovato',
@@ -372,6 +382,11 @@ const i18n = {
         emailPreviewTitle: 'Aperçu HTML isolé de l’e-mail',
         emailViewportPresets: 'Largeur de l’aperçu',
         emailViewportWidth: 'Largeur de l’aperçu de l’e-mail : {width}',
+        contentHTML: 'HTML',
+        contentText: 'Texte brut',
+        contentHeaders: 'En-têtes',
+        contentSource: 'Source',
+        sourceLoading: 'Chargement de la source…',
         // API Error Codes
         'EMAIL_NOT_FOUND': 'Email introuvable',
         'EMAIL_FILE_NOT_FOUND': 'Fichier email introuvable',
@@ -447,6 +462,11 @@ const i18n = {
         emailPreviewTitle: '격리된 이메일 HTML 미리보기',
         emailViewportPresets: '미리보기 너비',
         emailViewportWidth: '이메일 미리보기 너비: {width}',
+        contentHTML: 'HTML',
+        contentText: '일반 텍스트',
+        contentHeaders: '헤더',
+        contentSource: '원본',
+        sourceLoading: '원본을 불러오는 중…',
         // API Error Codes
         'EMAIL_NOT_FOUND': '이메일을 찾을 수 없습니다',
         'EMAIL_FILE_NOT_FOUND': '이메일 파일을 찾을 수 없습니다',
@@ -522,6 +542,11 @@ const i18n = {
         emailPreviewTitle: '隔離されたメール HTML プレビュー',
         emailViewportPresets: 'プレビュー幅',
         emailViewportWidth: 'メールプレビュー幅: {width}',
+        contentHTML: 'HTML',
+        contentText: 'プレーンテキスト',
+        contentHeaders: 'ヘッダー',
+        contentSource: 'ソース',
+        sourceLoading: 'ソースを読み込み中…',
         // API Error Codes
         'EMAIL_NOT_FOUND': 'メールが見つかりません',
         'EMAIL_FILE_NOT_FOUND': 'メールファイルが見つかりません',
@@ -812,6 +837,7 @@ function clearEmailSelection(historyMode = 'push') {
     emailDetailRequestSequence += 1;
     remoteContentAllowedEmailID = null;
     emailSourceCache.clear();
+    emailSourceErrors.clear();
     state.currentEmail = null;
     renderEmailDetail();
     renderEmailList();
@@ -874,6 +900,7 @@ const EMAIL_VIEWPORT_PRESETS = Object.freeze([
 let emailViewportPreset = '100%';
 let emailContentTab = 'html';
 const emailSourceCache = new Map();
+const emailSourceErrors = new Map();
 
 // Remote resources are enabled only for the currently rendered message after
 // an explicit user action. The choice is intentionally not persisted.
@@ -1440,11 +1467,15 @@ function renderEmailContentTabs(email) {
         <div class="email-content-tabs" role="tablist" aria-label="${t('emailList')}">
             ${availableTabs.map((tab) => `
                 <button type="button" role="tab" class="email-content-tab"
-                    aria-selected="${emailContentTab === tab}" ${tab === 'html' && !email.html ? 'disabled' : ''}
-                    onclick="setEmailContentTab('${tab}')">${t(labels[tab])}</button>
+                    id="email-content-tab-${tab}" aria-controls="email-content-panel"
+                    aria-selected="${emailContentTab === tab}" tabindex="${emailContentTab === tab ? '0' : '-1'}"
+                    ${tab === 'html' && !email.html ? 'disabled' : ''}
+                    onclick="setEmailContentTab('${tab}')"
+                    onkeydown="handleEmailContentTabKeydown(event, '${tab}')">${t(labels[tab])}</button>
             `).join('')}
         </div>
-        <div class="email-detail-body" role="tabpanel">${renderEmailContentPanel(email)}</div>
+        <div id="email-content-panel" class="email-detail-body" role="tabpanel"
+            aria-labelledby="email-content-tab-${emailContentTab}">${renderEmailContentPanel(email)}</div>
     `;
 }
 
@@ -1456,6 +1487,10 @@ function renderEmailContentPanel(email) {
         return `<pre class="email-detail-source">${escapeHtml(JSON.stringify(email.headers || {}, null, 2))}</pre>`;
     case 'source': {
         const source = emailSourceCache.get(email.id);
+        const sourceError = emailSourceErrors.get(email.id);
+        if (sourceError !== undefined) {
+            return `<div class="error">${escapeHtml(t('loadEmailDetailError', { error: sourceError }))}</div>`;
+        }
         return source === undefined
             ? `<div class="loading">${t('sourceLoading')}</div>`
             : `<pre class="email-detail-source">${escapeHtml(source)}</pre>`;
@@ -1465,21 +1500,44 @@ function renderEmailContentPanel(email) {
     }
 }
 
-async function setEmailContentTab(tab) {
+async function setEmailContentTab(tab, restoreFocus = false) {
     const email = state.currentEmail;
     if (!email || !['html', 'text', 'headers', 'source'].includes(tab)) return;
     if (tab === 'html' && !email.html) return;
     emailContentTab = tab;
     renderEmailDetail();
+    if (restoreFocus) {
+        document.getElementById(`email-content-tab-${tab}`)?.focus?.();
+    }
     if (tab !== 'source' || emailSourceCache.has(email.id)) return;
+    emailSourceErrors.delete(email.id);
     try {
         const source = await API.getEmailSource(email.id);
         emailSourceCache.set(email.id, source);
+        emailSourceErrors.delete(email.id);
         if (state.currentEmail && state.currentEmail.id === email.id && emailContentTab === 'source') renderEmailDetail();
     } catch (error) {
         console.error('Failed to load email source:', error);
+        emailSourceErrors.set(email.id, parseAPIError(error));
+        if (state.currentEmail && state.currentEmail.id === email.id && emailContentTab === 'source') renderEmailDetail();
         alert(t('loadEmailDetailError', { error: parseAPIError(error) }));
     }
+}
+
+function handleEmailContentTabKeydown(event, tab) {
+    const email = state.currentEmail;
+    if (!email) return;
+    const tabs = ['html', 'text', 'headers', 'source'].filter((candidate) => candidate !== 'html' || email.html);
+    const current = tabs.indexOf(tab);
+    if (current < 0) return;
+    let next = current;
+    if (event.key === 'ArrowRight') next = (current + 1) % tabs.length;
+    else if (event.key === 'ArrowLeft') next = (current - 1 + tabs.length) % tabs.length;
+    else if (event.key === 'Home') next = 0;
+    else if (event.key === 'End') next = tabs.length - 1;
+    else return;
+    event.preventDefault();
+    void setEmailContentTab(tabs[next], true);
 }
 
 function hasRemoteEmailResources(html) {
@@ -1688,6 +1746,7 @@ async function loadEmailDetail(id, { historyMode = 'push' } = {}) {
         if (historyMode === 'none' && currentEmailIDFromLocation() !== id) return;
         remoteContentAllowedEmailID = null;
         emailSourceCache.clear();
+        emailSourceErrors.clear();
         emailContentTab = email.html ? 'html' : 'text';
         state.currentEmail = email;
         renderEmailDetail();
@@ -2039,4 +2098,5 @@ window.deleteEmail = deleteEmail;
 window.downloadEmail = downloadEmail;
 window.viewEmailSource = viewEmailSource;
 window.setEmailContentTab = setEmailContentTab;
+window.handleEmailContentTabKeydown = handleEmailContentTabKeydown;
 window.t = t; // Make translation function available globally

--- a/web/app.js
+++ b/web/app.js
@@ -1506,7 +1506,7 @@ function renderEmailContentTabs(email) {
                     id="email-content-tab-${tab}" aria-controls="email-content-panel"
                     aria-selected="${emailContentTab === tab}" tabindex="${emailContentTab === tab ? '0' : '-1'}"
                     ${tab === 'html' && !email.html ? 'disabled' : ''}
-                    onclick="setEmailContentTab('${tab}')"
+                    onclick="setEmailContentTab('${tab}', true)"
                     onkeydown="handleEmailContentTabKeydown(event, '${tab}')">${t(labels[tab])}</button>
             `).join('')}
         </div>

--- a/web/style.css
+++ b/web/style.css
@@ -321,6 +321,47 @@ body {
     margin-top: 30px;
 }
 
+.email-content-tabs {
+    display: flex;
+    gap: 4px;
+    margin-top: 24px;
+    border-bottom: 1px solid #dfe4e8;
+}
+
+.email-content-tab {
+    padding: 9px 14px;
+    border: 0;
+    border-bottom: 2px solid transparent;
+    background: transparent;
+    color: #5d6d7e;
+    cursor: pointer;
+    font: inherit;
+}
+
+.email-content-tab[aria-selected="true"] {
+    border-bottom-color: #3498db;
+    color: #2980b9;
+    font-weight: 600;
+}
+
+.email-content-tab:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+}
+
+.email-detail-source {
+    margin: 0;
+    padding: 16px;
+    overflow: auto;
+    border: 1px solid #dfe4e8;
+    border-radius: 4px;
+    background: #f7f9fa;
+    color: #2c3e50;
+    font: 13px/1.55 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+
 .email-detail-text {
     white-space: pre-wrap;
     line-height: 1.8;
@@ -575,6 +616,15 @@ body {
         max-height: 400px;
     }
 
+    .email-content-tabs {
+        overflow-x: auto;
+    }
+
+    .email-content-tab {
+        flex: 0 0 auto;
+        min-height: 40px;
+    }
+
     .header-content {
         flex-direction: column;
         align-items: flex-start;
@@ -746,6 +796,24 @@ body.dark-theme .email-detail-meta {
 }
 
 body.dark-theme .email-detail-text {
+    color: #e0e0e0;
+}
+
+body.dark-theme .email-content-tabs {
+    border-bottom-color: #444;
+}
+
+body.dark-theme .email-content-tab {
+    color: #b8c2cc;
+}
+
+body.dark-theme .email-content-tab[aria-selected="true"] {
+    color: #5dade2;
+}
+
+body.dark-theme .email-detail-source {
+    border-color: #444;
+    background: #1a1a1a;
     color: #e0e0e0;
 }
 


### PR DESCRIPTION
## Summary

- add accessible HTML, plain-text, headers, and raw-source tabs to the message detail view
- keep isolated HTML preview behavior and responsive viewport controls unchanged
- fetch raw source only when its tab is first opened and cache only the current message
- add responsive and dark-theme styles plus browser-harness coverage

## Tests

- `node --check web/app.js`
- `go test ./...`
- `git diff --check`

Bun is not installed in the execution environment, so the new Bun browser test was added but not executed locally.