### PR TITLE
feat(config): add layered YAML and JSON configuration

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -262,6 +262,7 @@ docker buildx build \
 | `-tls-cert` | `MAILDEV_INCOMING_CERT` / `OWLMAIL_TLS_CERT` | - | SMTP TLS-Zertifikatsdatei |
 | `-tls-key` | `MAILDEV_INCOMING_KEY` / `OWLMAIL_TLS_KEY` | - | SMTP TLS-Private-Key-Datei |
 | `-log-level` | `MAILDEV_VERBOSE` / `MAILDEV_SILENT` / `OWLMAIL_LOG_LEVEL` | normal | Protokollierungsstufe |
+| `-config` | `OWLMAIL_CONFIG_FILE` | - | YAML- oder JSON-Konfigurationsdatei beim Start laden; CLI und Umgebung haben Vorrang |
 | `-use-uuid-for-email-id` | `OWLMAIL_USE_UUID_FOR_EMAIL_ID` | false | UUID für E-Mail-IDs verwenden (Standard: 8-Zeichen-Zufallszeichenfolge) |
 
 When TLS terminates at a reverse proxy, set `OWLMAIL_WEB_EXTERNAL_SCHEME` to `https`.

--- a/README.fr.md
+++ b/README.fr.md
@@ -263,6 +263,7 @@ docker buildx build \
 | `-tls-cert` | `MAILDEV_INCOMING_CERT` / `OWLMAIL_TLS_CERT` | - | SMTP TLS certificate file |
 | `-tls-key` | `MAILDEV_INCOMING_KEY` / `OWLMAIL_TLS_KEY` | - | SMTP TLS private key file |
 | `-log-level` | `MAILDEV_VERBOSE` / `MAILDEV_SILENT` / `OWLMAIL_LOG_LEVEL` | normal | Log level |
+| `-config` | `OWLMAIL_CONFIG_FILE` | - | Charger un fichier YAML ou JSON au démarrage ; la CLI et l’environnement sont prioritaires |
 | `-use-uuid-for-email-id` | `OWLMAIL_USE_UUID_FOR_EMAIL_ID` | false | Use UUID for email IDs (default: 8-character random string) |
 
 When TLS terminates at a reverse proxy, set `OWLMAIL_WEB_EXTERNAL_SCHEME` to `https`.

--- a/README.it.md
+++ b/README.it.md
@@ -262,6 +262,7 @@ docker buildx build \
 | `-tls-cert` | `MAILDEV_INCOMING_CERT` / `OWLMAIL_TLS_CERT` | - | File certificato TLS SMTP |
 | `-tls-key` | `MAILDEV_INCOMING_KEY` / `OWLMAIL_TLS_KEY` | - | File chiave privata TLS SMTP |
 | `-log-level` | `MAILDEV_VERBOSE` / `MAILDEV_SILENT` / `OWLMAIL_LOG_LEVEL` | normal | Livello di log |
+| `-config` | `OWLMAIL_CONFIG_FILE` | - | Carica un file YAML o JSON all’avvio; CLI e ambiente hanno priorità |
 | `-use-uuid-for-email-id` | `OWLMAIL_USE_UUID_FOR_EMAIL_ID` | false | Usa UUID per ID email (predefinito: stringa casuale di 8 caratteri) |
 
 When TLS terminates at a reverse proxy, set `OWLMAIL_WEB_EXTERNAL_SCHEME` to `https`.

--- a/README.ja.md
+++ b/README.ja.md
@@ -262,6 +262,7 @@ docker buildx build \
 | `-tls-cert` | `MAILDEV_INCOMING_CERT` / `OWLMAIL_TLS_CERT` | - | SMTP TLS certificate file |
 | `-tls-key` | `MAILDEV_INCOMING_KEY` / `OWLMAIL_TLS_KEY` | - | SMTP TLS private key file |
 | `-log-level` | `MAILDEV_VERBOSE` / `MAILDEV_SILENT` / `OWLMAIL_LOG_LEVEL` | normal | Log level |
+| `-config` | `OWLMAIL_CONFIG_FILE` | - | 起動時に YAML または JSON を読み込む。CLI と環境変数を優先 |
 | `-use-uuid-for-email-id` | `OWLMAIL_USE_UUID_FOR_EMAIL_ID` | false | Use UUID for email IDs (default: 8-character random string) |
 
 When TLS terminates at a reverse proxy, set `OWLMAIL_WEB_EXTERNAL_SCHEME` to `https`.

--- a/README.ko.md
+++ b/README.ko.md
@@ -262,6 +262,7 @@ docker buildx build \
 | `-tls-cert` | `MAILDEV_INCOMING_CERT` / `OWLMAIL_TLS_CERT` | - | SMTP TLS certificate file |
 | `-tls-key` | `MAILDEV_INCOMING_KEY` / `OWLMAIL_TLS_KEY` | - | SMTP TLS private key file |
 | `-log-level` | `MAILDEV_VERBOSE` / `MAILDEV_SILENT` / `OWLMAIL_LOG_LEVEL` | normal | Log level |
+| `-config` | `OWLMAIL_CONFIG_FILE` | - | 시작 시 YAML 또는 JSON 파일 로드; CLI와 환경 변수가 우선 |
 | `-use-uuid-for-email-id` | `OWLMAIL_USE_UUID_FOR_EMAIL_ID` | false | Use UUID for email IDs (default: 8-character random string) |
 
 When TLS terminates at a reverse proxy, set `OWLMAIL_WEB_EXTERNAL_SCHEME` to `https`.

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ the message body; clicking one focuses OwlMail and opens the message.
 
 | Argument | Environment Variable | Default | Description |
 |----------|---------------------|---------|-------------|
+| `-config` | `OWLMAIL_CONFIG_FILE` | - | Flat YAML or JSON file whose keys use CLI option names |
 | `-smtp` | `MAILDEV_SMTP_PORT` / `OWLMAIL_SMTP_PORT` | 1025 | SMTP port |
 | `-ip` | `MAILDEV_IP` / `OWLMAIL_SMTP_HOST` | localhost | SMTP host |
 | `-smtp-max-message-mb` | `OWLMAIL_SMTP_MAX_MESSAGE_MB` | 100 | Maximum inbound message size in MiB |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -279,6 +279,7 @@ Notifications API 需要 HTTPS，或 `http://localhost` 等受信任的本地来
 | `-tls-cert` | `MAILDEV_INCOMING_CERT` / `OWLMAIL_TLS_CERT` | - | SMTP TLS 证书文件 |
 | `-tls-key` | `MAILDEV_INCOMING_KEY` / `OWLMAIL_TLS_KEY` | - | SMTP TLS 私钥文件 |
 | `-log-level` | `MAILDEV_VERBOSE` / `MAILDEV_SILENT` / `OWLMAIL_LOG_LEVEL` | normal | 日志级别 |
+| `-config` | `OWLMAIL_CONFIG_FILE` | - | 启动时读取 YAML 或 JSON 配置文件；命令行和环境变量优先 |
 | `-use-uuid-for-email-id` | `OWLMAIL_USE_UUID_FOR_EMAIL_ID` | false | 使用 UUID 作为邮件 ID（默认使用 8 字符随机字符串） |
 
 若 TLS 在反向代理终止，请将 `OWLMAIL_WEB_EXTERNAL_SCHEME` 设置为 `https`。

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -838,7 +838,7 @@ func main() {
 	cfg, err := config.ParseFlags()
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to parse configuration: %v\n", err)
-		return
+		os.Exit(1)
 	}
 
 	// Initialize application

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -253,6 +253,13 @@ func defineAttachmentMigrationFlags(fs *flag.FlagSet) attachmentMigrationFlagRef
 }
 
 func attachmentMigrationConfigDefaults(args []string) (*config.Config, error) {
+	for _, argument := range args {
+		if argument == "-h" || argument == "--help" || argument == "-help" {
+			// Let the real FlagSet below render usage to the caller-selected
+			// stderr stream. Configuration defaults do not affect help text.
+			return config.DefaultConfig(), nil
+		}
+	}
 	scan := flag.NewFlagSet("migrate-attachments-config", flag.ContinueOnError)
 	scan.SetOutput(io.Discard)
 	refs := config.DefineFlags(scan)

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -253,17 +253,15 @@ func defineAttachmentMigrationFlags(fs *flag.FlagSet) attachmentMigrationFlagRef
 }
 
 func attachmentMigrationConfigDefaults(args []string) (*config.Config, error) {
-	for _, argument := range args {
-		if argument == "-h" || argument == "--help" || argument == "-help" {
-			// Let the real FlagSet below render usage to the caller-selected
-			// stderr stream. Configuration defaults do not affect help text.
-			return config.DefaultConfig(), nil
-		}
-	}
 	scan := flag.NewFlagSet("migrate-attachments-config", flag.ContinueOnError)
 	scan.SetOutput(io.Discard)
 	refs := config.DefineFlags(scan)
 	defineAttachmentMigrationFlags(scan)
+	if config.HelpRequested(args, scan) {
+		// Let the real FlagSet below render usage to the caller-selected
+		// stderr stream. Configuration defaults do not affect help text.
+		return config.DefaultConfig(), nil
+	}
 	if err := scan.Parse(args); err != nil {
 		return nil, err
 	}

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -886,6 +886,9 @@ func main() {
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		err := runAttachmentMigration(ctx, os.Args[2:], os.Stdout, os.Stderr)
 		stop()
+		if errors.Is(err, flag.ErrHelp) {
+			return
+		}
 		if err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Attachment migration failed: %v\n", err)
 			os.Exit(1)

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -220,15 +220,48 @@ func setupAttachmentHealth(store attachmentstore.Store, cfg *config.Config) (*at
 	return monitor, nil
 }
 
+type attachmentMigrationFlagRefs struct {
+	dryRun         *bool
+	deleteLocal    *bool
+	retries        *int
+	attemptTimeout *time.Duration
+	retryDelay     *time.Duration
+}
+
+func defineAttachmentMigrationFlags(fs *flag.FlagSet) attachmentMigrationFlagRefs {
+	return attachmentMigrationFlagRefs{
+		dryRun:         fs.Bool("dry-run", false, "Validate and report migration work without remote or local writes"),
+		deleteLocal:    fs.Bool("delete-local", false, "Delete each local attachment only after verified upload and metadata commit"),
+		retries:        fs.Int("retries", defaultAttachmentMigrationRetries, "Retry count from 0 to 100 after the initial attempt for each attachment"),
+		attemptTimeout: fs.Duration("migration-attempt-timeout", defaultAttachmentMigrationTimeout, "Timeout for each upload and verification attempt"),
+		retryDelay:     fs.Duration("migration-retry-delay", defaultAttachmentMigrationRetryDelay, "Delay between migration attempts"),
+	}
+}
+
+func attachmentMigrationConfigDefaults(args []string) (*config.Config, error) {
+	scan := flag.NewFlagSet("migrate-attachments-config", flag.ContinueOnError)
+	scan.SetOutput(io.Discard)
+	refs := config.DefineFlags(scan)
+	defineAttachmentMigrationFlags(scan)
+	if err := scan.Parse(args); err != nil {
+		return nil, err
+	}
+	path := strings.TrimSpace(config.ResolveConfig(scan, refs).ConfigFile)
+	if path == "" {
+		return config.DefaultConfig(), nil
+	}
+	return config.LoadConfigFile(path)
+}
+
 func runAttachmentMigration(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+	defaults, err := attachmentMigrationConfigDefaults(args)
+	if err != nil {
+		return err
+	}
 	fs := flag.NewFlagSet("migrate-attachments", flag.ContinueOnError)
 	fs.SetOutput(stderr)
-	refs := config.DefineFlags(fs)
-	dryRun := fs.Bool("dry-run", false, "Validate and report migration work without remote or local writes")
-	deleteLocal := fs.Bool("delete-local", false, "Delete each local attachment only after verified upload and metadata commit")
-	retries := fs.Int("retries", defaultAttachmentMigrationRetries, "Retry count from 0 to 100 after the initial attempt for each attachment")
-	attemptTimeout := fs.Duration("migration-attempt-timeout", defaultAttachmentMigrationTimeout, "Timeout for each upload and verification attempt")
-	retryDelay := fs.Duration("migration-retry-delay", defaultAttachmentMigrationRetryDelay, "Delay between migration attempts")
+	refs := config.DefineFlagsWithDefaults(fs, defaults)
+	migrationFlags := defineAttachmentMigrationFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -251,11 +284,11 @@ func runAttachmentMigration(ctx context.Context, args []string, stdout, stderr i
 		progressWriter = io.Discard
 	}
 	summary, migrationErr := mailserver.MigrateLocalAttachments(ctx, cfg.MailDir, store, mailserver.AttachmentMigrationOptions{
-		DryRun:         *dryRun,
-		DeleteLocal:    *deleteLocal,
-		Retries:        *retries,
-		AttemptTimeout: *attemptTimeout,
-		RetryDelay:     *retryDelay,
+		DryRun:         *migrationFlags.dryRun,
+		DeleteLocal:    *migrationFlags.deleteLocal,
+		Retries:        *migrationFlags.retries,
+		AttemptTimeout: *migrationFlags.attemptTimeout,
+		RetryDelay:     *migrationFlags.retryDelay,
 		Progress: func(progress mailserver.AttachmentMigrationProgress) {
 			if progress.Status == "retrying" {
 				_, _ = fmt.Fprintf(progressWriter, "%s %s/%s attempt=%d error=%v\n", progress.Status, progress.EmailID, progress.Filename, progress.Attempt, progress.Err)

--- a/cmd/owlmail/main.go
+++ b/cmd/owlmail/main.go
@@ -835,7 +835,11 @@ func main() {
 		return
 	}
 	// Parse configuration using the config package
-	cfg := config.ParseFlags()
+	cfg, err := config.ParseFlags()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Failed to parse configuration: %v\n", err)
+		return
+	}
 
 	// Initialize application
 	if err := initializeApplication(cfg); err != nil {

--- a/cmd/owlmail/main_test.go
+++ b/cmd/owlmail/main_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -1108,6 +1109,24 @@ func TestRunAttachmentMigrationDryRun(t *testing.T) {
 		"-mail-directory", directory,
 	}, &stdout, &stderr)
 	if err != nil {
+		t.Fatalf("runAttachmentMigration() error = %v, stderr = %s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `summary {"emailsScanned":0`) {
+		t.Fatalf("migration output = %q", stdout.String())
+	}
+}
+
+func TestRunAttachmentMigrationLoadsConfigFileAfterSubcommandFlags(t *testing.T) {
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	directory := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), "migration.yaml")
+	contents := fmt.Sprintf("s3-enabled: true\ns3-region: us-east-1\ns3-bucket: owlmail-test\nmail-directory: %q\n", directory)
+	if err := os.WriteFile(configPath, []byte(contents), 0600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if err := runAttachmentMigration(context.Background(), []string{"-dry-run", "-config", configPath}, &stdout, &stderr); err != nil {
 		t.Fatalf("runAttachmentMigration() error = %v, stderr = %s", err, stderr.String())
 	}
 	if !strings.Contains(stdout.String(), `summary {"emailsScanned":0`) {

--- a/cmd/owlmail/main_test.go
+++ b/cmd/owlmail/main_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -1154,6 +1155,17 @@ func TestRunAttachmentMigrationLoadsConfigFileAfterSubcommandFlags(t *testing.T)
 	}
 	if !strings.Contains(stdout.String(), `summary {"emailsScanned":0`) {
 		t.Fatalf("migration output = %q", stdout.String())
+	}
+}
+
+func TestRunAttachmentMigrationHelpUsesVisibleParser(t *testing.T) {
+	var stderr bytes.Buffer
+	err := runAttachmentMigration(context.Background(), []string{"-help"}, io.Discard, &stderr)
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("runAttachmentMigration() error = %v, want flag.ErrHelp", err)
+	}
+	if !strings.Contains(stderr.String(), "Usage of migrate-attachments:") || !strings.Contains(stderr.String(), "-dry-run") {
+		t.Fatalf("migration help output = %q", stderr.String())
 	}
 }
 

--- a/cmd/owlmail/main_test.go
+++ b/cmd/owlmail/main_test.go
@@ -1159,6 +1159,7 @@ func TestRunAttachmentMigrationLoadsConfigFileAfterSubcommandFlags(t *testing.T)
 }
 
 func TestRunAttachmentMigrationHelpUsesVisibleParser(t *testing.T) {
+	t.Setenv("OWLMAIL_CONFIG_FILE", filepath.Join(t.TempDir(), "missing.yaml"))
 	var stderr bytes.Buffer
 	err := runAttachmentMigration(context.Background(), []string{"-help"}, io.Discard, &stderr)
 	if !errors.Is(err, flag.ErrHelp) {
@@ -1166,6 +1167,24 @@ func TestRunAttachmentMigrationHelpUsesVisibleParser(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "Usage of migrate-attachments:") || !strings.Contains(stderr.String(), "-dry-run") {
 		t.Fatalf("migration help output = %q", stderr.String())
+	}
+}
+
+func TestAttachmentMigrationHelpTokenCanBeAFlagValue(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "migration.yaml")
+	if err := os.WriteFile(configPath, []byte("s3-enabled: true\ns3-bucket: loaded\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	defaults, err := attachmentMigrationConfigDefaults([]string{
+		"-config", configPath,
+		"-mail-directory", "-h",
+		"-dry-run",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !defaults.S3Enabled || defaults.S3Bucket != "loaded" {
+		t.Fatalf("configuration defaults were skipped: %#v", defaults)
 	}
 }
 

--- a/docs/en/Operations.md
+++ b/docs/en/Operations.md
@@ -5,6 +5,26 @@ readiness, persistence, webhook capacity, shutdown behavior, and common failure
 modes. See the [API Reference](./API-Reference.md) and
 [Webhook Forwarding](./Webhook-Forwarding.md) for protocol details.
 
+## Layered configuration files
+
+Use `-config PATH` or `OWLMAIL_CONFIG_FILE` to load a flat YAML or JSON object.
+Keys are the documented CLI option names without the leading dash:
+
+```yaml
+smtp: 1025
+web: 1080
+web-ip: 127.0.0.1
+mail-directory: ./data/mail
+metrics-enabled: true
+log-level: normal
+```
+
+Precedence is CLI flags, MailDev-compatible environment aliases, `OWLMAIL_*`
+environment variables, the configuration file, then built-in defaults. Unknown,
+duplicate, nested, null, oversized, and type-invalid file values fail startup.
+The file is limited to 1 MiB. Keep files containing passwords or object-storage
+credentials out of source control and restrict their filesystem permissions.
+
 ## Mailbox retention and state
 
 OwlMail can enforce age, message-count, and disk-usage limits together:

--- a/docs/zh-CN/Operations.md
+++ b/docs/zh-CN/Operations.md
@@ -4,6 +4,24 @@
 关闭行为和常见故障。协议细节见 [API 参考](./API-Reference.md)与
 [Webhook 消息转发](./Webhook-Forwarding.md)。
 
+## 分层配置文件
+
+使用 `-config PATH` 或 `OWLMAIL_CONFIG_FILE` 加载扁平的 YAML 或 JSON 对象。
+键名使用不带开头短横线的 CLI 参数名：
+
+```yaml
+smtp: 1025
+web: 1080
+web-ip: 127.0.0.1
+mail-directory: ./data/mail
+metrics-enabled: true
+log-level: normal
+```
+
+优先级依次为 CLI 参数、MailDev 兼容环境变量、`OWLMAIL_*` 环境变量、配置文件、
+内置默认值。未知、重复、嵌套、null、超大或类型错误的文件值会使启动失败。文件上限
+为 1 MiB。包含密码或对象存储凭据的配置文件不应提交到源码仓库，并应限制文件权限。
+
 ## 邮箱保留策略与状态
 
 OwlMail 可以同时限制邮件年龄、封数和磁盘占用：

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -522,7 +522,7 @@ func DefineFlagsWithDefaults(fs *flag.FlagSet, cfg *Config) *FlagRefs {
 		WebPort:                     fs.Int("web", cfg.WebPort, "Web API port"),
 		WebHost:                     fs.String("web-ip", cfg.WebHost, "IP address to bind Web API to"),
 		WebUser:                     fs.String("web-user", cfg.WebUser, "HTTP Basic Auth username"),
-		WebPassword:                 fs.String("web-password", cfg.WebPassword, "HTTP Basic Auth password"),
+		WebPassword:                 secretStringFlag(fs, "web-password", cfg.WebPassword, "HTTP Basic Auth password"),
 		WebExternalURL:              fs.String("web-external-url", cfg.WebExternalURL, "Browser-visible Web origin used in generated links"),
 		BasePathname:                fs.String("base-pathname", cfg.BasePathname, "Browser-visible URL path prefix (for example /owlmail)"),
 		MailDevRESTCompat:           fs.Bool("maildev-rest-compat", cfg.MailDevRESTCompat, "Enable the optional MailDev REST compatibility facade under /api"),
@@ -536,7 +536,7 @@ func DefineFlagsWithDefaults(fs *flag.FlagSet, cfg *Config) *FlagRefs {
 		OutgoingHost:                fs.String("outgoing-host", cfg.OutgoingHost, "Outgoing SMTP server host"),
 		OutgoingPort:                fs.Int("outgoing-port", cfg.OutgoingPort, "Outgoing SMTP server port"),
 		OutgoingUser:                fs.String("outgoing-user", cfg.OutgoingUser, "Outgoing SMTP server username"),
-		OutgoingPass:                fs.String("outgoing-pass", cfg.OutgoingPass, "Outgoing SMTP server password"),
+		OutgoingPass:                secretStringFlag(fs, "outgoing-pass", cfg.OutgoingPass, "Outgoing SMTP server password"),
 		OutgoingSecure:              fs.Bool("outgoing-secure", cfg.OutgoingSecure, "Use implicit TLS/SMTPS for outgoing SMTP (MailDev compatibility)"),
 		OutgoingTLSMode:             fs.String("outgoing-tls-mode", cfg.OutgoingTLSMode, "Outgoing SMTP transport: plain, starttls, or smtps"),
 		OutgoingInsecureSkipVerify:  fs.Bool("outgoing-insecure-skip-verify", cfg.OutgoingInsecureSkipVerify, "Skip outgoing SMTP certificate verification (unsafe)"),
@@ -550,7 +550,7 @@ func DefineFlagsWithDefaults(fs *flag.FlagSet, cfg *Config) *FlagRefs {
 		AutoRelayAddr:               fs.String("auto-relay-addr", cfg.AutoRelayAddr, "Auto relay to specific address"),
 		AutoRelayRules:              fs.String("auto-relay-rules", cfg.AutoRelayRules, "JSON file path for auto relay rules"),
 		SMTPUser:                    fs.String("smtp-user", cfg.SMTPUser, "SMTP username; set with smtp-password to require authentication"),
-		SMTPPassword:                fs.String("smtp-password", cfg.SMTPPassword, "SMTP password; set with smtp-user to require authentication"),
+		SMTPPassword:                secretStringFlag(fs, "smtp-password", cfg.SMTPPassword, "SMTP password; set with smtp-user to require authentication"),
 		SMTPAuthRequireTLS:          fs.Bool("smtp-auth-require-tls", cfg.SMTPAuthRequireTLS, "Require TLS before accepting SMTP AUTH"),
 		TLSEnabled:                  fs.Bool("tls", cfg.TLSEnabled, "Enable TLS/STARTTLS for SMTP server"),
 		TLSCertFile:                 fs.String("tls-cert", cfg.TLSCertFile, "TLS certificate file path"),
@@ -562,9 +562,9 @@ func DefineFlagsWithDefaults(fs *flag.FlagSet, cfg *Config) *FlagRefs {
 		S3Region:                    fs.String("s3-region", cfg.S3Region, "S3 region"),
 		S3Bucket:                    fs.String("s3-bucket", cfg.S3Bucket, "S3 bucket for attachments"),
 		S3Prefix:                    fs.String("s3-prefix", cfg.S3Prefix, "S3 object key prefix for attachments"),
-		S3AccessKeyID:               fs.String("s3-access-key", cfg.S3AccessKeyID, "S3 static access key (optional)"),
-		S3SecretAccessKey:           fs.String("s3-secret-key", cfg.S3SecretAccessKey, "S3 static secret key (optional)"),
-		S3SessionToken:              fs.String("s3-session-token", cfg.S3SessionToken, "S3 static credential session token (optional)"),
+		S3AccessKeyID:               secretStringFlag(fs, "s3-access-key", cfg.S3AccessKeyID, "S3 static access key (optional)"),
+		S3SecretAccessKey:           secretStringFlag(fs, "s3-secret-key", cfg.S3SecretAccessKey, "S3 static secret key (optional)"),
+		S3SessionToken:              secretStringFlag(fs, "s3-session-token", cfg.S3SessionToken, "S3 static credential session token (optional)"),
 		S3UsePathStyle:              fs.Bool("s3-use-path-style", cfg.S3UsePathStyle, "Use path-style S3 bucket addressing"),
 		S3StartupCheck:              fs.Bool("s3-startup-check", cfg.S3StartupCheck, "Fail startup when the initial S3 bucket check fails"),
 		S3HealthInterval:            fs.String("s3-health-check-interval", cfg.S3HealthInterval, "Background S3 health-check interval"),
@@ -575,6 +575,16 @@ func DefineFlagsWithDefaults(fs *flag.FlagSet, cfg *Config) *FlagRefs {
 		WebhookRedisPrefix:          fs.String("webhook-redis-prefix", cfg.WebhookRedisPrefix, "Redis key prefix for webhook delivery"),
 		WebhookShutdownTimeout:      fs.String("webhook-shutdown-timeout", cfg.WebhookShutdownTimeout, "Maximum time to drain webhook delivery during shutdown"),
 	}
+}
+
+// secretStringFlag retains a preloaded secret for resolution without exposing
+// it through flag.PrintDefaults on help or parse errors.
+func secretStringFlag(fs *flag.FlagSet, name, value, usage string) *string {
+	ref := fs.String(name, value, usage)
+	if option := fs.Lookup(name); option != nil {
+		option.DefValue = ""
+	}
+	return ref
 }
 
 // ResolveConfig resolves configuration from flag values and environment variables.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ package config
 
 import (
 	"flag"
+	"io"
 	"os"
 	"strconv"
 
@@ -738,15 +739,20 @@ func resolveSMTPMaxRecipientsWithFlag(fs *flag.FlagSet, flagValue int) int {
 // For tests, use DefineFlags and ResolveConfig separately.
 func ParseFlags() (*Config, error) {
 	fs := flag.CommandLine
-	configPath, err := configFileFromArgs(os.Args[1:])
-	if err != nil {
-		return nil, err
-	}
 	defaults := DefaultConfig()
-	if configPath != "" {
-		defaults, err = LoadConfigFile(configPath)
+	helpScan := flag.NewFlagSet("help-scan", flag.ContinueOnError)
+	helpScan.SetOutput(io.Discard)
+	DefineFlags(helpScan)
+	if !HelpRequested(os.Args[1:], helpScan) {
+		configPath, err := configFileFromArgs(os.Args[1:])
 		if err != nil {
 			return nil, err
+		}
+		if configPath != "" {
+			defaults, err = LoadConfigFile(configPath)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	refs := DefineFlagsWithDefaults(fs, defaults)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,11 +1,12 @@
 // Package config provides configuration parsing with MailDev environment variable compatibility.
 // It uses cli-kit for environment variable management and validation.
 //
-// Priority order: CLI flags > MAILDEV_* env vars > OWLMAIL_* env vars > default values
+// Priority order: CLI flags > MAILDEV_* env vars > OWLMAIL_* env vars > config file > default values
 package config
 
 import (
 	"flag"
+	"os"
 	"strconv"
 
 	"github.com/soulteary/cli-kit/env"
@@ -251,6 +252,7 @@ func ResolveLogLevel(fs *flag.FlagSet, flagName, defaultValue string) string {
 
 // Config holds all application configuration
 type Config struct {
+	ConfigFile string
 	// SMTP server configuration
 	SMTPPort            int
 	SMTPHost            string
@@ -345,6 +347,7 @@ type Config struct {
 // DefaultConfig returns a Config with default values
 func DefaultConfig() *Config {
 	return &Config{
+		ConfigFile:                  "",
 		SMTPPort:                    1025,
 		SMTPHost:                    "localhost",
 		SMTPMaxMessageMB:            DefaultSMTPMaxMessageMB,
@@ -419,6 +422,7 @@ func DefaultConfig() *Config {
 
 // FlagRefs holds references to all flag values for resolution after parsing.
 type FlagRefs struct {
+	ConfigFile                  *string
 	SMTPPort                    *int
 	SMTPHost                    *string
 	SMTPMaxMessageMB            *int
@@ -492,8 +496,16 @@ type FlagRefs struct {
 // DefineFlags defines all configuration flags on the given FlagSet.
 // It returns FlagRefs which should be passed to ResolveConfig after parsing.
 func DefineFlags(fs *flag.FlagSet) *FlagRefs {
-	cfg := DefaultConfig()
+	return DefineFlagsWithDefaults(fs, DefaultConfig())
+}
+
+// DefineFlagsWithDefaults defines flags using a preloaded configuration layer.
+func DefineFlagsWithDefaults(fs *flag.FlagSet, cfg *Config) *FlagRefs {
+	if cfg == nil {
+		cfg = DefaultConfig()
+	}
 	return &FlagRefs{
+		ConfigFile:                  fs.String("config", cfg.ConfigFile, "YAML or JSON configuration file"),
 		SMTPPort:                    fs.Int("smtp", cfg.SMTPPort, "SMTP port to catch emails"),
 		SMTPHost:                    fs.String("ip", cfg.SMTPHost, "IP address to bind SMTP service to"),
 		SMTPMaxMessageMB:            fs.Int("smtp-max-message-mb", cfg.SMTPMaxMessageMB, "Maximum inbound message size in MiB"),
@@ -571,6 +583,7 @@ func DefineFlags(fs *flag.FlagSet) *FlagRefs {
 func ResolveConfig(fs *flag.FlagSet, refs *FlagRefs) *Config {
 	outgoingSecure, outgoingTLSMode := resolveOutgoingTransport(fs, *refs.OutgoingSecure, *refs.OutgoingTLSMode)
 	return &Config{
+		ConfigFile:          resolveStringWithFlag(fs, "config", "OWLMAIL_CONFIG_FILE", *refs.ConfigFile),
 		SMTPPort:            resolveIntWithFlag(fs, "smtp", "OWLMAIL_SMTP_PORT", *refs.SMTPPort),
 		SMTPHost:            resolveStringWithFlag(fs, "ip", "OWLMAIL_SMTP_HOST", *refs.SMTPHost),
 		SMTPMaxMessageMB:    resolveIntWithFlag(fs, "smtp-max-message-mb", "OWLMAIL_SMTP_MAX_MESSAGE_MB", *refs.SMTPMaxMessageMB),
@@ -708,11 +721,22 @@ func resolveSMTPMaxRecipientsWithFlag(fs *flag.FlagSet, flagValue int) int {
 // ParseFlags is a convenience function that defines flags, parses arguments, and resolves config.
 // Note: This uses flag.CommandLine, so it should only be used in main().
 // For tests, use DefineFlags and ResolveConfig separately.
-func ParseFlags() *Config {
+func ParseFlags() (*Config, error) {
 	fs := flag.CommandLine
-	refs := DefineFlags(fs)
+	configPath, err := configFileFromArgs(os.Args[1:])
+	if err != nil {
+		return nil, err
+	}
+	defaults := DefaultConfig()
+	if configPath != "" {
+		defaults, err = LoadConfigFile(configPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+	refs := DefineFlagsWithDefaults(fs, defaults)
 	flag.Parse()
-	return ResolveConfig(fs, refs)
+	return ResolveConfig(fs, refs), nil
 }
 
 // resolveStringWithFlag resolves a string value considering CLI flag was already parsed

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -571,7 +571,7 @@ func DefineFlagsWithDefaults(fs *flag.FlagSet, cfg *Config) *FlagRefs {
 		S3HealthTimeout:             fs.String("s3-health-check-timeout", cfg.S3HealthTimeout, "Timeout for each S3 health check"),
 		WebhookConfig:               fs.String("webhook-config", cfg.WebhookConfig, "JSON file path for webhook forwarding targets"),
 		WebhookMaxConcurrency:       fs.Int("webhook-max-concurrency", cfg.WebhookMaxConcurrency, "Maximum concurrent webhook deliveries (0 = unlimited)"),
-		WebhookRedisURL:             fs.String("webhook-redis-url", cfg.WebhookRedisURL, "Redis URL for durable webhook delivery"),
+		WebhookRedisURL:             secretStringFlag(fs, "webhook-redis-url", cfg.WebhookRedisURL, "Redis URL for durable webhook delivery"),
 		WebhookRedisPrefix:          fs.String("webhook-redis-prefix", cfg.WebhookRedisPrefix, "Redis key prefix for webhook delivery"),
 		WebhookShutdownTimeout:      fs.String("webhook-shutdown-timeout", cfg.WebhookShutdownTimeout, "Maximum time to drain webhook delivery during shutdown"),
 	}

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+const maximumConfigFileBytes = 1 << 20
+
+// LoadConfigFile loads a flat YAML or JSON object whose keys match OwlMail
+// command-line option names. Unknown, duplicate, nested, and null values fail
+// closed so misspelled production settings cannot be silently ignored.
+func LoadConfigFile(path string) (*Config, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("stat config file: %w", err)
+	}
+	if info.Size() > maximumConfigFileBytes {
+		return nil, fmt.Errorf("config file exceeds %d bytes", maximumConfigFileBytes)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read config file: %w", err)
+	}
+	var document yaml.Node
+	if err := yaml.Unmarshal(data, &document); err != nil {
+		return nil, fmt.Errorf("parse config file: %w", err)
+	}
+	if len(document.Content) != 1 || document.Content[0].Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("config file must contain one flat object")
+	}
+
+	fs := flag.NewFlagSet("config-file", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	refs := DefineFlags(fs)
+	root := document.Content[0]
+	seen := make(map[string]struct{}, len(root.Content)/2)
+	for index := 0; index < len(root.Content); index += 2 {
+		keyNode, valueNode := root.Content[index], root.Content[index+1]
+		key := strings.TrimSpace(keyNode.Value)
+		if key == "" || key == "config" {
+			return nil, fmt.Errorf("invalid config file key %q", key)
+		}
+		if _, exists := seen[key]; exists {
+			return nil, fmt.Errorf("duplicate config file key %q", key)
+		}
+		seen[key] = struct{}{}
+		if fs.Lookup(key) == nil {
+			return nil, fmt.Errorf("unknown config file key %q", key)
+		}
+		if valueNode.Kind != yaml.ScalarNode || valueNode.Tag == "!!null" {
+			return nil, fmt.Errorf("config file key %q must have a scalar value", key)
+		}
+		value := valueNode.Value
+		if valueNode.Tag == "!!bool" {
+			parsed, err := strconv.ParseBool(value)
+			if err != nil {
+				return nil, fmt.Errorf("config file key %q: %w", key, err)
+			}
+			value = strconv.FormatBool(parsed)
+		}
+		if err := fs.Set(key, value); err != nil {
+			return nil, fmt.Errorf("config file key %q: %w", key, err)
+		}
+	}
+	cfg := ResolveConfig(fs, refs)
+	cfg.ConfigFile = path
+	return cfg, nil
+}
+
+func configFileFromArgs(args []string) (string, error) {
+	path := strings.TrimSpace(os.Getenv("OWLMAIL_CONFIG_FILE"))
+	for index := 0; index < len(args); index++ {
+		argument := args[index]
+		if argument == "-config" || argument == "--config" {
+			if index+1 >= len(args) || strings.HasPrefix(args[index+1], "-") {
+				return "", fmt.Errorf("%s requires a path", argument)
+			}
+			path = args[index+1]
+			index++
+			continue
+		}
+		if strings.HasPrefix(argument, "-config=") {
+			path = strings.TrimPrefix(argument, "-config=")
+		}
+		if strings.HasPrefix(argument, "--config=") {
+			path = strings.TrimPrefix(argument, "--config=")
+		}
+	}
+	return strings.TrimSpace(path), nil
+}

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -18,16 +18,24 @@ const maximumConfigFileBytes = 1 << 20
 // command-line option names. Unknown, duplicate, nested, and null values fail
 // closed so misspelled production settings cannot be silently ignored.
 func LoadConfigFile(path string) (*Config, error) {
-	info, err := os.Stat(path)
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open config file: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
 	if err != nil {
 		return nil, fmt.Errorf("stat config file: %w", err)
 	}
 	if info.Size() > maximumConfigFileBytes {
 		return nil, fmt.Errorf("config file exceeds %d bytes", maximumConfigFileBytes)
 	}
-	data, err := os.ReadFile(path)
+	data, err := io.ReadAll(io.LimitReader(file, maximumConfigFileBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("read config file: %w", err)
+	}
+	if len(data) > maximumConfigFileBytes {
+		return nil, fmt.Errorf("config file exceeds %d bytes", maximumConfigFileBytes)
 	}
 	var document yaml.Node
 	decoder := yaml.NewDecoder(bytes.NewReader(data))

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -28,8 +30,16 @@ func LoadConfigFile(path string) (*Config, error) {
 		return nil, fmt.Errorf("read config file: %w", err)
 	}
 	var document yaml.Node
-	if err := yaml.Unmarshal(data, &document); err != nil {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	if err := decoder.Decode(&document); err != nil {
 		return nil, fmt.Errorf("parse config file: %w", err)
+	}
+	var extra yaml.Node
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err != nil {
+			return nil, fmt.Errorf("parse additional config document: %w", err)
+		}
+		return nil, fmt.Errorf("config file must contain exactly one document")
 	}
 	if len(document.Content) != 1 || document.Content[0].Kind != yaml.MappingNode {
 		return nil, fmt.Errorf("config file must contain one flat object")
@@ -75,22 +85,44 @@ func LoadConfigFile(path string) (*Config, error) {
 
 func configFileFromArgs(args []string) (string, error) {
 	path := strings.TrimSpace(os.Getenv("OWLMAIL_CONFIG_FILE"))
+	fs := flag.NewFlagSet("config-file-scan", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	DefineFlags(fs)
 	for index := 0; index < len(args); index++ {
 		argument := args[index]
-		if argument == "-config" || argument == "--config" {
-			if index+1 >= len(args) || strings.HasPrefix(args[index+1], "-") {
-				return "", fmt.Errorf("%s requires a path", argument)
+		if argument == "--" || argument == "-" || !strings.HasPrefix(argument, "-") {
+			break
+		}
+		nameAndValue := strings.TrimPrefix(argument, "-")
+		if strings.HasPrefix(nameAndValue, "-") {
+			nameAndValue = strings.TrimPrefix(nameAndValue, "-")
+		}
+		name, value, hasValue := strings.Cut(nameAndValue, "=")
+		option := fs.Lookup(name)
+		if option == nil {
+			break
+		}
+		if name == "config" {
+			if !hasValue {
+				if index+1 >= len(args) {
+					return "", fmt.Errorf("%s requires a path", argument)
+				}
+				index++
+				value = args[index]
 			}
-			path = args[index+1]
-			index++
+			path = value
 			continue
 		}
-		if strings.HasPrefix(argument, "-config=") {
-			path = strings.TrimPrefix(argument, "-config=")
+		if hasValue {
+			continue
 		}
-		if strings.HasPrefix(argument, "--config=") {
-			path = strings.TrimPrefix(argument, "--config=")
+		if boolean, ok := option.Value.(interface{ IsBoolFlag() bool }); ok && boolean.IsBoolFlag() {
+			continue
 		}
+		if index+1 >= len(args) {
+			return "", fmt.Errorf("%s requires a value", argument)
+		}
+		index++
 	}
 	return strings.TrimSpace(path), nil
 }

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -132,3 +132,38 @@ func configFileFromArgs(args []string) (string, error) {
 	}
 	return strings.TrimSpace(path), nil
 }
+
+// HelpRequested reports whether -h or -help appears where FlagSet.Parse would
+// interpret it as an option. Help-looking tokens consumed as values, or those
+// after a positional argument or --, are deliberately ignored.
+func HelpRequested(args []string, fs *flag.FlagSet) bool {
+	if fs == nil {
+		return false
+	}
+	for index := 0; index < len(args); index++ {
+		argument := args[index]
+		if argument == "--" || argument == "-" || !strings.HasPrefix(argument, "-") {
+			return false
+		}
+		nameAndValue := strings.TrimPrefix(strings.TrimPrefix(argument, "-"), "-")
+		name, _, hasValue := strings.Cut(nameAndValue, "=")
+		if name == "h" || name == "help" {
+			return true
+		}
+		option := fs.Lookup(name)
+		if option == nil {
+			return false
+		}
+		if hasValue {
+			continue
+		}
+		if boolean, ok := option.Value.(interface{ IsBoolFlag() bool }); ok && boolean.IsBoolFlag() {
+			continue
+		}
+		if index+1 >= len(args) {
+			return false
+		}
+		index++
+	}
+	return false
+}

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -94,9 +94,7 @@ func configFileFromArgs(args []string) (string, error) {
 			break
 		}
 		nameAndValue := strings.TrimPrefix(argument, "-")
-		if strings.HasPrefix(nameAndValue, "-") {
-			nameAndValue = strings.TrimPrefix(nameAndValue, "-")
-		}
+		nameAndValue = strings.TrimPrefix(nameAndValue, "-")
 		name, value, hasValue := strings.Cut(nameAndValue, "=")
 		option := fs.Lookup(name)
 		if option == nil {

--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -121,3 +121,27 @@ func TestConfigFileFromArgs(t *testing.T) {
 		}
 	}
 }
+
+func TestHelpRequestedUsesFlagParserBoundaries(t *testing.T) {
+	fs := flag.NewFlagSet("help-scan-test", flag.ContinueOnError)
+	fs.String("config", "", "")
+	fs.String("mail-directory", "", "")
+	fs.Bool("dry-run", false, "")
+	for name, test := range map[string]struct {
+		args []string
+		want bool
+	}{
+		"direct":               {[]string{"-h"}, true},
+		"after config":         {[]string{"-config", "missing.yaml", "-help"}, true},
+		"consumed as value":    {[]string{"-mail-directory", "-h", "-dry-run"}, false},
+		"after double dash":    {[]string{"--", "-h"}, false},
+		"after positional":     {[]string{"serve", "-h"}, false},
+		"after unknown option": {[]string{"-unknown", "-h"}, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := HelpRequested(test.args, fs); got != test.want {
+				t.Fatalf("HelpRequested(%q) = %v, want %v", test.args, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestConfigFileLayering(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "owlmail.yaml")
+	if err := os.WriteFile(path, []byte("web: 8080\nmail-directory: /tmp/owlmail-from-file\nmetrics-enabled: true\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	fileDefaults, err := LoadConfigFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fileDefaults.WebPort != 8080 || fileDefaults.MailDir != "/tmp/owlmail-from-file" || !fileDefaults.MetricsEnabled {
+		t.Fatalf("unexpected file config: %#v", fileDefaults)
+	}
+
+	t.Setenv("OWLMAIL_WEB_PORT", "9090")
+	fs := flag.NewFlagSet("environment", flag.ContinueOnError)
+	refs := DefineFlagsWithDefaults(fs, fileDefaults)
+	_ = fs.Parse(nil)
+	if got := ResolveConfig(fs, refs).WebPort; got != 9090 {
+		t.Fatalf("environment layer = %d, want 9090", got)
+	}
+
+	fs = flag.NewFlagSet("cli", flag.ContinueOnError)
+	refs = DefineFlagsWithDefaults(fs, fileDefaults)
+	_ = fs.Parse([]string{"-web", "7070"})
+	if got := ResolveConfig(fs, refs).WebPort; got != 7070 {
+		t.Fatalf("CLI layer = %d, want 7070", got)
+	}
+}
+
+func TestLoadJSONConfigAndRejectInvalidFiles(t *testing.T) {
+	directory := t.TempDir()
+	jsonPath := filepath.Join(directory, "owlmail.json")
+	if err := os.WriteFile(jsonPath, []byte(`{"smtp":2025,"mcp-enabled":true}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadConfigFile(jsonPath)
+	if err != nil || cfg.SMTPPort != 2025 || !cfg.MCPEnabled {
+		t.Fatalf("JSON config = %#v, %v", cfg, err)
+	}
+
+	for name, content := range map[string]string{
+		"unknown.yaml": "webb: 8080\n",
+		"nested.yaml":  "web:\n  port: 8080\n",
+		"null.yaml":    "web: null\n",
+	} {
+		path := filepath.Join(directory, name)
+		if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := LoadConfigFile(path); err == nil {
+			t.Fatalf("%s was accepted", name)
+		}
+	}
+}
+
+func TestConfigFileFromArgs(t *testing.T) {
+	t.Setenv("OWLMAIL_CONFIG_FILE", "environment.yaml")
+	path, err := configFileFromArgs([]string{"-web", "8080", "--config=cli.json"})
+	if err != nil || path != "cli.json" {
+		t.Fatalf("path = %q, err = %v", path, err)
+	}
+	if _, err := configFileFromArgs([]string{"-config"}); err == nil || !strings.Contains(err.Error(), "requires a path") {
+		t.Fatalf("missing path error = %v", err)
+	}
+}

--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -1,9 +1,11 @@
 package config
 
 import (
+	"bytes"
 	"flag"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -34,6 +36,41 @@ func TestConfigFileLayering(t *testing.T) {
 	_ = fs.Parse([]string{"-web", "7070"})
 	if got := ResolveConfig(fs, refs).WebPort; got != 7070 {
 		t.Fatalf("CLI layer = %d, want 7070", got)
+	}
+}
+
+func TestConfigFileSecretsAreNotFlagDefaults(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "owlmail.yaml")
+	secrets := []string{"value-web-991", "value-outgoing-992", "value-smtp-993", "value-access-994", "value-private-995", "value-session-996"}
+	content := "web-password: value-web-991\noutgoing-pass: value-outgoing-992\nsmtp-password: value-smtp-993\ns3-access-key: value-access-994\ns3-secret-key: value-private-995\ns3-session-token: value-session-996\n"
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	fileDefaults, err := LoadConfigFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs := flag.NewFlagSet("redacted-help", flag.ContinueOnError)
+	var output bytes.Buffer
+	fs.SetOutput(&output)
+	refs := DefineFlagsWithDefaults(fs, fileDefaults)
+	fs.PrintDefaults()
+	for _, secret := range secrets {
+		if strings.Contains(output.String(), secret) {
+			t.Fatalf("flag defaults exposed %q: %s", secret, output.String())
+		}
+	}
+	if cfg := ResolveConfig(fs, refs); cfg.WebPassword != "value-web-991" || cfg.OutgoingPass != "value-outgoing-992" || cfg.SMTPPassword != "value-smtp-993" || cfg.S3SecretAccessKey != "value-private-995" {
+		t.Fatalf("redacting flag defaults changed resolution: %#v", cfg)
+	}
+}
+
+func TestConfigFileReadLimitCoversZeroSizedSources(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("/dev/zero is Unix-specific")
+	}
+	if _, err := LoadConfigFile("/dev/zero"); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("unbounded zero-sized config source error = %v", err)
 	}
 }
 

--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -49,9 +49,10 @@ func TestLoadJSONConfigAndRejectInvalidFiles(t *testing.T) {
 	}
 
 	for name, content := range map[string]string{
-		"unknown.yaml": "webb: 8080\n",
-		"nested.yaml":  "web:\n  port: 8080\n",
-		"null.yaml":    "web: null\n",
+		"unknown.yaml":  "webb: 8080\n",
+		"nested.yaml":   "web:\n  port: 8080\n",
+		"null.yaml":     "web: null\n",
+		"multiple.yaml": "web: 8080\n---\nmetrics-enabled: true\n",
 	} {
 		path := filepath.Join(directory, name)
 		if err := os.WriteFile(path, []byte(content), 0600); err != nil {
@@ -71,5 +72,15 @@ func TestConfigFileFromArgs(t *testing.T) {
 	}
 	if _, err := configFileFromArgs([]string{"-config"}); err == nil || !strings.Contains(err.Error(), "requires a path") {
 		t.Fatalf("missing path error = %v", err)
+	}
+	for name, args := range map[string][]string{
+		"double dash":      {"--", "-config=ignored.yaml"},
+		"positional":       {"serve", "-config=ignored.yaml"},
+		"other flag value": {"-mail-directory", "-config=mail-directory-value"},
+	} {
+		path, err := configFileFromArgs(args)
+		if err != nil || path != "environment.yaml" {
+			t.Fatalf("%s: path = %q, err = %v", name, path, err)
+		}
 	}
 }

--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -41,8 +41,8 @@ func TestConfigFileLayering(t *testing.T) {
 
 func TestConfigFileSecretsAreNotFlagDefaults(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "owlmail.yaml")
-	secrets := []string{"value-web-991", "value-outgoing-992", "value-smtp-993", "value-access-994", "value-private-995", "value-session-996"}
-	content := "web-password: value-web-991\noutgoing-pass: value-outgoing-992\nsmtp-password: value-smtp-993\ns3-access-key: value-access-994\ns3-secret-key: value-private-995\ns3-session-token: value-session-996\n"
+	secrets := []string{"value-web-991", "value-outgoing-992", "value-smtp-993", "value-access-994", "value-private-995", "value-session-996", "value-redis-password-997"}
+	content := "web-password: value-web-991\noutgoing-pass: value-outgoing-992\nsmtp-password: value-smtp-993\ns3-access-key: value-access-994\ns3-secret-key: value-private-995\ns3-session-token: value-session-996\nwebhook-redis-url: redis://user:value-redis-password-997@redis.example.test/0\n"
 	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +60,7 @@ func TestConfigFileSecretsAreNotFlagDefaults(t *testing.T) {
 			t.Fatalf("flag defaults exposed %q: %s", secret, output.String())
 		}
 	}
-	if cfg := ResolveConfig(fs, refs); cfg.WebPassword != "value-web-991" || cfg.OutgoingPass != "value-outgoing-992" || cfg.SMTPPassword != "value-smtp-993" || cfg.S3SecretAccessKey != "value-private-995" {
+	if cfg := ResolveConfig(fs, refs); cfg.WebPassword != "value-web-991" || cfg.OutgoingPass != "value-outgoing-992" || cfg.SMTPPassword != "value-smtp-993" || cfg.S3SecretAccessKey != "value-private-995" || !strings.Contains(cfg.WebhookRedisURL, "value-redis-password-997") {
 		t.Fatalf("redacting flag defaults changed resolution: %#v", cfg)
 	}
 }

--- a/internal/mailserver/data_limiter.go
+++ b/internal/mailserver/data_limiter.go
@@ -47,9 +47,15 @@ func (ms *MailServer) tryAcquireDataSlot() bool {
 
 func (ms *MailServer) releaseDataSlot() {
 	// Keep the slot held while a deterministic test hook accounts for the
-	// completed transaction. The deferred release still prevents a hook panic
-	// from leaking capacity.
-	defer ms.dataLimiter.release()
+	// completed transaction. The deferred cleanup still prevents a hook panic
+	// from leaking capacity, while afterDataRelease lets tests observe the point
+	// at which the capacity is actually available again.
+	defer func() {
+		ms.dataLimiter.release()
+		if ms.afterDataRelease != nil {
+			ms.afterDataRelease()
+		}
+	}()
 	if ms.beforeDataRelease != nil {
 		ms.beforeDataRelease()
 	}

--- a/internal/mailserver/data_limiter_test.go
+++ b/internal/mailserver/data_limiter_test.go
@@ -490,7 +490,7 @@ func TestClientAbortAndServerCloseReleaseDataSlot(t *testing.T) {
 			acquired := make(chan struct{})
 			released := make(chan struct{})
 			server.afterDataAcquire = func() { close(acquired) }
-			server.beforeDataRelease = func() { close(released) }
+			server.afterDataRelease = func() { close(released) }
 
 			client, err := smtp.Dial(listener.Addr().String())
 			if err != nil {

--- a/internal/mailserver/types.go
+++ b/internal/mailserver/types.go
@@ -157,6 +157,7 @@ type MailServer struct {
 	// for concurrency and shutdown tests.
 	afterDataAcquire  func()
 	beforeDataRelease func()
+	afterDataRelease  func()
 }
 
 // GetHost returns the SMTP server host


### PR DESCRIPTION
## Summary

- add flat YAML and JSON configuration files through `-config` or `OWLMAIL_CONFIG_FILE`
- enforce precedence: CLI, MailDev environment aliases, OwlMail environment, file, built-in defaults
- reuse documented CLI option names as file keys
- reject unknown, duplicate, nested, null, oversized, and type-invalid values
- cap files at 1 MiB and document secret-handling expectations
- preserve existing `DefineFlags` callers while adding preloaded defaults

## Tests

- `go test ./...`
- `go vet ./...`
- `git diff --check`