### PR TITLE
feat(mcp): add a read-only stdio bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,10 @@ MCP is disabled by default. Enable the official Streamable HTTP endpoint with
 an authenticated Web deployment therefore requires the same Basic Auth
 credentials for every MCP request.
 
+Local MCP clients may instead launch `owlmail mcp-stdio -mail-directory DIR`.
+This reuses the same read-only tools over stdio without opening a listener;
+protocol output stays on stdout and logs are sent to stderr.
+
 The server exposes seven read-only tools, adding `get_latest_email` and the
 event-driven `wait_for_email` testing workflow to the existing compact query,
 detached detail, bounded source, and attachment-metadata tools. It also exposes

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -842,7 +842,20 @@ func startServers(server *mailserver.MailServer, cfg *config.Config) error {
 	return nil
 }
 
-func runMCPStdio(ctx context.Context, args []string, stderr io.Writer) error {
+type reportedMCPStdioError struct{ err error }
+
+func (err *reportedMCPStdioError) Error() string { return err.err.Error() }
+func (err *reportedMCPStdioError) Unwrap() error { return err.err }
+
+func runMCPStdio(ctx context.Context, args []string, stderr io.Writer) (resultErr error) {
+	loggerReady := false
+	defer func() {
+		if resultErr == nil || !loggerReady || errors.Is(resultErr, flag.ErrHelp) || errors.Is(resultErr, context.Canceled) {
+			return
+		}
+		common.Error("MCP stdio bridge failed: %v", resultErr)
+		resultErr = &reportedMCPStdioError{err: resultErr}
+	}()
 	fs := flag.NewFlagSet("mcp-stdio", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	refs := config.DefineFlags(fs)
@@ -854,6 +867,7 @@ func runMCPStdio(ctx context.Context, args []string, stderr io.Writer) error {
 		return err
 	}
 	common.InitLoggerOutputWithFormat(parseLogLevel(cfg.LogLevel), cfg.LogFormat, stderr)
+	loggerReady = true
 	if strings.TrimSpace(cfg.MailDir) == "" {
 		return fmt.Errorf("mcp-stdio requires -mail-directory or OWLMAIL_MAIL_DIR")
 	}
@@ -973,7 +987,8 @@ func main() {
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		err := runMCPStdio(ctx, os.Args[2:], os.Stderr)
 		stop()
-		if err != nil && !errors.Is(err, flag.ErrHelp) && !errors.Is(err, context.Canceled) {
+		var reported *reportedMCPStdioError
+		if err != nil && !errors.Is(err, flag.ErrHelp) && !errors.Is(err, context.Canceled) && !errors.As(err, &reported) {
 			_, _ = fmt.Fprintf(os.Stderr, "MCP stdio bridge failed: %v\n", err)
 			os.Exit(1)
 		}

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -31,6 +31,7 @@ import (
 )
 
 const generatedWebPasswordBytes = 24
+const mcpRefreshErrorLogInterval = time.Minute
 
 const (
 	defaultAttachmentMigrationRetries    = 3
@@ -850,12 +851,14 @@ func runMCPStdio(ctx context.Context, args []string, stderr io.Writer) error {
 		return err
 	}
 	defer func() { _ = server.Close() }()
+	var lastRefreshErrorReport time.Time
 	if err := server.RefreshReadOnlyMailbox(); err != nil {
 		var partial *mailserver.ReadOnlyRefreshPartialError
 		if !errors.As(err, &partial) {
 			return fmt.Errorf("load read-only mailbox: %w", err)
 		}
 		common.Error("MCP stdio mailbox loaded with skipped entries: %v", err)
+		lastRefreshErrorReport = time.Now()
 	}
 	sessionTimeout, err := time.ParseDuration(cfg.MCPSessionTimeout)
 	if err != nil || sessionTimeout <= 0 {
@@ -889,7 +892,13 @@ func runMCPStdio(ctx context.Context, args []string, stderr io.Writer) error {
 				return
 			case <-ticker.C:
 				if err := server.RefreshReadOnlyMailbox(); err != nil {
-					common.Error("MCP stdio mailbox refresh failed: %v", err)
+					now := time.Now()
+					if lastRefreshErrorReport.IsZero() || now.Sub(lastRefreshErrorReport) >= mcpRefreshErrorLogInterval {
+						common.Error("MCP stdio mailbox refresh failed: %v", err)
+						lastRefreshErrorReport = now
+					}
+				} else {
+					lastRefreshErrorReport = time.Time{}
 				}
 			}
 		}

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -15,6 +15,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -841,11 +842,17 @@ func runMCPStdio(ctx context.Context, args []string, stderr io.Writer) error {
 		return err
 	}
 	common.InitLoggerOutput(parseLogLevel(cfg.LogLevel), stderr)
-	server, err := createMailServer(cfg)
+	if strings.TrimSpace(cfg.MailDir) == "" {
+		return fmt.Errorf("mcp-stdio requires -mail-directory or OWLMAIL_MAIL_DIR")
+	}
+	server, err := mailserver.NewMailServerWithOptions(cfg.SMTPPort, cfg.SMTPHost, cfg.MailDir, mailserver.ServerOptions{ReadOnly: true})
 	if err != nil {
 		return err
 	}
 	defer func() { _ = server.Close() }()
+	if err := server.RefreshReadOnlyMailbox(); err != nil {
+		return fmt.Errorf("load read-only mailbox: %w", err)
+	}
 	sessionTimeout, err := time.ParseDuration(cfg.MCPSessionTimeout)
 	if err != nil || sessionTimeout <= 0 {
 		return fmt.Errorf("invalid MCP session timeout %q", cfg.MCPSessionTimeout)
@@ -865,6 +872,28 @@ func runMCPStdio(ctx context.Context, args []string, stderr io.Writer) error {
 		return err
 	}
 	defer func() { _ = service.Close() }()
+	watchContext, stopWatcher := context.WithCancel(ctx)
+	var watcher sync.WaitGroup
+	watcher.Add(1)
+	go func() {
+		defer watcher.Done()
+		ticker := time.NewTicker(500 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-watchContext.Done():
+				return
+			case <-ticker.C:
+				if err := server.RefreshReadOnlyMailbox(); err != nil {
+					common.Error("MCP stdio mailbox refresh failed: %v", err)
+				}
+			}
+		}
+	}()
+	defer func() {
+		stopWatcher()
+		watcher.Wait()
+	}()
 	return service.RunStdio(ctx)
 }
 

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -820,6 +820,54 @@ func startServers(server *mailserver.MailServer, cfg *config.Config) error {
 	return nil
 }
 
+func runMCPStdio(ctx context.Context, args []string, stderr io.Writer) error {
+	fs := flag.NewFlagSet("mcp-stdio", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	refs := config.DefineFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	cfg := config.ResolveConfig(fs, refs)
+	// The bridge is a read-only mailbox process. Ignore unrelated delivery and
+	// retention settings even if they are present in the parent environment.
+	cfg.OutgoingHost = ""
+	cfg.AutoRelay = false
+	cfg.WebhookConfig = ""
+	cfg.WebhookRedisURL = ""
+	cfg.MailRetentionDays = 0
+	cfg.MailMaxMessages = 0
+	cfg.MailMaxDiskMB = 0
+	if err := config.ValidateConfig(cfg); err != nil {
+		return err
+	}
+	common.InitLoggerOutput(parseLogLevel(cfg.LogLevel), stderr)
+	server, err := createMailServer(cfg)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = server.Close() }()
+	sessionTimeout, err := time.ParseDuration(cfg.MCPSessionTimeout)
+	if err != nil || sessionTimeout <= 0 {
+		return fmt.Errorf("invalid MCP session timeout %q", cfg.MCPSessionTimeout)
+	}
+	shutdownTimeout, err := time.ParseDuration(cfg.MCPShutdownTimeout)
+	if err != nil || shutdownTimeout <= 0 {
+		return fmt.Errorf("invalid MCP shutdown timeout %q", cfg.MCPShutdownTimeout)
+	}
+	webBaseURL, err := mcpWebBaseURL(cfg)
+	if err != nil {
+		return err
+	}
+	service, err := mcpserver.New(server, mcpserver.Options{
+		SessionTimeout: sessionTimeout, ShutdownTimeout: shutdownTimeout, WebBaseURL: webBaseURL,
+	})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = service.Close() }()
+	return service.RunStdio(ctx)
+}
+
 func main() {
 	if len(os.Args) > 1 && os.Args[1] == "sendmail" {
 		os.Exit(sendmail.Run(os.Args[2:], os.Stdin, os.Stdout, os.Stderr))
@@ -830,6 +878,16 @@ func main() {
 		stop()
 		if err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Attachment migration failed: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	if len(os.Args) > 1 && os.Args[1] == "mcp-stdio" {
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		err := runMCPStdio(ctx, os.Args[2:], os.Stderr)
+		stop()
+		if err != nil && !errors.Is(err, flag.ErrHelp) && !errors.Is(err, context.Canceled) {
+			_, _ = fmt.Fprintf(os.Stderr, "MCP stdio bridge failed: %v\n", err)
 			os.Exit(1)
 		}
 		return

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -851,7 +851,11 @@ func runMCPStdio(ctx context.Context, args []string, stderr io.Writer) error {
 	}
 	defer func() { _ = server.Close() }()
 	if err := server.RefreshReadOnlyMailbox(); err != nil {
-		return fmt.Errorf("load read-only mailbox: %w", err)
+		var partial *mailserver.ReadOnlyRefreshPartialError
+		if !errors.As(err, &partial) {
+			return fmt.Errorf("load read-only mailbox: %w", err)
+		}
+		common.Error("MCP stdio mailbox loaded with skipped entries: %v", err)
 	}
 	sessionTimeout, err := time.ParseDuration(cfg.MCPSessionTimeout)
 	if err != nil || sessionTimeout <= 0 {

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -850,23 +850,14 @@ func runMCPStdio(ctx context.Context, args []string, stderr io.Writer) error {
 		return err
 	}
 	cfg := config.ResolveConfig(fs, refs)
-	// The bridge is a read-only mailbox process. Ignore unrelated delivery and
-	// retention settings even if they are present in the parent environment.
-	cfg.OutgoingHost = ""
-	cfg.AutoRelay = false
-	cfg.WebhookConfig = ""
-	cfg.WebhookRedisURL = ""
-	cfg.MailRetentionDays = 0
-	cfg.MailMaxMessages = 0
-	cfg.MailMaxDiskMB = 0
-	if err := config.ValidateConfig(cfg); err != nil {
+	if err := validateMCPStdioConfig(cfg); err != nil {
 		return err
 	}
-	common.InitLoggerOutput(parseLogLevel(cfg.LogLevel), stderr)
+	common.InitLoggerOutputWithFormat(parseLogLevel(cfg.LogLevel), cfg.LogFormat, stderr)
 	if strings.TrimSpace(cfg.MailDir) == "" {
 		return fmt.Errorf("mcp-stdio requires -mail-directory or OWLMAIL_MAIL_DIR")
 	}
-	server, err := mailserver.NewMailServerWithOptions(cfg.SMTPPort, cfg.SMTPHost, cfg.MailDir, mailserver.ServerOptions{ReadOnly: true})
+	server, err := mailserver.NewMailServerWithOptions(0, "localhost", cfg.MailDir, mailserver.ServerOptions{ReadOnly: true})
 	if err != nil {
 		return err
 	}
@@ -928,6 +919,40 @@ func runMCPStdio(ctx context.Context, args []string, stderr io.Writer) error {
 		watcher.Wait()
 	}()
 	return service.RunStdio(ctx)
+}
+
+func validateMCPStdioConfig(cfg *config.Config) error {
+	if cfg == nil {
+		return fmt.Errorf("config cannot be nil")
+	}
+	if err := config.ValidateLogLevel(cfg.LogLevel); err != nil {
+		return err
+	}
+	if err := config.ValidateLogFormat(cfg.LogFormat); err != nil {
+		return err
+	}
+	if _, err := config.NormalizeBasePathname(cfg.BasePathname); err != nil {
+		return err
+	}
+	externalURL, err := config.NormalizeWebExternalURL(cfg.WebExternalURL)
+	if err != nil {
+		return err
+	}
+	if externalURL == "" {
+		if cfg.WebExternalScheme != "" && cfg.WebExternalScheme != "http" && cfg.WebExternalScheme != "https" {
+			return fmt.Errorf("web external scheme must be http or https")
+		}
+		if err := config.ValidatePort(cfg.WebPort, "Web port"); err != nil {
+			return err
+		}
+	}
+	if sessionTimeout, err := time.ParseDuration(cfg.MCPSessionTimeout); err != nil || sessionTimeout <= 0 {
+		return fmt.Errorf("MCP session timeout must be a positive duration")
+	}
+	if shutdownTimeout, err := time.ParseDuration(cfg.MCPShutdownTimeout); err != nil || shutdownTimeout <= 0 {
+		return fmt.Errorf("MCP shutdown timeout must be a positive duration")
+	}
+	return nil
 }
 
 func main() {

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -969,6 +969,17 @@ func validateMCPStdioConfig(cfg *config.Config) error {
 	return nil
 }
 
+func reportMCPStdioResult(err error, stderr io.Writer) int {
+	if err == nil || errors.Is(err, flag.ErrHelp) || errors.Is(err, context.Canceled) {
+		return 0
+	}
+	var reported *reportedMCPStdioError
+	if !errors.As(err, &reported) {
+		_, _ = fmt.Fprintf(stderr, "MCP stdio bridge failed: %v\n", err)
+	}
+	return 1
+}
+
 func main() {
 	if len(os.Args) > 1 && os.Args[1] == "sendmail" {
 		os.Exit(sendmail.Run(os.Args[2:], os.Stdin, os.Stdout, os.Stderr))
@@ -987,10 +998,8 @@ func main() {
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		err := runMCPStdio(ctx, os.Args[2:], os.Stderr)
 		stop()
-		var reported *reportedMCPStdioError
-		if err != nil && !errors.Is(err, flag.ErrHelp) && !errors.Is(err, context.Canceled) && !errors.As(err, &reported) {
-			_, _ = fmt.Fprintf(os.Stderr, "MCP stdio bridge failed: %v\n", err)
-			os.Exit(1)
+		if exitCode := reportMCPStdioResult(err, os.Stderr); exitCode != 0 {
+			os.Exit(exitCode)
 		}
 		return
 	}

--- a/cmd/owlmail/mcp_stdio_test.go
+++ b/cmd/owlmail/mcp_stdio_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"strings"
+	"testing"
+)
+
+func TestRunMCPStdioHelp(t *testing.T) {
+	var stderr bytes.Buffer
+	err := runMCPStdio(context.Background(), []string{"-h"}, &stderr)
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("runMCPStdio(-h) error = %v", err)
+	}
+	if !strings.Contains(stderr.String(), "mail-directory") {
+		t.Fatalf("help did not include mailbox configuration: %s", stderr.String())
+	}
+}

--- a/cmd/owlmail/mcp_stdio_test.go
+++ b/cmd/owlmail/mcp_stdio_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -40,5 +42,24 @@ func TestValidateMCPStdioConfigIgnoresUnusedServerSettings(t *testing.T) {
 	cfg.LogFormat = "invalid"
 	if err := validateMCPStdioConfig(cfg); err == nil {
 		t.Fatal("stdio validation accepted an invalid active log format")
+	}
+}
+
+func TestRunMCPStdioFormatsTerminalErrorsAsJSON(t *testing.T) {
+	var stderr bytes.Buffer
+	err := runMCPStdio(context.Background(), []string{
+		"-log-format", "json",
+		"-mail-directory", filepath.Join(t.TempDir(), "missing"),
+	}, &stderr)
+	var reported *reportedMCPStdioError
+	if !errors.As(err, &reported) {
+		t.Fatalf("runMCPStdio() error = %v, want reportedMCPStdioError", err)
+	}
+	var entry map[string]interface{}
+	if decodeErr := json.Unmarshal(bytes.TrimSpace(stderr.Bytes()), &entry); decodeErr != nil {
+		t.Fatalf("terminal stderr is not JSON: %q: %v", stderr.String(), decodeErr)
+	}
+	if entry["level"] != "error" || !strings.Contains(entry["message"].(string), "MCP stdio bridge failed") {
+		t.Fatalf("terminal JSON entry = %#v", entry)
 	}
 }

--- a/cmd/owlmail/mcp_stdio_test.go
+++ b/cmd/owlmail/mcp_stdio_test.go
@@ -7,6 +7,8 @@ import (
 	"flag"
 	"strings"
 	"testing"
+
+	"github.com/soulteary/owlmail/internal/config"
 )
 
 func TestRunMCPStdioHelp(t *testing.T) {
@@ -17,5 +19,26 @@ func TestRunMCPStdioHelp(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "mail-directory") {
 		t.Fatalf("help did not include mailbox configuration: %s", stderr.String())
+	}
+}
+
+func TestValidateMCPStdioConfigIgnoresUnusedServerSettings(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.SMTPMaxMessageMB = -1
+	cfg.MailCleanupInterval = "never"
+	cfg.OutgoingHost = "smtp.example.test"
+	cfg.OutgoingPort = -1
+	cfg.WebhookMaxConcurrency = -1
+	cfg.WebhookRedisPrefix = ""
+	cfg.WebhookShutdownTimeout = "never"
+	cfg.S3Enabled = true
+	cfg.S3Bucket = ""
+
+	if err := validateMCPStdioConfig(cfg); err != nil {
+		t.Fatalf("stdio validation rejected an unused server setting: %v", err)
+	}
+	cfg.LogFormat = "invalid"
+	if err := validateMCPStdioConfig(cfg); err == nil {
+		t.Fatal("stdio validation accepted an invalid active log format")
 	}
 }

--- a/cmd/owlmail/mcp_stdio_test.go
+++ b/cmd/owlmail/mcp_stdio_test.go
@@ -63,3 +63,30 @@ func TestRunMCPStdioFormatsTerminalErrorsAsJSON(t *testing.T) {
 		t.Fatalf("terminal JSON entry = %#v", entry)
 	}
 }
+
+
+func TestReportMCPStdioResult(t *testing.T) {
+	reportedCause := errors.New("already logged")
+	for _, test := range []struct {
+		name       string
+		err        error
+		wantCode   int
+		wantOutput bool
+	}{
+		{name: "success", wantCode: 0},
+		{name: "help", err: flag.ErrHelp, wantCode: 0},
+		{name: "canceled", err: context.Canceled, wantCode: 0},
+		{name: "unreported failure", err: errors.New("transport failed"), wantCode: 1, wantOutput: true},
+		{name: "reported failure", err: &reportedMCPStdioError{err: reportedCause}, wantCode: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			if code := reportMCPStdioResult(test.err, &stderr); code != test.wantCode {
+				t.Fatalf("exit code = %d, want %d", code, test.wantCode)
+			}
+			if got := stderr.Len() > 0; got != test.wantOutput {
+				t.Fatalf("stderr present = %t, want %t: %q", got, test.wantOutput, stderr.String())
+			}
+		})
+	}
+}

--- a/cmd/owlmail/mcp_stdio_test.go
+++ b/cmd/owlmail/mcp_stdio_test.go
@@ -64,7 +64,6 @@ func TestRunMCPStdioFormatsTerminalErrorsAsJSON(t *testing.T) {
 	}
 }
 
-
 func TestReportMCPStdioResult(t *testing.T) {
 	reportedCause := errors.New("already logged")
 	for _, test := range []struct {

--- a/docs/en/Operations.md
+++ b/docs/en/Operations.md
@@ -435,6 +435,24 @@ Configure the MCP client URL as `http://localhost:1080/mcp` and send the Basic
 Auth credentials above. For a remotely reachable endpoint, use HTTPS and
 network access controls in addition to authentication.
 
+For local agent clients that launch a subprocess, the same read-only surface is
+available over stdio without opening an HTTP listener:
+
+```json
+{
+  "mcpServers": {
+    "owlmail": {
+      "command": "/absolute/path/to/owlmail",
+      "args": ["mcp-stdio", "-mail-directory", "/absolute/path/to/maildir"]
+    }
+  }
+}
+```
+
+Protocol messages use stdout and OwlMail logs use stderr. The stdio command
+ignores relay, webhook, and retention settings inherited from the environment,
+so its MCP tools and process remain read-only.
+
 ## HTTPS and TLS
 
 Web HTTPS and SMTP TLS are separate settings:

--- a/docs/en/Operations.md
+++ b/docs/en/Operations.md
@@ -451,7 +451,10 @@ available over stdio without opening an HTTP listener:
 
 Protocol messages use stdout and OwlMail logs use stderr. The stdio command
 ignores relay, webhook, and retention settings inherited from the environment,
-so its MCP tools and process remain read-only.
+so its MCP tools and process remain read-only. The mail directory must already
+exist. The bridge rescans committed EML files every 500 ms using a read-only
+loader; it never runs storage recovery, metadata migration, or quarantine, and
+new captures become visible to queries and `wait_for_email`.
 
 ## HTTPS and TLS
 

--- a/docs/zh-CN/Operations.md
+++ b/docs/zh-CN/Operations.md
@@ -373,6 +373,23 @@ fragment 和 path 的 HTTP(S) origin。代理子路径继续通过 `-base-pathna
 将 MCP 客户端 URL 配置为 `http://localhost:1080/mcp` 并携带上述 Basic Auth。
 远程可访问时，除认证外还应使用 HTTPS 和网络访问控制。
 
+对于由本地代理客户端启动的子进程，同一套只读能力也可以通过 stdio 使用，且不会
+打开 HTTP 监听端口：
+
+```json
+{
+  "mcpServers": {
+    "owlmail": {
+      "command": "/absolute/path/to/owlmail",
+      "args": ["mcp-stdio", "-mail-directory", "/absolute/path/to/maildir"]
+    }
+  }
+}
+```
+
+协议消息写入 stdout，OwlMail 日志写入 stderr。stdio 命令会忽略从环境继承的中继、
+Webhook 与保留策略配置，使 MCP 工具和该进程保持只读。
+
 ## HTTPS 与 TLS
 
 Web HTTPS 与 SMTP TLS 是两组独立设置：

--- a/docs/zh-CN/Operations.md
+++ b/docs/zh-CN/Operations.md
@@ -388,7 +388,9 @@ fragment 和 path 的 HTTP(S) origin。代理子路径继续通过 `-base-pathna
 ```
 
 协议消息写入 stdout，OwlMail 日志写入 stderr。stdio 命令会忽略从环境继承的中继、
-Webhook 与保留策略配置，使 MCP 工具和该进程保持只读。
+Webhook 与保留策略配置，使 MCP 工具和该进程保持只读。邮件目录必须已经存在。
+bridge 每 500 ms 使用只读加载器扫描已提交的 EML 文件；不会执行存储恢复、元数据
+迁移或隔离，新捕获邮件会进入查询结果与 `wait_for_email`。
 
 ## HTTPS 与 TLS
 

--- a/internal/common/logger.go
+++ b/internal/common/logger.go
@@ -58,7 +58,13 @@ func InitLogger(level LogLevel) {
 // InitLoggerOutput initializes the global console logger on a selected stream.
 // Stdio protocols use stderr so logs cannot corrupt protocol messages.
 func InitLoggerOutput(level LogLevel, output io.Writer) {
-	initLogger(level, "console", output)
+	InitLoggerOutputWithFormat(level, "console", output)
+}
+
+// InitLoggerOutputWithFormat initializes the global logger in console or JSON
+// form on a selected stream.
+func InitLoggerOutputWithFormat(level LogLevel, format string, output io.Writer) {
+	initLogger(level, format, output)
 }
 
 // InitLoggerWithFormat initializes the global logger in console or JSON form.

--- a/internal/common/logger.go
+++ b/internal/common/logger.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"sync"
 
@@ -50,12 +51,18 @@ func getLoggerUnsafe() *logger.Logger {
 // InitLogger initializes the global logger. Holds the lock for the whole call so it does
 // not race with Log/Verbose/Error: logger.New() writes zerolog globals, and Msg() reads them.
 func InitLogger(level LogLevel) {
+	InitLoggerOutput(level, os.Stdout)
+}
+
+// InitLoggerOutput initializes the global console logger on a selected stream.
+// Stdio protocols use stderr so logs cannot corrupt protocol messages.
+func InitLoggerOutput(level LogLevel, output io.Writer) {
 	defaultLogMu.Lock()
 	defer defaultLogMu.Unlock()
 	kitLevel := owlmailToLoggerLevel(level)
 	l := logger.New(logger.Config{
 		Level:       kitLevel,
-		Output:      os.Stdout,
+		Output:      output,
 		Format:      logger.FormatConsole,
 		ServiceName: "owlmail",
 	})

--- a/internal/common/logger_test.go
+++ b/internal/common/logger_test.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 )
 
@@ -67,6 +69,21 @@ func TestConvenienceFunctions(t *testing.T) {
 
 func TestInitLoggerSilentMode(t *testing.T) {
 	InitLogger(LogLevelSilent)
+}
+
+func TestInitLoggerOutputWithFormatUsesJSON(t *testing.T) {
+	var output bytes.Buffer
+	InitLoggerOutputWithFormat(LogLevelNormal, "json", &output)
+	defer InitLogger(LogLevelNormal)
+	Log("stdio diagnostic")
+
+	var entry map[string]interface{}
+	if err := json.Unmarshal(output.Bytes(), &entry); err != nil {
+		t.Fatalf("stderr log is not JSON: %q: %v", output.String(), err)
+	}
+	if entry["message"] != "stdio diagnostic" {
+		t.Fatalf("JSON message = %#v", entry["message"])
+	}
 }
 
 // TestGlobalFatalWithErrorHandler tests global Fatal function with error handler

--- a/internal/mailserver/attachment_migration.go
+++ b/internal/mailserver/attachment_migration.go
@@ -536,7 +536,7 @@ func persistMigrationMetadata(mailDir string, metadata emailMetadata) error {
 	server := &MailServer{mailDir: mailDir}
 	// Reuse the normal atomic temp-write, fsync, rename, and directory-fsync
 	// path without constructing or starting a MailServer.
-	email := &Email{ID: metadata.ID, Read: metadata.Read, Attachments: make([]*Attachment, 0, len(metadata.Attachments))}
+	email := &Email{\n\t\tID:          metadata.ID,\n\t\tRead:        metadata.Read,\n\t\tEnvelope:    cloneEnvelope(metadata.Envelope),\n\t\tAttachments: make([]*Attachment, 0, len(metadata.Attachments)),\n\t}
 	for _, saved := range metadata.Attachments {
 		email.Attachments = append(email.Attachments, &Attachment{
 			GeneratedFileName: saved.GeneratedFileName,

--- a/internal/mailserver/attachment_migration.go
+++ b/internal/mailserver/attachment_migration.go
@@ -536,7 +536,12 @@ func persistMigrationMetadata(mailDir string, metadata emailMetadata) error {
 	server := &MailServer{mailDir: mailDir}
 	// Reuse the normal atomic temp-write, fsync, rename, and directory-fsync
 	// path without constructing or starting a MailServer.
-	email := &Email{\n\t\tID:          metadata.ID,\n\t\tRead:        metadata.Read,\n\t\tEnvelope:    cloneEnvelope(metadata.Envelope),\n\t\tAttachments: make([]*Attachment, 0, len(metadata.Attachments)),\n\t}
+	email := &Email{
+		ID:          metadata.ID,
+		Read:        metadata.Read,
+		Envelope:    cloneEnvelope(metadata.Envelope),
+		Attachments: make([]*Attachment, 0, len(metadata.Attachments)),
+	}
 	for _, saved := range metadata.Attachments {
 		email.Attachments = append(email.Attachments, &Attachment{
 			GeneratedFileName: saved.GeneratedFileName,

--- a/internal/mailserver/attachment_migration_test.go
+++ b/internal/mailserver/attachment_migration_test.go
@@ -123,6 +123,39 @@ func migrationMetadata(t *testing.T, directory, id string) emailMetadata {
 	return metadata
 }
 
+func TestPersistMigrationMetadataPreservesEnvelope(t *testing.T) {
+	directory := t.TempDir()
+	sequence := time.Now().UTC()
+	metadata := emailMetadata{
+		Version:  currentMetadataVersion,
+		ID:       "preserve-envelope",
+		Read:     true,
+		Sequence: sequence,
+		Envelope: &Envelope{
+			From:          "sender@example.test",
+			To:            []string{"visible@example.test", "blind@example.test"},
+			CC:            []string{"copy@example.test"},
+			BCC:           []string{"blind@example.test"},
+			CalculatedBCC: []string{"blind@example.test"},
+			Host:          "mx.example.test",
+			RemoteAddress: "192.0.2.1:2525",
+		},
+	}
+
+	if err := persistMigrationMetadata(directory, metadata); err != nil {
+		t.Fatal(err)
+	}
+	got := migrationMetadata(t, directory, metadata.ID)
+	if got.Envelope == nil || got.Envelope.From != metadata.Envelope.From ||
+		len(got.Envelope.To) != 2 || got.Envelope.To[1] != "blind@example.test" ||
+		len(got.Envelope.CC) != 1 || got.Envelope.CC[0] != "copy@example.test" ||
+		len(got.Envelope.BCC) != 1 || got.Envelope.BCC[0] != "blind@example.test" ||
+		len(got.Envelope.CalculatedBCC) != 1 || got.Envelope.CalculatedBCC[0] != "blind@example.test" ||
+		got.Envelope.Host != metadata.Envelope.Host || got.Envelope.RemoteAddress != metadata.Envelope.RemoteAddress {
+		t.Fatalf("persisted envelope = %#v, want %#v", got.Envelope, metadata.Envelope)
+	}
+}
+
 func TestAttachmentMigrationPreflightHonorsCancellation(t *testing.T) {
 	directory := t.TempDir()
 	_, path := createLocalMigrationMessage(t, directory, "preflight-canceled", multipartMessage())

--- a/internal/mailserver/config.go
+++ b/internal/mailserver/config.go
@@ -99,8 +99,15 @@ func NewMailServerWithOptions(port int, host, mailDir string, options ServerOpti
 		maxRecipients = defaultSMTPMaxRecipients
 	}
 
-	// Create mail directory
-	if err := os.MkdirAll(mailDir, 0755); err != nil {
+	if options.ReadOnly {
+		info, err := os.Stat(mailDir)
+		if err != nil {
+			return nil, fmt.Errorf("open read-only mail directory: %w", err)
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("read-only mail path is not a directory")
+		}
+	} else if err := os.MkdirAll(mailDir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create mail directory: %w", err)
 	}
 
@@ -149,10 +156,12 @@ func NewMailServerWithOptions(port int, host, mailDir string, options ServerOpti
 
 	common.Log("owlmail using directory %s", mailDir)
 
-	// Load existing emails from directory
-	if err := ms.LoadMailsFromDirectory(); err != nil {
-		common.Error("Failed to load emails from directory: %v", err)
-		// Continue anyway, as this is not a fatal error
+	// Read-only observers explicitly refresh through the non-mutating loader.
+	if !options.ReadOnly {
+		if err := ms.LoadMailsFromDirectory(); err != nil {
+			common.Error("Failed to load emails from directory: %v", err)
+			// Continue anyway, as this is not a fatal error
+		}
 	}
 	if ms.mailboxIndex != nil {
 		if err := ms.rebuildMailboxIndex(); err != nil {

--- a/internal/mailserver/read_only.go
+++ b/internal/mailserver/read_only.go
@@ -169,7 +169,12 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 		ms.storeOrder = append(ms.storeOrder, id)
 	}
 	sort.SliceStable(ms.storeOrder, func(i, j int) bool {
-		return ms.receivedAtByID[ms.storeOrder[i]].Before(ms.receivedAtByID[ms.storeOrder[j]])
+		left, right := ms.storeOrder[i], ms.storeOrder[j]
+		leftTime, rightTime := ms.receivedAtByID[left], ms.receivedAtByID[right]
+		if leftTime.Equal(rightTime) {
+			return left < right
+		}
+		return leftTime.Before(rightTime)
 	})
 	ms.resetMailboxStorePositionsLocked()
 	ms.storeMutex.Unlock()

--- a/internal/mailserver/read_only.go
+++ b/internal/mailserver/read_only.go
@@ -146,7 +146,7 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 				continue
 			}
 		}
-		if len(email.Attachments) > 0 && (item.metadata == nil || len(item.metadata.Attachments) == 0) {
+		if len(email.Attachments) > 0 && !item.metadataUncertain && (item.metadata == nil || len(item.metadata.Attachments) == 0) {
 			if err := ms.restoreLegacyLocalAttachmentMetadata(id, email.Attachments); err != nil {
 				refreshErrors = append(refreshErrors, fmt.Errorf("restore legacy attachment metadata for %s: %w", id, err))
 				continue

--- a/internal/mailserver/read_only.go
+++ b/internal/mailserver/read_only.go
@@ -146,6 +146,25 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 		loaded[id] = email
 	}
 
+	// A writer in another process may start or complete deletion while this
+	// observer parses an EML from the initial directory snapshot. Recheck the
+	// durable transaction markers and source path immediately before publishing
+	// any parsed or previously known entry into the refreshed snapshot.
+	for id := range candidates {
+		if ms.beforeReadOnlyPublish != nil {
+			ms.beforeReadOnlyPublish(id)
+		}
+		visible, visibilityErr := ms.readOnlyEmailVisible(id)
+		if visibilityErr != nil {
+			uncertainIDs[id] = struct{}{}
+			refreshErrors = append(refreshErrors, fmt.Errorf("recheck email %s before publication: %w", id, visibilityErr))
+		}
+		if !visible {
+			delete(candidates, id)
+			delete(loaded, id)
+		}
+	}
+
 	newEmails := make([]*Email, 0, len(loaded))
 	ms.storeMutex.Lock()
 	for id := range ms.storeByID {
@@ -205,4 +224,30 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 		return &ReadOnlyRefreshPartialError{err: err}
 	}
 	return nil
+}
+
+func (ms *MailServer) readOnlyEmailVisible(id string) (bool, error) {
+	if _, err := os.Lstat(deletionFencePath(ms.mailDir, id)); err == nil {
+		return false, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+
+	rollbackPath := rollbackFencePath(ms.mailDir, id)
+	if state, err := readRollbackFenceState(rollbackPath); err == nil {
+		if state != acceptedFenceState && state != localFenceState {
+			return false, nil
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+
+	info, err := os.Stat(filepath.Join(ms.mailDir, id+".eml"))
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return !info.IsDir(), nil
 }

--- a/internal/mailserver/read_only.go
+++ b/internal/mailserver/read_only.go
@@ -147,18 +147,32 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 	}
 
 	// A writer in another process may start or complete deletion while this
-	// observer parses an EML from the initial directory snapshot. Recheck the
-	// durable transaction markers and source path immediately before publishing
-	// any parsed or previously known entry into the refreshed snapshot.
+	// observer parses an EML from the initial directory snapshot. Take one fresh
+	// directory snapshot immediately before publication: an in-progress delete
+	// has a fence, while a completed delete no longer has its source EML.
 	for id := range candidates {
-		visible, visibilityErr := ms.readOnlyEmailVisible(id)
-		if visibilityErr != nil {
-			uncertainIDs[id] = struct{}{}
-			refreshErrors = append(refreshErrors, fmt.Errorf("recheck email %s before publication: %w", id, visibilityErr))
+		if ms.beforeReadOnlyPublish != nil {
+			ms.beforeReadOnlyPublish(id)
 		}
-		if !visible {
+	}
+	visible, visibilityErrors, visibilityErr := ms.readOnlyVisibilitySnapshot()
+	if visibilityErr != nil {
+		refreshErrors = append(refreshErrors, fmt.Errorf("rescan mail directory before publication: %w", visibilityErr))
+		for id := range candidates {
+			uncertainIDs[id] = struct{}{}
 			delete(candidates, id)
 			delete(loaded, id)
+		}
+	} else {
+		for id := range candidates {
+			if itemErr := visibilityErrors[id]; itemErr != nil {
+				uncertainIDs[id] = struct{}{}
+				refreshErrors = append(refreshErrors, fmt.Errorf("recheck email %s before publication: %w", id, itemErr))
+			}
+			if !visible[id] {
+				delete(candidates, id)
+				delete(loaded, id)
+			}
 		}
 	}
 
@@ -223,37 +237,40 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 	return nil
 }
 
-func (ms *MailServer) readOnlyEmailVisible(id string) (bool, error) {
-	info, err := os.Stat(filepath.Join(ms.mailDir, id+".eml"))
-	if errors.Is(err, os.ErrNotExist) {
-		return false, nil
-	}
+func (ms *MailServer) readOnlyVisibilitySnapshot() (map[string]bool, map[string]error, error) {
+	entries, err := os.ReadDir(ms.mailDir)
 	if err != nil {
-		return false, err
+		return nil, nil, err
 	}
-	if info.IsDir() {
-		return false, nil
-	}
-
-	// Transaction fences are the final publication gate. In particular, the
-	// deletion fence is checked last so a deletion started after either the
-	// source stat or rollback-fence read wins over the stale source observation.
-	if ms.beforeReadOnlyPublish != nil {
-		ms.beforeReadOnlyPublish(id)
-	}
-	rollbackPath := rollbackFencePath(ms.mailDir, id)
-	if state, err := readRollbackFenceState(rollbackPath); err == nil {
-		if state != acceptedFenceState && state != localFenceState {
-			return false, nil
+	visible := make(map[string]bool)
+	visibilityErrors := make(map[string]error)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".eml") {
+			continue
 		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return false, err
+		id := strings.TrimSuffix(entry.Name(), ".eml")
+		if validateEmailID(id) == nil {
+			visible[id] = true
+		}
 	}
-	if _, err := os.Lstat(deletionFencePath(ms.mailDir, id)); err == nil {
-		return false, nil
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return false, err
+	for _, entry := range entries {
+		if id, ok := deletionFenceID(entry.Name()); ok {
+			delete(visible, id)
+			continue
+		}
+		id, ok := rollbackFenceID(entry.Name())
+		if !ok {
+			continue
+		}
+		state, stateErr := readRollbackFenceState(filepath.Join(ms.mailDir, entry.Name()))
+		if stateErr != nil {
+			delete(visible, id)
+			visibilityErrors[id] = stateErr
+			continue
+		}
+		if state != acceptedFenceState && state != localFenceState {
+			delete(visible, id)
+		}
 	}
-
-	return true, nil
+	return visible, visibilityErrors, nil
 }

--- a/internal/mailserver/read_only.go
+++ b/internal/mailserver/read_only.go
@@ -149,6 +149,7 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 		if len(email.Attachments) > 0 && (item.metadata == nil || len(item.metadata.Attachments) == 0) {
 			if err := ms.restoreLegacyLocalAttachmentMetadata(id, email.Attachments); err != nil {
 				refreshErrors = append(refreshErrors, fmt.Errorf("restore legacy attachment metadata for %s: %w", id, err))
+				continue
 			}
 		}
 		loaded[id] = email

--- a/internal/mailserver/read_only.go
+++ b/internal/mailserver/read_only.go
@@ -140,6 +140,9 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 		if email.HTML != "" {
 			email.HTML = strings.TrimSpace(sanitizeHTML(email.HTML))
 		}
+		if item.metadataUncertain && len(email.Attachments) > 0 {
+			continue
+		}
 		if item.metadata != nil {
 			if err := restoreAttachmentMetadata(email, *item.metadata); err != nil {
 				refreshErrors = append(refreshErrors, fmt.Errorf("restore attachment metadata for %s: %w", id, err))

--- a/internal/mailserver/read_only.go
+++ b/internal/mailserver/read_only.go
@@ -125,6 +125,9 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 			email.Time = item.receivedAt
 		}
 		email.Read = item.read
+		if item.metadata != nil && item.metadata.Envelope != nil {
+			envelope = cloneEnvelope(item.metadata.Envelope)
+		}
 		email.Envelope = envelope
 		email.Source = path
 		if info, statErr := item.entry.Info(); statErr == nil {
@@ -141,6 +144,11 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 			if err := restoreAttachmentMetadata(email, *item.metadata); err != nil {
 				refreshErrors = append(refreshErrors, fmt.Errorf("restore attachment metadata for %s: %w", id, err))
 				continue
+			}
+		}
+		if len(email.Attachments) > 0 && (item.metadata == nil || len(item.metadata.Attachments) == 0) {
+			if err := ms.restoreLegacyLocalAttachmentMetadata(id, email.Attachments); err != nil {
+				refreshErrors = append(refreshErrors, fmt.Errorf("restore legacy attachment metadata for %s: %w", id, err))
 			}
 		}
 		loaded[id] = email
@@ -197,6 +205,10 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 				if err := restoreAttachmentMetadata(updated, *item.metadata); err != nil {
 					refreshErrors = append(refreshErrors, fmt.Errorf("restore attachment metadata for %s: %w", id, err))
 					continue
+				}
+				if item.metadata.Envelope != nil {
+					updated.Envelope = cloneEnvelope(item.metadata.Envelope)
+					updated.CalculatedBCC = calculateBCC(append([]string(nil), updated.Envelope.To...), addressListToStrings(updated.To), addressListToStrings(updated.CC))
 				}
 			}
 			updated.Read = item.read

--- a/internal/mailserver/read_only.go
+++ b/internal/mailserver/read_only.go
@@ -151,9 +151,6 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 	// durable transaction markers and source path immediately before publishing
 	// any parsed or previously known entry into the refreshed snapshot.
 	for id := range candidates {
-		if ms.beforeReadOnlyPublish != nil {
-			ms.beforeReadOnlyPublish(id)
-		}
 		visible, visibilityErr := ms.readOnlyEmailVisible(id)
 		if visibilityErr != nil {
 			uncertainIDs[id] = struct{}{}
@@ -227,6 +224,24 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 }
 
 func (ms *MailServer) readOnlyEmailVisible(id string) (bool, error) {
+	info, err := os.Stat(filepath.Join(ms.mailDir, id+".eml"))
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if info.IsDir() {
+		return false, nil
+	}
+
+	// Transaction fences are the final publication gate. In particular, a
+	// deletion started after the source stat must win over this stale source
+	// observation because writers commit the deletion fence before unlinking
+	// the EML.
+	if ms.beforeReadOnlyPublish != nil {
+		ms.beforeReadOnlyPublish(id)
+	}
 	if _, err := os.Lstat(deletionFencePath(ms.mailDir, id)); err == nil {
 		return false, nil
 	} else if !errors.Is(err, os.ErrNotExist) {
@@ -242,12 +257,5 @@ func (ms *MailServer) readOnlyEmailVisible(id string) (bool, error) {
 		return false, err
 	}
 
-	info, err := os.Stat(filepath.Join(ms.mailDir, id+".eml"))
-	if errors.Is(err, os.ErrNotExist) {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	return !info.IsDir(), nil
+	return true, nil
 }

--- a/internal/mailserver/read_only.go
+++ b/internal/mailserver/read_only.go
@@ -30,10 +30,11 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 	}
 
 	type candidate struct {
-		entry      os.DirEntry
-		receivedAt time.Time
-		read       bool
-		metadata   *emailMetadata
+		entry             os.DirEntry
+		receivedAt        time.Time
+		read              bool
+		metadata          *emailMetadata
+		metadataUncertain bool
 	}
 	candidates := make(map[string]candidate)
 	var refreshErrors []error
@@ -81,6 +82,7 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 			item.receivedAt = metadata.Sequence
 			item.metadata = &metadata
 		} else if !os.IsNotExist(metadataErr) {
+			item.metadataUncertain = true
 			refreshErrors = append(refreshErrors, fmt.Errorf("read metadata for %s: %w", id, metadataErr))
 		}
 		candidates[id] = item
@@ -157,6 +159,9 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 	}
 	for id, item := range candidates {
 		if email := ms.storeByID[id]; email != nil {
+			if item.metadataUncertain {
+				continue
+			}
 			updated := cloneEmail(email)
 			if item.metadata != nil {
 				if err := restoreAttachmentMetadata(updated, *item.metadata); err != nil {

--- a/internal/mailserver/read_only.go
+++ b/internal/mailserver/read_only.go
@@ -26,6 +26,24 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 	}
 	candidates := make(map[string]candidate)
 	var refreshErrors []error
+	blockedIDs := make(map[string]struct{})
+	for _, file := range files {
+		if id, ok := deletionFenceID(file.Name()); ok {
+			blockedIDs[id] = struct{}{}
+			continue
+		}
+		if id, ok := rollbackFenceID(file.Name()); ok {
+			state, stateErr := readRollbackFenceState(filepath.Join(ms.mailDir, file.Name()))
+			if stateErr != nil {
+				blockedIDs[id] = struct{}{}
+				refreshErrors = append(refreshErrors, fmt.Errorf("read rollback fence for %s: %w", id, stateErr))
+				continue
+			}
+			if state != acceptedFenceState && state != localFenceState {
+				blockedIDs[id] = struct{}{}
+			}
+		}
+	}
 	for _, file := range files {
 		if file.IsDir() || !strings.HasSuffix(file.Name(), ".eml") {
 			continue
@@ -33,6 +51,9 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 		id := strings.TrimSuffix(file.Name(), ".eml")
 		if err := validateEmailID(id); err != nil {
 			refreshErrors = append(refreshErrors, fmt.Errorf("ignore invalid email filename %q: %w", file.Name(), err))
+			continue
+		}
+		if _, blocked := blockedIDs[id]; blocked {
 			continue
 		}
 		info, err := file.Info()

--- a/internal/mailserver/read_only.go
+++ b/internal/mailserver/read_only.go
@@ -33,6 +33,7 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 		entry      os.DirEntry
 		receivedAt time.Time
 		read       bool
+		metadata   *emailMetadata
 	}
 	candidates := make(map[string]candidate)
 	var refreshErrors []error
@@ -78,6 +79,7 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 		if metadata, metadataErr := ms.loadEmailMetadata(id); metadataErr == nil {
 			item.read = metadata.Read
 			item.receivedAt = metadata.Sequence
+			item.metadata = &metadata
 		} else if !os.IsNotExist(metadataErr) {
 			refreshErrors = append(refreshErrors, fmt.Errorf("read metadata for %s: %w", id, metadataErr))
 		}
@@ -133,8 +135,8 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 		if email.HTML != "" {
 			email.HTML = strings.TrimSpace(sanitizeHTML(email.HTML))
 		}
-		if metadata, metadataErr := ms.loadEmailMetadata(id); metadataErr == nil {
-			if err := restoreAttachmentMetadata(email, metadata); err != nil {
+		if item.metadata != nil {
+			if err := restoreAttachmentMetadata(email, *item.metadata); err != nil {
 				refreshErrors = append(refreshErrors, fmt.Errorf("restore attachment metadata for %s: %w", id, err))
 				continue
 			}
@@ -155,14 +157,21 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 	}
 	for id, item := range candidates {
 		if email := ms.storeByID[id]; email != nil {
-			email.Read = item.read
+			updated := cloneEmail(email)
+			if item.metadata != nil {
+				if err := restoreAttachmentMetadata(updated, *item.metadata); err != nil {
+					refreshErrors = append(refreshErrors, fmt.Errorf("restore attachment metadata for %s: %w", id, err))
+					continue
+				}
+			}
+			updated.Read = item.read
+			ms.storeByID[id] = updated
 			ms.receivedAtByID[id] = item.receivedAt
 		}
 	}
 	for id, email := range loaded {
 		ms.storeByID[id] = cloneEmail(email)
 		ms.receivedAtByID[id] = candidates[id].receivedAt
-		newEmails = append(newEmails, cloneEmail(email))
 	}
 	ms.storeOrder = ms.storeOrder[:0]
 	for id := range ms.storeByID {
@@ -176,6 +185,11 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 		}
 		return leftTime.Before(rightTime)
 	})
+	for _, id := range ms.storeOrder {
+		if email := loaded[id]; email != nil {
+			newEmails = append(newEmails, cloneEmail(email))
+		}
+	}
 	ms.resetMailboxStorePositionsLocked()
 	ms.storeMutex.Unlock()
 

--- a/internal/mailserver/read_only.go
+++ b/internal/mailserver/read_only.go
@@ -235,24 +235,22 @@ func (ms *MailServer) readOnlyEmailVisible(id string) (bool, error) {
 		return false, nil
 	}
 
-	// Transaction fences are the final publication gate. In particular, a
-	// deletion started after the source stat must win over this stale source
-	// observation because writers commit the deletion fence before unlinking
-	// the EML.
+	// Transaction fences are the final publication gate. In particular, the
+	// deletion fence is checked last so a deletion started after either the
+	// source stat or rollback-fence read wins over the stale source observation.
 	if ms.beforeReadOnlyPublish != nil {
 		ms.beforeReadOnlyPublish(id)
 	}
-	if _, err := os.Lstat(deletionFencePath(ms.mailDir, id)); err == nil {
-		return false, nil
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return false, err
-	}
-
 	rollbackPath := rollbackFencePath(ms.mailDir, id)
 	if state, err := readRollbackFenceState(rollbackPath); err == nil {
 		if state != acceptedFenceState && state != localFenceState {
 			return false, nil
 		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+	if _, err := os.Lstat(deletionFencePath(ms.mailDir, id)); err == nil {
+		return false, nil
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return false, err
 	}

--- a/internal/mailserver/read_only.go
+++ b/internal/mailserver/read_only.go
@@ -1,0 +1,144 @@
+package mailserver
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// RefreshReadOnlyMailbox synchronizes the in-memory snapshot with committed
+// EML files without recovery, metadata migration, quarantine, or any write to
+// the mailbox. Newly observed messages emit the ordinary in-process new event.
+func (ms *MailServer) RefreshReadOnlyMailbox() error {
+	files, err := os.ReadDir(ms.mailDir)
+	if err != nil {
+		return fmt.Errorf("read mail directory: %w", err)
+	}
+
+	type candidate struct {
+		entry      os.DirEntry
+		receivedAt time.Time
+		read       bool
+	}
+	candidates := make(map[string]candidate)
+	var refreshErrors []error
+	for _, file := range files {
+		if file.IsDir() || !strings.HasSuffix(file.Name(), ".eml") {
+			continue
+		}
+		id := strings.TrimSuffix(file.Name(), ".eml")
+		if err := validateEmailID(id); err != nil {
+			refreshErrors = append(refreshErrors, fmt.Errorf("ignore invalid email filename %q: %w", file.Name(), err))
+			continue
+		}
+		info, err := file.Info()
+		if err != nil {
+			refreshErrors = append(refreshErrors, fmt.Errorf("stat email %s: %w", id, err))
+			continue
+		}
+		item := candidate{entry: file, receivedAt: info.ModTime().UTC()}
+		if metadata, metadataErr := ms.loadEmailMetadata(id); metadataErr == nil {
+			item.read = metadata.Read
+			item.receivedAt = metadata.Sequence
+		} else if !os.IsNotExist(metadataErr) {
+			refreshErrors = append(refreshErrors, fmt.Errorf("read metadata for %s: %w", id, metadataErr))
+		}
+		candidates[id] = item
+	}
+
+	ms.storeMutex.RLock()
+	existing := make(map[string]struct{}, len(ms.storeByID))
+	for id := range ms.storeByID {
+		existing[id] = struct{}{}
+	}
+	ms.storeMutex.RUnlock()
+
+	loaded := make(map[string]*Email)
+	for id, item := range candidates {
+		if _, ok := existing[id]; ok {
+			continue
+		}
+		path := filepath.Join(ms.mailDir, item.entry.Name())
+		file, err := os.Open(path)
+		if err != nil {
+			refreshErrors = append(refreshErrors, fmt.Errorf("open email %s: %w", id, err))
+			continue
+		}
+		email, envelope, parseErr := ms.parseEmailMessage(id, file, nil, false, filepath.Join(ms.mailDir, id))
+		closeErr := file.Close()
+		if parseErr != nil || closeErr != nil {
+			if parseErr != nil {
+				refreshErrors = append(refreshErrors, fmt.Errorf("parse email %s: %w", id, parseErr))
+			}
+			if closeErr != nil {
+				refreshErrors = append(refreshErrors, fmt.Errorf("close email %s: %w", id, closeErr))
+			}
+			continue
+		}
+		if !ms.retainAllHeaders.Load() {
+			email.AllHeaders = nil
+		}
+		email.ID = id
+		if email.Time.IsZero() {
+			email.Time = item.receivedAt
+		}
+		email.Read = item.read
+		email.Envelope = envelope
+		email.Source = path
+		if info, statErr := item.entry.Info(); statErr == nil {
+			email.Size = info.Size()
+			email.SizeHuman = formatBytes(info.Size())
+		}
+		if envelope != nil {
+			email.CalculatedBCC = calculateBCC(append([]string(nil), envelope.To...), addressListToStrings(email.To), addressListToStrings(email.CC))
+		}
+		if email.HTML != "" {
+			email.HTML = strings.TrimSpace(sanitizeHTML(email.HTML))
+		}
+		if metadata, metadataErr := ms.loadEmailMetadata(id); metadataErr == nil {
+			if err := restoreAttachmentMetadata(email, metadata); err != nil {
+				refreshErrors = append(refreshErrors, fmt.Errorf("restore attachment metadata for %s: %w", id, err))
+				continue
+			}
+		}
+		loaded[id] = email
+	}
+
+	newEmails := make([]*Email, 0, len(loaded))
+	ms.storeMutex.Lock()
+	for id := range ms.storeByID {
+		if _, ok := candidates[id]; !ok {
+			delete(ms.storeByID, id)
+			delete(ms.receivedAtByID, id)
+		}
+	}
+	for id, item := range candidates {
+		if email := ms.storeByID[id]; email != nil {
+			email.Read = item.read
+			ms.receivedAtByID[id] = item.receivedAt
+		}
+	}
+	for id, email := range loaded {
+		ms.storeByID[id] = cloneEmail(email)
+		ms.receivedAtByID[id] = candidates[id].receivedAt
+		newEmails = append(newEmails, cloneEmail(email))
+	}
+	ms.storeOrder = ms.storeOrder[:0]
+	for id := range ms.storeByID {
+		ms.storeOrder = append(ms.storeOrder, id)
+	}
+	sort.SliceStable(ms.storeOrder, func(i, j int) bool {
+		return ms.receivedAtByID[ms.storeOrder[i]].Before(ms.receivedAtByID[ms.storeOrder[j]])
+	})
+	ms.resetMailboxStorePositionsLocked()
+	ms.storeMutex.Unlock()
+
+	for _, email := range newEmails {
+		ms.emitAsynchronous("new", email)
+	}
+	return errors.Join(refreshErrors...)
+}

--- a/internal/mailserver/read_only.go
+++ b/internal/mailserver/read_only.go
@@ -10,6 +10,16 @@ import (
 	"time"
 )
 
+// ReadOnlyRefreshPartialError reports files that could not be inspected while
+// preserving every mailbox entry whose state could not be determined safely.
+// The top-level mailbox directory was still readable.
+type ReadOnlyRefreshPartialError struct {
+	err error
+}
+
+func (err *ReadOnlyRefreshPartialError) Error() string { return err.err.Error() }
+func (err *ReadOnlyRefreshPartialError) Unwrap() error { return err.err }
+
 // RefreshReadOnlyMailbox synchronizes the in-memory snapshot with committed
 // EML files without recovery, metadata migration, quarantine, or any write to
 // the mailbox. Newly observed messages emit the ordinary in-process new event.
@@ -27,6 +37,7 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 	candidates := make(map[string]candidate)
 	var refreshErrors []error
 	blockedIDs := make(map[string]struct{})
+	uncertainIDs := make(map[string]struct{})
 	for _, file := range files {
 		if id, ok := deletionFenceID(file.Name()); ok {
 			blockedIDs[id] = struct{}{}
@@ -36,6 +47,7 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 			state, stateErr := readRollbackFenceState(filepath.Join(ms.mailDir, file.Name()))
 			if stateErr != nil {
 				blockedIDs[id] = struct{}{}
+				uncertainIDs[id] = struct{}{}
 				refreshErrors = append(refreshErrors, fmt.Errorf("read rollback fence for %s: %w", id, stateErr))
 				continue
 			}
@@ -58,6 +70,7 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 		}
 		info, err := file.Info()
 		if err != nil {
+			uncertainIDs[id] = struct{}{}
 			refreshErrors = append(refreshErrors, fmt.Errorf("stat email %s: %w", id, err))
 			continue
 		}
@@ -133,6 +146,9 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 	ms.storeMutex.Lock()
 	for id := range ms.storeByID {
 		if _, ok := candidates[id]; !ok {
+			if _, uncertain := uncertainIDs[id]; uncertain {
+				continue
+			}
 			delete(ms.storeByID, id)
 			delete(ms.receivedAtByID, id)
 		}
@@ -161,5 +177,8 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 	for _, email := range newEmails {
 		ms.emitAsynchronous("new", email)
 	}
-	return errors.Join(refreshErrors...)
+	if err := errors.Join(refreshErrors...); err != nil {
+		return &ReadOnlyRefreshPartialError{err: err}
+	}
+	return nil
 }

--- a/internal/mailserver/read_only.go
+++ b/internal/mailserver/read_only.go
@@ -140,7 +140,7 @@ func (ms *MailServer) RefreshReadOnlyMailbox() error {
 		if email.HTML != "" {
 			email.HTML = strings.TrimSpace(sanitizeHTML(email.HTML))
 		}
-		if item.metadataUncertain && len(email.Attachments) > 0 {
+		if item.metadataUncertain {
 			continue
 		}
 		if item.metadata != nil {

--- a/internal/mailserver/read_only_test.go
+++ b/internal/mailserver/read_only_test.go
@@ -1,6 +1,7 @@
 package mailserver
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -101,5 +102,49 @@ func TestRefreshReadOnlyMailboxHidesTransactionFencedMail(t *testing.T) {
 	}
 	if _, err := server.GetEmail("deleted-message"); err == nil {
 		t.Fatal("deletion-fenced email became visible")
+	}
+}
+
+func TestRefreshReadOnlyMailboxPreservesExistingMailWhenFenceIsUnreadable(t *testing.T) {
+	directory := t.TempDir()
+	server, err := NewMailServerWithOptions(1025, "localhost", directory, ServerOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	const id = "stable-message"
+	raw := []byte("From: sender@example.test\r\nTo: recipient@example.test\r\nSubject: stable\r\n\r\nbody")
+	if err := os.WriteFile(filepath.Join(directory, id+".eml"), raw, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.RefreshReadOnlyMailbox(); err != nil {
+		t.Fatal(err)
+	}
+
+	notified := make(chan string, 1)
+	server.On("new", func(email *Email) { notified <- email.ID })
+	fence := rollbackFencePath(directory, id)
+	if err := os.Mkdir(fence, 0700); err != nil {
+		t.Fatal(err)
+	}
+	err = server.RefreshReadOnlyMailbox()
+	var partial *ReadOnlyRefreshPartialError
+	if !errors.As(err, &partial) {
+		t.Fatalf("refresh error = %v, want ReadOnlyRefreshPartialError", err)
+	}
+	if email, getErr := server.GetEmail(id); getErr != nil || email.Subject != "stable" {
+		t.Fatalf("existing email was discarded: %#v, %v", email, getErr)
+	}
+	if err := os.Remove(fence); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.RefreshReadOnlyMailbox(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case duplicate := <-notified:
+		t.Fatalf("existing email emitted a duplicate notification for %q", duplicate)
+	case <-time.After(50 * time.Millisecond):
 	}
 }

--- a/internal/mailserver/read_only_test.go
+++ b/internal/mailserver/read_only_test.go
@@ -25,7 +25,9 @@ func TestRefreshReadOnlyMailboxObservesNewMailWithoutMutatingArtifacts(t *testin
 	}
 
 	notified := make(chan string, 1)
-	server.On("new", func(email *Email) { notified <- email.ID })
+	if err := server.OnWithConcurrency("new", 1, func(email *Email) { notified <- email.ID }); err != nil {
+		t.Fatal(err)
+	}
 	raw := "From: sender@example.test\r\nTo: recipient@example.test\r\nSubject: observed\r\nDate: Wed, 02 Sep 2026 12:00:00 +0000\r\n\r\nbody"
 	if err := os.WriteFile(filepath.Join(directory, "observed.eml"), []byte(raw), 0600); err != nil {
 		t.Fatal(err)
@@ -169,7 +171,9 @@ func TestRefreshReadOnlyMailboxUsesDeterministicOrderForEqualTimestamps(t *testi
 		}
 	}
 	notified := make(chan string, 2)
-	server.On("new", func(email *Email) { notified <- email.ID })
+	if err := server.OnWithConcurrency("new", 1, func(email *Email) { notified <- email.ID }); err != nil {
+		t.Fatal(err)
+	}
 	for iteration := 0; iteration < 5; iteration++ {
 		if err := server.RefreshReadOnlyMailbox(); err != nil {
 			t.Fatal(err)
@@ -245,5 +249,20 @@ func TestRefreshReadOnlyMailboxReappliesRepairedAttachmentMetadata(t *testing.T)
 	attachment := after.Attachments[0]
 	if attachment.GeneratedFileName != "restored.bin" || attachment.ContentSHA256 != "0123456789abcdef" || attachment.Storage != attachmentStorageLocal {
 		t.Fatalf("repaired attachment metadata = %#v", attachment)
+	}
+
+	if err := os.WriteFile(server.metadataPath(id), []byte("temporarily-unreadable"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	partial = nil
+	if err := server.RefreshReadOnlyMailbox(); !errors.As(err, &partial) {
+		t.Fatalf("partial refresh error = %v, want ReadOnlyRefreshPartialError", err)
+	}
+	afterPartial, err := server.GetEmail(id)
+	if err != nil || !afterPartial.Read {
+		t.Fatalf("partial refresh lost known read state: %#v, %v", afterPartial, err)
+	}
+	if receivedAt := server.receivedAt(id); !receivedAt.Equal(metadata.Sequence) {
+		t.Fatalf("partial refresh sequence = %s, want %s", receivedAt, metadata.Sequence)
 	}
 }

--- a/internal/mailserver/read_only_test.go
+++ b/internal/mailserver/read_only_test.go
@@ -104,6 +104,58 @@ func TestRefreshReadOnlyMailboxRestoresPersistedEnvelopeRecipients(t *testing.T)
 	}
 }
 
+func TestRefreshReadOnlyMailboxDefersNewEventUntilEnvelopeMetadataIsReadable(t *testing.T) {
+	directory := t.TempDir()
+	const id = "deferred-envelope-metadata"
+	raw := "From: sender@example.test\r\nTo: visible@example.test\r\nSubject: deferred envelope\r\n\r\nbody"
+	if err := os.WriteFile(filepath.Join(directory, id+".eml"), []byte(raw), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(directory, metadataDirectoryName), 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(directory, metadataDirectoryName, id+".json"), []byte("invalid"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	observer, err := NewMailServerWithOptions(1025, "localhost", directory, ServerOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = observer.Close() }()
+	notified := make(chan *Email, 1)
+	observer.On("new", func(email *Email) { notified <- email })
+	var partial *ReadOnlyRefreshPartialError
+	if err := observer.RefreshReadOnlyMailbox(); !errors.As(err, &partial) {
+		t.Fatalf("initial refresh error = %v, want ReadOnlyRefreshPartialError", err)
+	}
+	if _, err := observer.GetEmail(id); err == nil {
+		t.Fatal("email with uncertain envelope metadata was published")
+	}
+
+	metadata := emailMetadata{
+		Version: currentMetadataVersion, ID: id, Sequence: time.Now().UTC(),
+		Envelope: &Envelope{To: []string{"visible@example.test", "blind@example.test"}},
+	}
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(directory, metadataDirectoryName, id+".json"), encoded, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := observer.RefreshReadOnlyMailbox(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case email := <-notified:
+		if email.Envelope == nil || len(email.Envelope.To) != 2 || len(email.CalculatedBCC) != 1 || email.CalculatedBCC[0].Address != "blind@example.test" {
+			t.Fatalf("notified email = %#v", email)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("repaired envelope metadata did not emit a new event")
+	}
+}
+
 func TestRefreshReadOnlyMailboxRestoresLegacyAttachmentFilenameWithoutWritingMetadata(t *testing.T) {
 	directory := t.TempDir()
 	const id = "legacy-read-only-attachment"

--- a/internal/mailserver/read_only_test.go
+++ b/internal/mailserver/read_only_test.go
@@ -139,6 +139,42 @@ func TestRefreshReadOnlyMailboxRestoresLegacyAttachmentFilenameWithoutWritingMet
 	}
 }
 
+func TestRefreshReadOnlyMailboxRetriesLegacyAttachmentRestoration(t *testing.T) {
+	directory := t.TempDir()
+	const id = "legacy-attachment-retry"
+	if err := os.WriteFile(filepath.Join(directory, id+".eml"), multipartMessage(), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	observer, err := NewMailServerWithOptions(1025, "localhost", directory, ServerOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = observer.Close() }()
+	var partial *ReadOnlyRefreshPartialError
+	if err := observer.RefreshReadOnlyMailbox(); !errors.As(err, &partial) {
+		t.Fatalf("initial refresh error = %v, want ReadOnlyRefreshPartialError", err)
+	}
+	if _, err := observer.GetEmail(id); err == nil {
+		t.Fatal("email with unresolved legacy attachment metadata was published")
+	}
+
+	attachmentDirectory := filepath.Join(directory, id)
+	if err := os.MkdirAll(attachmentDirectory, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(attachmentDirectory, "recovered.txt"), []byte("data"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := observer.RefreshReadOnlyMailbox(); err != nil {
+		t.Fatal(err)
+	}
+	observed, err := observer.GetEmail(id)
+	if err != nil || len(observed.Attachments) != 1 || observed.Attachments[0].GeneratedFileName != "recovered.txt" {
+		t.Fatalf("recovered email = %#v, %v", observed, err)
+	}
+}
+
 func TestRefreshReadOnlyMailboxHidesTransactionFencedMail(t *testing.T) {
 	directory := t.TempDir()
 	server, err := NewMailServerWithOptions(1025, "localhost", directory, ServerOptions{ReadOnly: true})

--- a/internal/mailserver/read_only_test.go
+++ b/internal/mailserver/read_only_test.go
@@ -108,6 +108,42 @@ func TestRefreshReadOnlyMailboxHidesTransactionFencedMail(t *testing.T) {
 	}
 }
 
+func TestVisibleRawEmailSourceHidesDeletionFencedMail(t *testing.T) {
+	directory := t.TempDir()
+	server, err := NewMailServerWithOptions(1025, "localhost", directory, ServerOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	const id = "source-hidden-by-fence"
+	raw := []byte("From: sender@example.test\r\nTo: recipient@example.test\r\nSubject: source\r\n\r\nbody")
+	emlPath := filepath.Join(directory, id+".eml")
+	if err := os.WriteFile(emlPath, raw, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.RefreshReadOnlyMailbox(); err != nil {
+		t.Fatal(err)
+	}
+	content, size, truncated, err := server.GetVisibleRawEmailContentLimit(id, 1024)
+	if err != nil || string(content) != string(raw) || size != int64(len(raw)) || truncated {
+		t.Fatalf("visible source = %q, %d, %t, %v", content, size, truncated, err)
+	}
+
+	if err := os.WriteFile(deletionFencePath(directory, id), []byte(deletionFenceState+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.RefreshReadOnlyMailbox(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(emlPath); err != nil {
+		t.Fatalf("source file was unexpectedly removed: %v", err)
+	}
+	if _, _, _, err := server.GetVisibleRawEmailContentLimit(id, 1024); err == nil {
+		t.Fatal("deletion-fenced source remained readable")
+	}
+}
+
 func TestRefreshReadOnlyMailboxRechecksDeletionFenceBeforePublishing(t *testing.T) {
 	directory := t.TempDir()
 	server, err := NewMailServerWithOptions(1025, "localhost", directory, ServerOptions{ReadOnly: true})

--- a/internal/mailserver/read_only_test.go
+++ b/internal/mailserver/read_only_test.go
@@ -148,3 +148,32 @@ func TestRefreshReadOnlyMailboxPreservesExistingMailWhenFenceIsUnreadable(t *tes
 	case <-time.After(50 * time.Millisecond):
 	}
 }
+
+func TestRefreshReadOnlyMailboxUsesDeterministicOrderForEqualTimestamps(t *testing.T) {
+	directory := t.TempDir()
+	server, err := NewMailServerWithOptions(1025, "localhost", directory, ServerOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	timestamp := time.Date(2026, 9, 3, 1, 0, 0, 0, time.UTC)
+	for _, id := range []string{"message-b", "message-a"} {
+		path := filepath.Join(directory, id+".eml")
+		if err := os.WriteFile(path, []byte("From: sender@example.test\r\nTo: recipient@example.test\r\nSubject: "+id+"\r\n\r\nbody"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(path, timestamp, timestamp); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for iteration := 0; iteration < 5; iteration++ {
+		if err := server.RefreshReadOnlyMailbox(); err != nil {
+			t.Fatal(err)
+		}
+		emails := server.GetAllEmail()
+		if len(emails) != 2 || emails[0].ID != "message-a" || emails[1].ID != "message-b" {
+			t.Fatalf("iteration %d order = %#v", iteration, emails)
+		}
+	}
+}

--- a/internal/mailserver/read_only_test.go
+++ b/internal/mailserver/read_only_test.go
@@ -59,3 +59,47 @@ func TestReadOnlyConstructorRequiresExistingDirectory(t *testing.T) {
 		t.Fatalf("missing mailbox was created: %v", err)
 	}
 }
+
+func TestRefreshReadOnlyMailboxHidesTransactionFencedMail(t *testing.T) {
+	directory := t.TempDir()
+	server, err := NewMailServerWithOptions(1025, "localhost", directory, ServerOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	raw := []byte("From: sender@example.test\r\nTo: recipient@example.test\r\nSubject: fenced\r\n\r\nbody")
+	for _, id := range []string{"active-message", "deleted-message"} {
+		if err := os.WriteFile(filepath.Join(directory, id+".eml"), raw, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(rollbackFencePath(directory, "active-message"), []byte(activeFenceState+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(deletionFencePath(directory, "deleted-message"), []byte(deletionFenceState+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := server.RefreshReadOnlyMailbox(); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"active-message", "deleted-message"} {
+		if _, err := server.GetEmail(id); err == nil {
+			t.Fatalf("transaction-fenced email %q became visible", id)
+		}
+	}
+
+	if err := os.WriteFile(rollbackFencePath(directory, "active-message"), []byte(acceptedFenceState+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.RefreshReadOnlyMailbox(); err != nil {
+		t.Fatal(err)
+	}
+	if email, err := server.GetEmail("active-message"); err != nil || email.Subject != "fenced" {
+		t.Fatalf("accepted email = %#v, %v", email, err)
+	}
+	if _, err := server.GetEmail("deleted-message"); err == nil {
+		t.Fatal("deletion-fenced email became visible")
+	}
+}

--- a/internal/mailserver/read_only_test.go
+++ b/internal/mailserver/read_only_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/emersion/go-message/mail"
 )
 
 func TestRefreshReadOnlyMailboxObservesNewMailWithoutMutatingArtifacts(t *testing.T) {
@@ -61,6 +63,79 @@ func TestReadOnlyConstructorRequiresExistingDirectory(t *testing.T) {
 	}
 	if _, err := os.Stat(missing); !os.IsNotExist(err) {
 		t.Fatalf("missing mailbox was created: %v", err)
+	}
+}
+
+func TestRefreshReadOnlyMailboxRestoresPersistedEnvelopeRecipients(t *testing.T) {
+	directory := t.TempDir()
+	writer, err := NewMailServer(1025, "localhost", directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const id = "persisted-envelope"
+	raw := "From: sender@example.test\r\nTo: visible@example.test\r\nSubject: envelope\r\n\r\nbody"
+	if err := os.WriteFile(filepath.Join(directory, id+".eml"), []byte(raw), 0600); err != nil {
+		t.Fatal(err)
+	}
+	envelope := &Envelope{From: "sender@example.test", To: []string{"visible@example.test", "blind@example.test"}}
+	email := &Email{To: []*mail.Address{{Address: "visible@example.test"}}, Subject: "envelope"}
+	if err := writer.SaveEmailToStore(id, false, envelope, email); err != nil {
+		t.Fatal(err)
+	}
+	_ = writer.Close()
+
+	observer, err := NewMailServerWithOptions(1025, "localhost", directory, ServerOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = observer.Close() }()
+	if err := observer.RefreshReadOnlyMailbox(); err != nil {
+		t.Fatal(err)
+	}
+	observed, err := observer.GetEmail(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observed.Envelope == nil || len(observed.Envelope.To) != 2 || observed.Envelope.To[1] != "blind@example.test" {
+		t.Fatalf("restored envelope = %#v", observed.Envelope)
+	}
+	if len(observed.CalculatedBCC) != 1 || observed.CalculatedBCC[0].Address != "blind@example.test" {
+		t.Fatalf("calculated BCC = %#v", observed.CalculatedBCC)
+	}
+}
+
+func TestRefreshReadOnlyMailboxRestoresLegacyAttachmentFilenameWithoutWritingMetadata(t *testing.T) {
+	directory := t.TempDir()
+	const id = "legacy-read-only-attachment"
+	const generatedFilename = "legacy-generated.txt"
+	if err := os.WriteFile(filepath.Join(directory, id+".eml"), multipartMessage(), 0600); err != nil {
+		t.Fatal(err)
+	}
+	attachmentDirectory := filepath.Join(directory, id)
+	if err := os.MkdirAll(attachmentDirectory, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(attachmentDirectory, generatedFilename), []byte("data"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	observer, err := NewMailServerWithOptions(1025, "localhost", directory, ServerOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = observer.Close() }()
+	if err := observer.RefreshReadOnlyMailbox(); err != nil {
+		t.Fatal(err)
+	}
+	observed, err := observer.GetEmail(id)
+	if err != nil || len(observed.Attachments) != 1 {
+		t.Fatalf("observed email = %#v, %v", observed, err)
+	}
+	if got := observed.Attachments[0].GeneratedFileName; got != generatedFilename {
+		t.Fatalf("restored attachment filename = %q, want %q", got, generatedFilename)
+	}
+	if _, err := os.Stat(filepath.Join(directory, metadataDirectoryName)); !os.IsNotExist(err) {
+		t.Fatalf("read-only legacy restoration created metadata: %v", err)
 	}
 }
 

--- a/internal/mailserver/read_only_test.go
+++ b/internal/mailserver/read_only_test.go
@@ -182,6 +182,48 @@ func TestRefreshReadOnlyMailboxRechecksDeletionFenceBeforePublishing(t *testing.
 	}
 }
 
+func TestRefreshReadOnlyMailboxRejectsDeletionCompletedBeforePublicationRescan(t *testing.T) {
+	directory := t.TempDir()
+	server, err := NewMailServerWithOptions(1025, "localhost", directory, ServerOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	const id = "deleted-before-rescan"
+	raw := []byte("From: sender@example.test\r\nTo: recipient@example.test\r\nSubject: deleted\r\n\r\nbody")
+	if err := os.WriteFile(filepath.Join(directory, id+".eml"), raw, 0600); err != nil {
+		t.Fatal(err)
+	}
+	server.beforeReadOnlyPublish = func(candidateID string) {
+		if candidateID != id {
+			return
+		}
+		server.beforeReadOnlyPublish = nil
+		if err := server.ensureDeletionFence(id); err != nil {
+			t.Errorf("create deletion fence: %v", err)
+			return
+		}
+		if err := server.cleanupDeletionFencedEmail(id); err != nil {
+			t.Errorf("complete deletion: %v", err)
+		}
+	}
+	notified := make(chan string, 1)
+	server.On("new", func(email *Email) { notified <- email.ID })
+
+	if err := server.RefreshReadOnlyMailbox(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.GetEmail(id); err == nil {
+		t.Fatal("completed deletion was published from a stale source observation")
+	}
+	select {
+	case published := <-notified:
+		t.Fatalf("completed deletion emitted a new event for %q", published)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
 func TestRefreshReadOnlyMailboxPreservesExistingMailWhenFenceIsUnreadable(t *testing.T) {
 	directory := t.TempDir()
 	server, err := NewMailServerWithOptions(1025, "localhost", directory, ServerOptions{ReadOnly: true})

--- a/internal/mailserver/read_only_test.go
+++ b/internal/mailserver/read_only_test.go
@@ -108,6 +108,44 @@ func TestRefreshReadOnlyMailboxHidesTransactionFencedMail(t *testing.T) {
 	}
 }
 
+func TestRefreshReadOnlyMailboxRechecksDeletionFenceBeforePublishing(t *testing.T) {
+	directory := t.TempDir()
+	server, err := NewMailServerWithOptions(1025, "localhost", directory, ServerOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	const id = "deleted-during-refresh"
+	raw := []byte("From: sender@example.test\r\nTo: recipient@example.test\r\nSubject: disappearing\r\n\r\nbody")
+	if err := os.WriteFile(filepath.Join(directory, id+".eml"), raw, 0600); err != nil {
+		t.Fatal(err)
+	}
+	server.beforeReadOnlyPublish = func(candidateID string) {
+		if candidateID != id {
+			return
+		}
+		server.beforeReadOnlyPublish = nil
+		if err := os.WriteFile(deletionFencePath(directory, id), []byte(deletionFenceState+"\n"), 0600); err != nil {
+			t.Errorf("create deletion fence: %v", err)
+		}
+	}
+	notified := make(chan string, 1)
+	server.On("new", func(email *Email) { notified <- email.ID })
+
+	if err := server.RefreshReadOnlyMailbox(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.GetEmail(id); err == nil {
+		t.Fatal("deletion-fenced email was published after parsing")
+	}
+	select {
+	case published := <-notified:
+		t.Fatalf("deletion-fenced email emitted a new event for %q", published)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
 func TestRefreshReadOnlyMailboxPreservesExistingMailWhenFenceIsUnreadable(t *testing.T) {
 	directory := t.TempDir()
 	server, err := NewMailServerWithOptions(1025, "localhost", directory, ServerOptions{ReadOnly: true})

--- a/internal/mailserver/read_only_test.go
+++ b/internal/mailserver/read_only_test.go
@@ -442,9 +442,8 @@ func TestRefreshReadOnlyMailboxReappliesRepairedAttachmentMetadata(t *testing.T)
 	if err := server.RefreshReadOnlyMailbox(); !errors.As(err, &partial) {
 		t.Fatalf("initial refresh error = %v, want ReadOnlyRefreshPartialError", err)
 	}
-	before, err := server.GetEmail(id)
-	if err != nil || len(before.Attachments) != 1 {
-		t.Fatalf("initial email = %#v, %v", before, err)
+	if _, err := server.GetEmail(id); err == nil {
+		t.Fatal("attachment email with uncertain metadata was published")
 	}
 
 	metadata := emailMetadata{

--- a/internal/mailserver/read_only_test.go
+++ b/internal/mailserver/read_only_test.go
@@ -1,0 +1,61 @@
+package mailserver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRefreshReadOnlyMailboxObservesNewMailWithoutMutatingArtifacts(t *testing.T) {
+	directory := t.TempDir()
+	artifact := filepath.Join(directory, ".owlmail-tmp-active")
+	if err := os.WriteFile(artifact, []byte("active"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	server, err := NewMailServerWithOptions(1025, "localhost", directory, ServerOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+	if err := server.RefreshReadOnlyMailbox(); err != nil {
+		t.Fatal(err)
+	}
+
+	notified := make(chan string, 1)
+	server.On("new", func(email *Email) { notified <- email.ID })
+	raw := "From: sender@example.test\r\nTo: recipient@example.test\r\nSubject: observed\r\nDate: Wed, 02 Sep 2026 12:00:00 +0000\r\n\r\nbody"
+	if err := os.WriteFile(filepath.Join(directory, "observed.eml"), []byte(raw), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.RefreshReadOnlyMailbox(); err != nil {
+		t.Fatal(err)
+	}
+	if email, err := server.GetEmail("observed"); err != nil || email.Subject != "observed" {
+		t.Fatalf("GetEmail() = %#v, %v", email, err)
+	}
+	select {
+	case id := <-notified:
+		if id != "observed" {
+			t.Fatalf("notification ID = %q", id)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("new mail was not announced")
+	}
+	if data, err := os.ReadFile(artifact); err != nil || string(data) != "active" {
+		t.Fatalf("observer mutated active artifact: %q, %v", data, err)
+	}
+	if _, err := os.Stat(filepath.Join(directory, metadataDirectoryName)); !os.IsNotExist(err) {
+		t.Fatalf("observer created metadata directory: %v", err)
+	}
+}
+
+func TestReadOnlyConstructorRequiresExistingDirectory(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing")
+	if _, err := NewMailServerWithOptions(1025, "localhost", missing, ServerOptions{ReadOnly: true}); err == nil {
+		t.Fatal("read-only constructor created a missing mailbox")
+	}
+	if _, err := os.Stat(missing); !os.IsNotExist(err) {
+		t.Fatalf("missing mailbox was created: %v", err)
+	}
+}

--- a/internal/mailserver/read_only_test.go
+++ b/internal/mailserver/read_only_test.go
@@ -1,6 +1,7 @@
 package mailserver
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -167,6 +168,8 @@ func TestRefreshReadOnlyMailboxUsesDeterministicOrderForEqualTimestamps(t *testi
 			t.Fatal(err)
 		}
 	}
+	notified := make(chan string, 2)
+	server.On("new", func(email *Email) { notified <- email.ID })
 	for iteration := 0; iteration < 5; iteration++ {
 		if err := server.RefreshReadOnlyMailbox(); err != nil {
 			t.Fatal(err)
@@ -175,5 +178,72 @@ func TestRefreshReadOnlyMailboxUsesDeterministicOrderForEqualTimestamps(t *testi
 		if len(emails) != 2 || emails[0].ID != "message-a" || emails[1].ID != "message-b" {
 			t.Fatalf("iteration %d order = %#v", iteration, emails)
 		}
+	}
+	if first, second := <-notified, <-notified; first != "message-a" || second != "message-b" {
+		t.Fatalf("notification order = %q, %q; want message-a, message-b", first, second)
+	}
+}
+
+func TestRefreshReadOnlyMailboxReappliesRepairedAttachmentMetadata(t *testing.T) {
+	directory := t.TempDir()
+	server, err := NewMailServerWithOptions(1025, "localhost", directory, ServerOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = server.Close() }()
+
+	const id = "repaired-metadata"
+	raw := "From: sender@example.test\r\nTo: recipient@example.test\r\nSubject: attachment\r\n" +
+		"Content-Type: multipart/mixed; boundary=boundary\r\n\r\n" +
+		"--boundary\r\nContent-Type: text/plain\r\n\r\nbody\r\n" +
+		"--boundary\r\nContent-Type: application/octet-stream\r\nContent-Disposition: attachment; filename=file.bin\r\n\r\ndata\r\n" +
+		"--boundary--\r\n"
+	if err := os.WriteFile(filepath.Join(directory, id+".eml"), []byte(raw), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(directory, metadataDirectoryName), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(server.metadataPath(id), []byte("not-json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	var partial *ReadOnlyRefreshPartialError
+	if err := server.RefreshReadOnlyMailbox(); !errors.As(err, &partial) {
+		t.Fatalf("initial refresh error = %v, want ReadOnlyRefreshPartialError", err)
+	}
+	before, err := server.GetEmail(id)
+	if err != nil || len(before.Attachments) != 1 {
+		t.Fatalf("initial email = %#v, %v", before, err)
+	}
+
+	metadata := emailMetadata{
+		Version:  currentMetadataVersion,
+		ID:       id,
+		Read:     true,
+		Sequence: time.Date(2026, 9, 3, 2, 0, 0, 0, time.UTC),
+		Attachments: []attachmentMetadata{{
+			GeneratedFileName: "restored.bin",
+			Size:              4,
+			ContentSHA256:     "0123456789abcdef",
+			Storage:           attachmentStorageLocal,
+		}},
+	}
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(server.metadataPath(id), encoded, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.RefreshReadOnlyMailbox(); err != nil {
+		t.Fatal(err)
+	}
+	after, err := server.GetEmail(id)
+	if err != nil || !after.Read || len(after.Attachments) != 1 {
+		t.Fatalf("refreshed email = %#v, %v", after, err)
+	}
+	attachment := after.Attachments[0]
+	if attachment.GeneratedFileName != "restored.bin" || attachment.ContentSHA256 != "0123456789abcdef" || attachment.Storage != attachmentStorageLocal {
+		t.Fatalf("repaired attachment metadata = %#v", attachment)
 	}
 }

--- a/internal/mailserver/storage_governance.go
+++ b/internal/mailserver/storage_governance.go
@@ -82,6 +82,7 @@ type emailMetadata struct {
 	ID          string               `json:"id"`
 	Read        bool                 `json:"read"`
 	Sequence    time.Time            `json:"sequence"`
+	Envelope    *Envelope            `json:"envelope,omitempty"`
 	Attachments []attachmentMetadata `json:"attachments,omitempty"`
 }
 
@@ -308,6 +309,7 @@ func (ms *MailServer) persistEmailMetadataAt(email *Email, receivedAt time.Time)
 		ID:          email.ID,
 		Read:        email.Read,
 		Sequence:    receivedAt,
+		Envelope:    cloneEnvelope(email.Envelope),
 		Attachments: make([]attachmentMetadata, 0, len(email.Attachments)),
 	}
 	for _, attachment := range email.Attachments {

--- a/internal/mailserver/store.go
+++ b/internal/mailserver/store.go
@@ -884,6 +884,9 @@ func (ms *MailServer) LoadMailsFromDirectory() error {
 		if parseErr == nil && closeErr == nil {
 			persistRestoredMetadata := !metadataLoaded || metadata.Version < currentMetadataVersion
 			if metadataLoaded {
+				if metadata.Envelope != nil {
+					envelope = cloneEnvelope(metadata.Envelope)
+				}
 				if metadataErr := restoreAttachmentMetadata(email, metadata); metadataErr != nil {
 					loadErrors = append(loadErrors, fmt.Errorf("restore attachment metadata for %s: %w", id, metadataErr))
 					continue

--- a/internal/mailserver/store.go
+++ b/internal/mailserver/store.go
@@ -436,6 +436,19 @@ func (ms *MailServer) GetRawEmailContentLimit(id string, maxBytes int64) ([]byte
 	return content, stat.Size(), stat.Size() > int64(len(content)), nil
 }
 
+// GetVisibleRawEmailContentLimit reads source only while the message belongs to
+// the current mailbox snapshot. Holding the read lock through the file read
+// prevents a concurrent read-only refresh from hiding the message after the
+// visibility check but before the source is returned.
+func (ms *MailServer) GetVisibleRawEmailContentLimit(id string, maxBytes int64) ([]byte, int64, bool, error) {
+	ms.storeMutex.RLock()
+	defer ms.storeMutex.RUnlock()
+	if _, visible := ms.storeByID[id]; !visible {
+		return nil, 0, false, fmt.Errorf("email is not visible")
+	}
+	return ms.GetRawEmailContentLimit(id, maxBytes)
+}
+
 // GetEmailHTML returns the HTML content of an email
 func (ms *MailServer) GetEmailHTML(id string) (string, error) {
 	email, err := ms.GetEmail(id)

--- a/internal/mailserver/types.go
+++ b/internal/mailserver/types.go
@@ -58,6 +58,9 @@ type TLSConfig struct {
 // MaxDataConcurrency leaves SMTP DATA concurrency unlimited. Zero protocol
 // timeout and recipient fields select their established defaults.
 type ServerOptions struct {
+	// ReadOnly requires an existing mail directory and prevents constructor
+	// writes. It is used by observer processes such as the MCP stdio bridge.
+	ReadOnly           bool
 	OutgoingConfig     *outgoing.OutgoingConfig
 	AuthConfig         *SMTPAuthConfig
 	AuthRequireTLS     bool

--- a/internal/mailserver/types.go
+++ b/internal/mailserver/types.go
@@ -154,6 +154,7 @@ type MailServer struct {
 	beforeQuarantineMove       func(string) error
 	beforeEmailRollback        func(string) error
 	beforeEmailDelete          func(string) error
+	beforeReadOnlyPublish      func(string)
 	syncAcceptedFenceDirectory func(string) error
 
 	// DATA hooks are nil in production and provide deterministic synchronization

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -43,6 +43,7 @@ type Options struct {
 // Service owns the SDK server, Streamable HTTP handler, and active sessions.
 type Service struct {
 	mailbox         *mailserver.MailServer
+	server          *mcp.Server
 	handler         *mcp.StreamableHTTPHandler
 	sessionTimeout  time.Duration
 	shutdownTimeout time.Duration
@@ -116,6 +117,7 @@ func New(mailbox *mailserver.MailServer, options Options) (*Service, error) {
 	registerTools(server, mailbox, service)
 	registerResources(server, mailbox, service)
 	registerPrompts(server, service)
+	service.server = server
 	// One bounded dispatcher is enough: notify only snapshots the bounded waiter
 	// set, evaluates filters, and publishes an ID to buffered result channels.
 	if err := mailbox.OnWithConcurrency("new", 1, service.waiters.notify); err != nil {
@@ -128,6 +130,15 @@ func New(mailbox *mailserver.MailServer, options Options) (*Service, error) {
 		SessionTimeout: options.SessionTimeout,
 	})
 	return service, nil
+}
+
+// RunStdio serves the same read-only tools, resources, and prompts over the
+// official MCP stdio transport until the context is canceled or stdin closes.
+func (service *Service) RunStdio(ctx context.Context) error {
+	if service == nil || service.server == nil {
+		return fmt.Errorf("MCP service is not initialized")
+	}
+	return service.server.Run(ctx, &mcp.StdioTransport{})
 }
 
 // ServeHTTP serves the official MCP Streamable HTTP transport.

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -473,7 +473,7 @@ func registerTools(server *mcp.Server, mailbox *mailserver.MailServer, service *
 		if maxBytes < 1 || maxBytes > maximumSourceMaxBytes {
 			return nil, getSourceOutput{}, fmt.Errorf("max_bytes must be between 1 and %d", maximumSourceMaxBytes)
 		}
-		content, size, truncated, err := mailbox.GetRawEmailContentLimit(input.ID, int64(maxBytes))
+		content, size, truncated, err := mailbox.GetVisibleRawEmailContentLimit(input.ID, int64(maxBytes))
 		if err != nil {
 			return nil, getSourceOutput{}, fmt.Errorf("email source was not found")
 		}

--- a/internal/mcpserver/stdio_test.go
+++ b/internal/mcpserver/stdio_test.go
@@ -1,0 +1,13 @@
+package mcpserver
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRunStdioRejectsUninitializedService(t *testing.T) {
+	var service *Service
+	if err := service.RunStdio(context.Background()); err == nil {
+		t.Fatal("uninitialized service was accepted")
+	}
+}


### PR DESCRIPTION
## Summary

- add `owlmail mcp-stdio` using the official MCP stdio transport
- reuse the existing seven read-only tools, resources, prompts, limits, and mailbox store
- reserve stdout for protocol frames and route application logs to stderr
- ignore inherited relay, webhook, and retention settings in the stdio subprocess
- document client configuration in English and Chinese operations guides

## Tests

- `go test ./...`
- `go vet ./...`
- `git diff --check`