### PR TITLE
docs: position OwlMail as an AI-native testing gateway

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -55,7 +55,11 @@ Ereignisse und AI Agents eine begrenzte, schreibgeschützte MCP-Schnittstelle.
 - **Migrationspfade** — Optionale MailDev- und MailCatcher-REST-Fassaden, ohne
   Socket.IO oder vollständige Gleichwertigkeit zu versprechen.
 
-- **Lokale Werkzeuge** — Webhook-Regeln im eingebetteten `/webhooks`-Editor\n  erstellen und Altprogramme über den [Sendmail-Leitfaden](./docs/de/Sendmail.md)\n  anbinden. Quell- und Browsertests verwenden Bun; die Binärdatei benötigt keine Laufzeit.\n\n## 🆕 OwlMail 0.8.0
+- **Lokale Werkzeuge** — Webhook-Regeln im eingebetteten `/webhooks`-Editor
+  erstellen und Altprogramme über den [Sendmail-Leitfaden](./docs/de/Sendmail.md)
+  anbinden. Quell- und Browsertests verwenden Bun; die Binärdatei benötigt keine Laufzeit.
+
+## 🆕 OwlMail 0.8.0
 
 `v0.8.0` ist die aktuelle stabile Version. Sie ergänzt persistente Relay-Aufträge,
 geschichtete YAML/JSON-Konfiguration, optionales SQLite-Indexing, Prometheus-

--- a/README.de.md
+++ b/README.de.md
@@ -1,8 +1,9 @@
 # OwlMail
 
-> 🦉 Ein Go-Server für E-Mail-Entwicklungstests mit MailDev-ähnlichen Workflows und OwlMail-eigenen APIs
+> 🦉 Ein selbst gehostetes, AI-natives E-Mail-Test-Gateway für Entwicklung, CI, Automatisierung und Coding Agents.
 
 [![Go Version](https://img.shields.io/badge/Go-1.27.0+-00ADD8?style=flat&logo=go)](https://go.dev/)
+[![Latest Release](https://img.shields.io/github/v/release/soulteary/owlmail)](https://github.com/soulteary/owlmail/releases)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![MailDev Workflows](https://img.shields.io/badge/MailDev-Workflow%20Compatibility-blue.svg)](./docs/de/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 [![Go Report Card](.github/goreportcard.svg)](.github/goreportcard-report.md)
@@ -13,10 +14,18 @@
 
 ---
 
-OwlMail ist ein SMTP-Server mit Web-Interface für Entwicklungs- und
-Testumgebungen. Er unterstützt gängige [MailDev](https://github.com/maildev/maildev)-Workflows,
-verwendet jedoch eigene API-Antworten und ein natives WebSocket-Protokoll. Prüfen
-Sie vor der Migration von API- oder Socket.IO-Clients die dokumentierten Unterschiede.
+OwlMail fängt Anwendungs-E-Mails vor einem echten Postfach ab und macht sie zu
+deterministischen, prüfbaren Testdaten. Entwickler nutzen die Weboberfläche,
+Tests die versionierte REST-API und OpenAPI, Automatisierungen dauerhafte
+Ereignisse und AI Agents eine begrenzte, schreibgeschützte MCP-Schnittstelle.
+
+| Nutzer | Schnittstelle | Typischer Ablauf |
+|---|---|---|
+| Entwickler | Weboberfläche und Browser-Benachrichtigungen | HTML, Text, Header, Quelle, Links und Anhänge prüfen |
+| Tests und CI | REST API, OpenAPI 3.1 und WebSocket | Registrierungs-, Reset- und Benachrichtigungs-E-Mails verifizieren |
+| Automatisierung | Signierte Webhooks und optional Redis Streams | Committete E-Mails in wiederherstellbare Ereignisse umwandeln |
+| AI Coding Agents | Schreibgeschütztes MCP über Streamable HTTP oder stdio | E-Mails suchen, abrufen und ereignisbasiert erwarten |
+| SMTP-Betrieb | Manuelles und automatisches Relay | Ausgewählte Test-E-Mails mit klaren TLS-Regeln weiterleiten |
 
 ![](.github/assets/owlmail-banner.jpg)
 
@@ -28,49 +37,38 @@ Sie vor der Migration von API- oder Socket.IO-Clients die dokumentierten Untersc
 
 ![Demo-Video](.github/assets/realtime.gif)
 
-## ✨ Funktionen
+## ✨ Warum OwlMail
 
-### Kernfunktionen
+- **Deterministische Erfassung** — EML, Metadaten und Anhänge werden vor der
+  atomaren Sichtbarkeit vollständig bereitgestellt.
+- **Für Integrationstests** — `/api/v1`, OpenAPI 3.1, natives WebSocket,
+  Health/Readiness, Suche, Filterung und Export.
+- **AI-nativ, nicht AI-abhängig** — Das standardmäßig deaktivierte MCP bietet
+  sieben geschlossene Nur-Lese-Tools, begrenzte Ressourcen, Prompts und
+  ereignisbasiertes `wait_for_email`; OwlMail benötigt selbst kein LLM.
+- **Dauerhafte Automatisierung** — Lokale Webhook-Outbox, optional Redis Streams,
+  HMAC, stabile Zustell-IDs, begrenzte Wiederholungen und geordnetes Beenden.
+- **Expliziter Betrieb** — SMTP-Kapazitätsgrenzen, Persistenz, optionale
+  S3-Anhänge, SQLite-Index, Prometheus-Metriken und JSON-Protokolle.
+- **Kontrollierte Zustellung** — Persistente asynchrone Relay-Aufträge verwenden
+  unveränderliche Konfiguration, Streaming-DATA und explizite TLS-Modi.
+- **Migrationspfade** — Optionale MailDev- und MailCatcher-REST-Fassaden, ohne
+  Socket.IO oder vollständige Gleichwertigkeit zu versprechen.
 
-- ✅ **SMTP-Server** - Empfängt und speichert alle gesendeten E-Mails (Standard-Port 1025)
-- ✅ **Web-Interface** - E-Mails über einen Browser anzeigen und verwalten (Standard-Port 1080)
-- ✅ **E-Mail-Persistenz** - E-Mails werden als `.eml`-Dateien gespeichert, unterstützt Laden aus Verzeichnis
-- ✅ **E-Mail-Weiterleitung** - Unterstützt Weiterleitung von E-Mails an echte SMTP-Server
-- ✅ **Auto-Relay** - Unterstützt automatische Weiterleitung aller E-Mails mit Regel-Filterung
-- ✅ **Webhook-Weiterleitung** - Sendet passende neue E-Mails mit benutzerdefinierten Nachrichtenvorlagen an HTTP-Webhooks
-- ✅ **Eingehende SMTP-Authentifizierung** - Erzwungene PLAIN/LOGIN-Authentifizierung mit konfigurationsfreiem NO-AUTH-Testmodus
-- ✅ **TLS/STARTTLS** - Unterstützt verschlüsselte Verbindungen
-- ✅ **SMTPS** - Unterstützt direkte TLS-Verbindung auf Port 465, wenn SMTP-TLS aktiviert ist
+- **Lokale Werkzeuge** — Webhook-Regeln im eingebetteten `/webhooks`-Editor\n  erstellen und Altprogramme über den [Sendmail-Leitfaden](./docs/de/Sendmail.md)\n  anbinden. Quell- und Browsertests verwenden Bun; die Binärdatei benötigt keine Laufzeit.\n\n## 🆕 OwlMail 0.8.0
 
-### Erweiterte Funktionen
+`v0.8.0` ist die aktuelle stabile Version. Sie ergänzt persistente Relay-Aufträge,
+geschichtete YAML/JSON-Konfiguration, optionales SQLite-Indexing, Prometheus-
+Metriken, strukturierte Logs, MailCatcher REST, MCP stdio und strengere Grenzen.
 
-- 🆕 **Batch-Operationen** - Batch-Löschen, Batch-als-gelesen-markieren
-- 🆕 **Browser-Benachrichtigungen** - Optionale Live-Benachrichtigungen für neue E-Mails
-- 🆕 **E-Mail-Statistiken** - E-Mail-Statistiken abrufen
-- 🆕 **E-Mail-Vorschau** - Leichtgewichtige E-Mail-Vorschau-API
-- 🆕 **E-Mail-Export** - E-Mails als ZIP-Dateien exportieren
-- 🆕 **Konfigurationsverwaltungs-API** - Vollständige Konfigurationsverwaltung (GET/PUT/PATCH)
-- 🆕 **Leistungsstarke Suche** - Volltextsuche, Datumsbereichsfilterung, Sortierung
-- 🆕 **Verbesserte RESTful API** - Standardisierteres API-Design (`/api/v1/*`)
-- 🆕 **Integrierte Hilfe** - Lokaler zweisprachiger Leitfaden im Posteingang oder unter `/help`
-- 🆕 **Webhook-Konfigurator** - Eingebetteter lokaler Editor unter `/webhooks` zum Erstellen, Importieren, Prüfen, Kopieren und Herunterladen von Weiterleitungsregeln
-- 🆕 **Sendmail-kompatible CLI** - [`owlmail sendmail`](./docs/de/Sendmail.md) übergibt PHP-, Cron- und Altprogramm-Nachrichten über die normale SMTP-Grenze
+Alle Installationsbeispiele verwenden `ghcr.io/soulteary/owlmail:0.8.0`.
+Für reproduzierbare CI sollte die vollständige Version oder
+`ghcr.io/soulteary/owlmail@sha256:<digest>` verwendet werden.
+Details stehen in den [Versionshinweisen 0.8.0](./docs/en/Release-0.8.0.md).
 
-### Kompatibilität
-
-- ✅ **MailDev-ähnliche Workflow-Routen** - Gängige E-Mail-, Relay-, Konfigurations- und Health-Abläufe
-- ✅ **Ausgewählte MailDev-Umgebungsaliase** - Unterstützte `MAILDEV_*`-Namen stehen in der Konfigurationstabelle
-- ✅ **Auto-Relay-Regeln** - MailDev-ähnliche JSON-Allow/Deny-Regeln
-- ⚠️ **Dokumentierte Unterschiede** - API-Präfixe, Payloads, Lesezustand und Live-Protokoll sind nicht identisch
-
-### Bereitstellungseigenschaften
-
-- ⚡ **Einzelne Binärdatei** - UI und Hilfe sind eingebettet
-- ⚡ **Keine Sprachlaufzeit** - Die Binärdatei benötigt weder Go noch Bun oder Node.js
-- ⚡ **Explizite Parallelitätssteuerung** - Webhook-Zustellung kann begrenzt oder bewusst unbegrenzt sein
-
-Das Repository veröffentlicht keinen reproduzierbaren Projektvergleich. Messen
-Sie Startzeit, Speicher und Durchsatz mit der eigenen Last.
+> [!IMPORTANT]
+> OwlMail ist für Entwicklung, Tests, CI und vertrauenswürdige interne Netze
+> gedacht, nicht als öffentliches Produktions-MTA oder mandantenfähiger Maildienst.
 
 ## 🚀 Schnellstart
 
@@ -704,4 +702,4 @@ Wenn dieses Projekt Ihnen hilft, geben Sie bitte einen Star ⭐!
 
 ---
 
-**OwlMail** - Ein Go-Server für E-Mail-Entwicklungstests mit dokumentierten MailDev-Migrationspfaden 🦉
+**OwlMail** — ein selbst gehostetes E-Mail-Test-Gateway für Entwicklung, CI, Automatisierung und AI Agents. 🦉

--- a/README.fr.md
+++ b/README.fr.md
@@ -56,7 +56,11 @@ borné en lecture seule.
 - **Migration claire** — Façades REST MailDev et MailCatcher optionnelles, sans
   prétendre implémenter Socket.IO ni une équivalence exacte.
 
-- **Outils locaux** — Créez les règles dans l’éditeur `/webhooks` intégré et\n  utilisez le [guide sendmail](./docs/fr/Sendmail.md) pour les programmes existants.\n  Les tests source et navigateur utilisent Bun ; le binaire déployé n’en dépend pas.\n\n## 🆕 OwlMail 0.8.0
+- **Outils locaux** — Créez les règles dans l’éditeur `/webhooks` intégré et
+  utilisez le [guide sendmail](./docs/fr/Sendmail.md) pour les programmes existants.
+  Les tests source et navigateur utilisent Bun ; le binaire déployé n’en dépend pas.
+
+## 🆕 OwlMail 0.8.0
 
 `v0.8.0` est la version stable actuelle. Elle ajoute les tâches Relay
 persistantes, la configuration YAML/JSON en couches, l’index SQLite optionnel,

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,8 +1,9 @@
 # OwlMail
 
-> 🦉 Un serveur Go de développement et de test d'e-mails, avec des workflows de style MailDev et des API propres à OwlMail
+> 🦉 Une passerelle de test d’e-mails auto-hébergée et AI-native pour le développement, la CI, l’automatisation et les agents de code.
 
 [![Go Version](https://img.shields.io/badge/Go-1.27.0+-00ADD8?style=flat&logo=go)](https://go.dev/)
+[![Latest Release](https://img.shields.io/github/v/release/soulteary/owlmail)](https://github.com/soulteary/owlmail/releases)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![MailDev Workflows](https://img.shields.io/badge/MailDev-Workflow%20Compatibility-blue.svg)](./docs/fr/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 [![Go Report Card](.github/goreportcard.svg)](.github/goreportcard-report.md)
@@ -13,11 +14,19 @@
 
 ---
 
-OwlMail est un serveur SMTP avec interface web pour les environnements de
-développement et de test. Il couvre des workflows courants de
-[MailDev](https://github.com/maildev/maildev), mais utilise ses propres réponses
-API et un protocole WebSocket natif. Vérifiez les différences avant de migrer un
-client API ou Socket.IO.
+OwlMail capture les e-mails applicatifs avant leur arrivée dans une vraie boîte
+et les transforme en données de test déterministes et inspectables. Les
+développeurs utilisent l’interface Web, les tests l’API REST versionnée et
+OpenAPI, les automatisations des événements durables et les agents AI un MCP
+borné en lecture seule.
+
+| Utilisateur | Interface | Workflow typique |
+|---|---|---|
+| Développeurs | Interface Web et notifications navigateur | Inspecter HTML, texte, en-têtes, source, liens et pièces jointes |
+| Tests et CI | API REST, OpenAPI 3.1 et WebSocket | Vérifier les e-mails d’inscription, de réinitialisation et de notification |
+| Automatisation | Webhooks signés et Redis Streams optionnel | Transformer un e-mail validé en événement récupérable |
+| Agents de code AI | MCP en lecture seule via Streamable HTTP ou stdio | Rechercher, récupérer et attendre un e-mail sans accès destructif |
+| Exploitation SMTP | Relais manuel et automatique | Transférer un e-mail de test avec des politiques TLS explicites |
 
 ![](.github/assets/owlmail-banner.jpg)
 
@@ -29,49 +38,39 @@ client API ou Socket.IO.
 
 ![Vidéo de démonstration](.github/assets/realtime.gif)
 
-## ✨ Features
+## ✨ Pourquoi OwlMail
 
-### Core Features
+- **Capture déterministe** — EML, métadonnées et pièces jointes sont préparés
+  avant qu’un commit atomique ne rende le message visible.
+- **Prêt pour les tests d’intégration** — `/api/v1`, OpenAPI 3.1, WebSocket natif,
+  sondes de santé, recherche, filtrage et export.
+- **AI-native sans dépendre de l’AI** — Le MCP désactivé par défaut expose sept
+  outils fermés en lecture seule, des ressources bornées, des prompts et
+  `wait_for_email` événementiel ; OwlMail ne requiert aucun LLM.
+- **Automatisation durable** — Outbox Webhook locale, Redis Streams optionnel,
+  HMAC, identifiants stables, reprises bornées et arrêt progressif.
+- **Exploitation explicite** — Limites SMTP, persistance, pièces jointes S3
+  optionnelles, index SQLite, métriques Prometheus et logs JSON.
+- **Livraison contrôlée** — Les tâches Relay persistantes utilisent des
+  instantanés immuables, DATA en streaming et des modes TLS explicites.
+- **Migration claire** — Façades REST MailDev et MailCatcher optionnelles, sans
+  prétendre implémenter Socket.IO ni une équivalence exacte.
 
-- ✅ **SMTP Server** - Receives and stores all sent emails (default port 1025)
-- ✅ **Web Interface** - View and manage emails through a browser (default port 1080)
-- ✅ **Email Persistence** - Emails saved as `.eml` files, supports loading from directory
-- ✅ **Email Relay** - Supports forwarding emails to real SMTP servers
-- ✅ **Auto Relay** - Supports automatically forwarding all emails with rule filtering
-- ✅ **Webhook Forwarding** - Sends matching new emails to HTTP webhooks with custom message templates
-- ✅ **Authentification SMTP entrante** - Authentification PLAIN/LOGIN obligatoire avec un mode de test NO AUTH sans configuration
-- ✅ **TLS/STARTTLS** - Supports encrypted connections
-- ✅ **SMTPS** - Supports direct TLS connection on port 465 when SMTP TLS is enabled
+- **Outils locaux** — Créez les règles dans l’éditeur `/webhooks` intégré et\n  utilisez le [guide sendmail](./docs/fr/Sendmail.md) pour les programmes existants.\n  Les tests source et navigateur utilisent Bun ; le binaire déployé n’en dépend pas.\n\n## 🆕 OwlMail 0.8.0
 
-### Enhanced Features
+`v0.8.0` est la version stable actuelle. Elle ajoute les tâches Relay
+persistantes, la configuration YAML/JSON en couches, l’index SQLite optionnel,
+les métriques Prometheus, les logs structurés, la façade MailCatcher REST, le
+pont MCP stdio et des validations plus strictes.
 
-- 🆕 **Batch Operations** - Batch delete, batch mark as read
-- 🆕 **Notifications navigateur** - Notifications temps réel facultatives pour les nouveaux e-mails
-- 🆕 **Email Statistics** - Get email statistics
-- 🆕 **Email Preview** - Lightweight email preview API
-- 🆕 **Email Export** - Export emails as ZIP files
-- 🆕 **Configuration Management API** - Complete configuration management (GET/PUT/PATCH)
-- 🆕 **Powerful Search** - Full-text search, date range filtering, sorting
-- 🆕 **Improved RESTful API** - More standardized API design (`/api/v1/*`)
-- 🆕 **Aide intégrée** - Guide local bilingue depuis la boîte de réception ou `/help`
-- 🆕 **Configurateur Webhook** - Éditeur local intégré sous `/webhooks` pour créer, importer, valider, copier et télécharger les règles de transfert
-- 🆕 **CLI compatible sendmail** - [`owlmail sendmail`](./docs/fr/Sendmail.md) soumet les messages PHP, Cron et historiques via la frontière SMTP normale
+Tous les exemples utilisent `ghcr.io/soulteary/owlmail:0.8.0`.
+Pour une CI reproductible, utilisez la version complète ou
+`ghcr.io/soulteary/owlmail@sha256:<digest>`.
+Consultez les [notes de version 0.8.0](./docs/en/Release-0.8.0.md).
 
-### Compatibility
-
-- ✅ **Routes de workflow de style MailDev** - Flux courants d'e-mail, de relais, de configuration et de santé
-- ✅ **Alias MailDev sélectionnés** - Les noms `MAILDEV_*` pris en charge figurent dans le tableau de configuration
-- ✅ **Règles d'auto-relais** - Règles JSON allow/deny de style MailDev
-- ⚠️ **Différences documentées** - Préfixes API, payloads, état de lecture et protocole temps réel diffèrent
-
-### Caractéristiques de déploiement
-
-- ⚡ **Binaire unique** - L'interface et l'aide sont intégrées
-- ⚡ **Sans runtime de langage** - Le binaire déployé ne requiert ni Go, ni Bun, ni Node.js
-- ⚡ **Concurrence explicite** - Les Webhooks peuvent être limités ou volontairement illimités
-
-Le dépôt ne publie pas de benchmark comparatif reproductible. Mesurez démarrage,
-mémoire et débit avec votre propre charge.
+> [!IMPORTANT]
+> OwlMail cible le développement, les tests, la CI et les réseaux internes de
+> confiance ; ce n’est ni un MTA public de production ni un service multi-tenant.
 
 ## 🚀 Quick Start
 
@@ -702,4 +701,4 @@ If this project helps you, please give it a Star ⭐!
 
 ---
 
-**OwlMail** - Un serveur Go de test d'e-mails avec des chemins de migration MailDev documentés 🦉
+**OwlMail** — une passerelle de test d’e-mails auto-hébergée pour le développement, la CI, l’automatisation et les agents AI. 🦉

--- a/README.it.md
+++ b/README.it.md
@@ -55,7 +55,11 @@ automazioni eventi durevoli e gli agenti AI un MCP limitato in sola lettura.
 - **Migrazione chiara** — Facade REST MailDev e MailCatcher opzionali, senza
   promettere Socket.IO o equivalenza completa.
 
-- **Strumenti locali** — Crea regole nell’editor `/webhooks` integrato e usa la\n  [guida sendmail](./docs/it/Sendmail.md) per i programmi legacy. I test sorgente\n  e browser usano Bun; il binario distribuito non richiede runtime.\n\n## 🆕 OwlMail 0.8.0
+- **Strumenti locali** — Crea regole nell’editor `/webhooks` integrato e usa la
+  [guida sendmail](./docs/it/Sendmail.md) per i programmi legacy. I test sorgente
+  e browser usano Bun; il binario distribuito non richiede runtime.
+
+## 🆕 OwlMail 0.8.0
 
 `v0.8.0` è la versione stabile corrente. Aggiunge job Relay persistenti,
 configurazione YAML/JSON a livelli, indice SQLite opzionale, metriche

--- a/README.it.md
+++ b/README.it.md
@@ -1,8 +1,9 @@
 # OwlMail
 
-> 🦉 Un server Go per lo sviluppo e il test delle email, con workflow in stile MailDev e API specifiche di OwlMail
+> 🦉 Un gateway self-hosted e AI-native per test email, CI, automazione e coding agent.
 
 [![Go Version](https://img.shields.io/badge/Go-1.27.0+-00ADD8?style=flat&logo=go)](https://go.dev/)
+[![Latest Release](https://img.shields.io/github/v/release/soulteary/owlmail)](https://github.com/soulteary/owlmail/releases)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![MailDev Workflows](https://img.shields.io/badge/MailDev-Workflow%20Compatibility-blue.svg)](./docs/it/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 [![Go Report Card](.github/goreportcard.svg)](.github/goreportcard-report.md)
@@ -13,10 +14,18 @@
 
 ---
 
-OwlMail è un server SMTP con interfaccia web per ambienti di sviluppo e test.
-Supporta workflow comuni di [MailDev](https://github.com/maildev/maildev), ma usa
-risposte API e un protocollo WebSocket propri. Verifica le differenze documentate
-prima di migrare client API o Socket.IO.
+OwlMail intercetta le email dell’applicazione prima che raggiungano una casella
+reale e le trasforma in dati di test deterministici e ispezionabili. Gli
+sviluppatori usano la Web UI, i test la REST API versionata e OpenAPI, le
+automazioni eventi durevoli e gli agenti AI un MCP limitato in sola lettura.
+
+| Utente | Interfaccia | Workflow tipico |
+|---|---|---|
+| Sviluppatori | Web UI e notifiche browser | Ispezionare HTML, testo, header, sorgente, link e allegati |
+| Test e CI | REST API, OpenAPI 3.1 e WebSocket | Verificare email di registrazione, reset e notifica |
+| Automazione | Webhook firmati e Redis Streams opzionale | Convertire email confermate in eventi recuperabili |
+| Coding agent AI | MCP in sola lettura via Streamable HTTP o stdio | Cercare, recuperare e attendere email senza accesso distruttivo |
+| Operazioni SMTP | Relay manuale e automatico | Inoltrare email di test con policy TLS esplicite |
 
 ![](.github/assets/owlmail-banner.jpg)
 
@@ -28,49 +37,39 @@ prima di migrare client API o Socket.IO.
 
 ![Video dimostrativo](.github/assets/realtime.gif)
 
-## ✨ Funzionalità
+## ✨ Perché OwlMail
 
-### Funzionalità Core
+- **Acquisizione deterministica** — EML, metadati e allegati sono preparati
+  prima che un commit atomico renda visibile il messaggio.
+- **Pronto per test di integrazione** — `/api/v1`, OpenAPI 3.1, WebSocket nativo,
+  health/readiness, ricerca, filtri ed esportazione.
+- **AI-native senza dipendere dall’AI** — MCP, disattivato per impostazione
+  predefinita, offre sette tool di sola lettura, risorse limitate, prompt e
+  `wait_for_email` event-driven; OwlMail non richiede un LLM.
+- **Automazione durevole** — Outbox Webhook locale, Redis Streams opzionale,
+  HMAC, ID stabili, retry limitati e arresto controllato.
+- **Operazioni esplicite** — Limiti SMTP, persistenza, allegati S3 opzionali,
+  indice SQLite, metriche Prometheus e log JSON.
+- **Consegna controllata** — I job Relay persistenti usano snapshot immutabili,
+  DATA in streaming e modalità TLS esplicite.
+- **Migrazione chiara** — Facade REST MailDev e MailCatcher opzionali, senza
+  promettere Socket.IO o equivalenza completa.
 
-- ✅ **Server SMTP** - Riceve e memorizza tutte le email inviate (porta predefinita 1025)
-- ✅ **Interfaccia Web** - Visualizza e gestisci le email tramite un browser (porta predefinita 1080)
-- ✅ **Persistenza Email** - Le email vengono salvate come file `.eml`, supporta il caricamento da directory
-- ✅ **Inoltro Email** - Supporta l'inoltro di email a server SMTP reali
-- ✅ **Inoltro Automatico** - Supporta l'inoltro automatico di tutte le email con filtri basati su regole
-- ✅ **Inoltro Webhook** - Invia le nuove email corrispondenti a webhook HTTP con modelli di messaggio personalizzati
-- ✅ **Autenticazione SMTP in ingresso** - Autenticazione PLAIN/LOGIN obbligatoria con modalità di test NO AUTH senza configurazione
-- ✅ **TLS/STARTTLS** - Supporta connessioni crittografate
-- ✅ **SMTPS** - Supporta la connessione TLS diretta sulla porta 465 quando SMTP TLS è abilitato
+- **Strumenti locali** — Crea regole nell’editor `/webhooks` integrato e usa la\n  [guida sendmail](./docs/it/Sendmail.md) per i programmi legacy. I test sorgente\n  e browser usano Bun; il binario distribuito non richiede runtime.\n\n## 🆕 OwlMail 0.8.0
 
-### Funzionalità Avanzate
+`v0.8.0` è la versione stabile corrente. Aggiunge job Relay persistenti,
+configurazione YAML/JSON a livelli, indice SQLite opzionale, metriche
+Prometheus, log strutturati, facade MailCatcher REST, bridge MCP stdio e
+validazioni più rigorose.
 
-- 🆕 **Operazioni Batch** - Eliminazione batch, segnatura batch come lette
-- 🆕 **Notifiche browser** - Notifiche live opzionali per le nuove email
-- 🆕 **Statistiche Email** - Ottieni statistiche sulle email
-- 🆕 **Anteprima Email** - API leggera per l'anteprima delle email
-- 🆕 **Esportazione Email** - Esporta email come file ZIP
-- 🆕 **API di Gestione Configurazione** - Gestione completa della configurazione (GET/PUT/PATCH)
-- 🆕 **Ricerca Potente** - Ricerca full-text, filtri per intervallo di date, ordinamento
-- 🆕 **API RESTful Migliorata** - Design API più standardizzato (`/api/v1/*`)
-- 🆕 **Guida integrata** - Guida locale bilingue dalla casella di posta o su `/help`
-- 🆕 **Configuratore Webhook** - Editor locale integrato in `/webhooks` per creare, importare, validare, copiare e scaricare le regole di inoltro
-- 🆕 **CLI compatibile con sendmail** - [`owlmail sendmail`](./docs/it/Sendmail.md) consegna i messaggi di PHP, Cron e programmi legacy tramite il normale confine SMTP
+Tutti gli esempi usano `ghcr.io/soulteary/owlmail:0.8.0`.
+Per una CI riproducibile usa la versione completa o
+`ghcr.io/soulteary/owlmail@sha256:<digest>`.
+Consulta le [note di rilascio 0.8.0](./docs/en/Release-0.8.0.md).
 
-### Compatibilità
-
-- ✅ **Route per workflow in stile MailDev** - Flussi comuni per email, relay, configurazione e health check
-- ✅ **Alias selezionati per variabili MailDev** - I nomi `MAILDEV_*` supportati sono nella tabella di configurazione
-- ✅ **Regole di inoltro automatico** - Regole JSON allow/deny in stile MailDev
-- ⚠️ **Differenze documentate** - Prefissi API, payload, stato di lettura e protocollo live non sono identici
-
-### Caratteristiche di distribuzione
-
-- ⚡ **Binario singolo** - Interfaccia e guida sono incorporate
-- ⚡ **Nessun runtime del linguaggio** - Il binario non richiede Go, Bun o Node.js
-- ⚡ **Concorrenza esplicita** - I Webhook possono essere limitati o intenzionalmente illimitati
-
-Il repository non pubblica benchmark comparativi riproducibili. Misura avvio,
-memoria e throughput con il tuo carico reale.
+> [!IMPORTANT]
+> OwlMail è destinato a sviluppo, test, CI e reti interne affidabili; non è un
+> MTA pubblico di produzione né un servizio email multi-tenant.
 
 ## 🚀 Quick Start
 
@@ -700,4 +699,4 @@ Se questo progetto ti aiuta, per favore dagli una Star ⭐!
 
 ---
 
-**OwlMail** - Un server Go per test email con percorsi di migrazione MailDev documentati 🦉
+**OwlMail** — un gateway email self-hosted per sviluppo, CI, automazione e agenti AI. 🦉

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,8 +1,9 @@
 # OwlMail
 
-> 🦉 MailDev 風ワークフローと OwlMail 独自 API を備えた Go 製メール開発・テストサーバー
+> 🦉 開発、CI、自動化、コーディング Agent のためのセルフホスト型 AI ネイティブ・メールテストゲートウェイ。
 
 [![Go Version](https://img.shields.io/badge/Go-1.27.0+-00ADD8?style=flat&logo=go)](https://go.dev/)
+[![Latest Release](https://img.shields.io/github/v/release/soulteary/owlmail)](https://github.com/soulteary/owlmail/releases)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![MailDev Workflows](https://img.shields.io/badge/MailDev-Workflow%20Compatibility-blue.svg)](./docs/ja/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 [![Go Report Card](.github/goreportcard.svg)](.github/goreportcard-report.md)
@@ -13,10 +14,18 @@
 
 ---
 
-OwlMail は開発・テスト環境向けの SMTP サーバーと Web UI です。
-[MailDev](https://github.com/maildev/maildev) の一般的なワークフローを扱いますが、
-API レスポンスと WebSocket プロトコルは独自です。API や Socket.IO クライアントを
-移行する前に、文書化された相違点を確認してください。
+OwlMail はアプリケーションメールを実際の受信箱へ届く前に捕捉し、決定論的で
+検証可能なテストデータに変換します。開発者は Web UI、テストはバージョン化
+REST API と OpenAPI、自動化は永続イベント、AI Agent は境界が明確な読み取り
+専用 MCP を利用できます。
+
+| 利用者 | インターフェース | 代表的なワークフロー |
+|---|---|---|
+| 開発者 | Web UI とブラウザ通知 | HTML、テキスト、Header、ソース、リンク、添付を確認 |
+| テストと CI | REST API、OpenAPI 3.1、WebSocket | 登録、パスワードリセット、通知メールを検証 |
+| 自動化 | 署名付き Webhook、任意の Redis Streams | コミット済みメールを復旧可能なイベントへ変換 |
+| AI コーディング Agent | Streamable HTTP / stdio の読み取り専用 MCP | 破壊的権限なしでメールを検索、取得、待機 |
+| SMTP 運用 | 手動・自動 Relay | 明示的な TLS と再試行ポリシーでテストメールを転送 |
 
 ![](.github/assets/owlmail-banner.jpg)
 
@@ -28,49 +37,38 @@ API レスポンスと WebSocket プロトコルは独自です。API や Socket
 
 ![デモ動画](.github/assets/realtime.gif)
 
-## ✨ Features
+## ✨ OwlMail を選ぶ理由
 
-### Core Features
+- **決定論的な捕捉** — EML、メタデータ、添付を staging し、原子的な commit
+  が完了してから API とイベントへ公開します。
+- **統合テスト対応** — `/api/v1`、OpenAPI 3.1、ネイティブ WebSocket、
+  health/readiness、検索、フィルター、エクスポートを提供します。
+- **AI ネイティブで AI 非依存** — 既定で無効の MCP は、7 個の閉じた読み取り
+  専用 Tool、上限付き Resource、Prompt、イベント駆動 `wait_for_email` を提供し、
+  OwlMail 自体は LLM を必要としません。
+- **永続的な自動化** — ローカル Webhook outbox、任意の Redis Streams、HMAC、
+  安定した配信 ID、有限再試行、graceful drain。
+- **明示的な運用境界** — SMTP 容量制限、永続化、任意の S3 添付、SQLite
+  index、Prometheus metrics、JSON log。
+- **制御された配信** — 永続非同期 Relay job は不変 snapshot、ストリーミング
+  DATA、明示的 TLS mode、状態照会を利用します。
+- **移行パス** — MailDev / MailCatcher REST facade は既定で無効であり、
+  Socket.IO や完全互換を主張しません。
 
-- ✅ **SMTP Server** - Receives and stores all sent emails (default port 1025)
-- ✅ **Web Interface** - View and manage emails through a browser (default port 1080)
-- ✅ **Email Persistence** - Emails saved as `.eml` files, supports loading from directory
-- ✅ **Email Relay** - Supports forwarding emails to real SMTP servers
-- ✅ **Auto Relay** - Supports automatically forwarding all emails with rule filtering
-- ✅ **Webhook Forwarding** - Sends matching new emails to HTTP webhooks with custom message templates
-- ✅ **受信 SMTP 認証** - PLAIN/LOGIN の必須認証と、設定不要の NO AUTH テストモードに対応
-- ✅ **TLS/STARTTLS** - Supports encrypted connections
-- ✅ **SMTPS** - Supports direct TLS connection on port 465 when SMTP TLS is enabled
+- **ローカルツール** — 組み込み `/webhooks` editor でルールを作成し、従来\n  プログラムは [sendmail ガイド](./docs/ja/Sendmail.md)を参照できます。ソースと\n  ブラウザテストは Bun を使用しますが、配布バイナリの実行には不要です。\n\n## 🆕 OwlMail 0.8.0
 
-### Enhanced Features
+`v0.8.0` は現在の安定版です。永続 Relay job、階層化 YAML/JSON 設定、任意の
+SQLite index、Prometheus metrics、構造化 log、MailCatcher REST facade、MCP
+stdio bridge、強化された Web inbox と厳格な検証を追加しました。
 
-- 🆕 **Batch Operations** - Batch delete, batch mark as read
-- 🆕 **ブラウザ通知** - 新着メールの任意リアルタイム通知
-- 🆕 **Email Statistics** - Get email statistics
-- 🆕 **Email Preview** - Lightweight email preview API
-- 🆕 **Email Export** - Export emails as ZIP files
-- 🆕 **Configuration Management API** - Complete configuration management (GET/PUT/PATCH)
-- 🆕 **Powerful Search** - Full-text search, date range filtering, sorting
-- 🆕 **Improved RESTful API** - More standardized API design (`/api/v1/*`)
-- 🆕 **内蔵ヘルプ** - 受信トレイまたは `/help` から開けるローカル二言語ガイド
-- 🆕 **Webhook 設定ツール** - `/webhooks` で転送ルールの作成、インポート、検証、コピー、ダウンロードができる組み込みローカルエディター
-- 🆕 **sendmail 互換 CLI** - [`owlmail sendmail`](./docs/ja/Sendmail.md) は PHP、Cron、従来プログラムのメールを通常の SMTP 境界経由で送信
+以下の例は `ghcr.io/soulteary/owlmail:0.8.0` に固定しています。
+再現可能な CI では完全なバージョンまたは
+`ghcr.io/soulteary/owlmail@sha256:<digest>` を使用してください。
+[0.8.0 リリースノート](./docs/en/Release-0.8.0.md)も参照してください。
 
-### Compatibility
-
-- ✅ **MailDev 風ワークフロールート** - 一般的なメール、リレー、設定、ヘルスチェックを提供
-- ✅ **選択された MailDev 環境変数エイリアス** - 対応する `MAILDEV_*` は設定表に記載
-- ✅ **自動リレールール** - MailDev 風 JSON allow/deny ルールをサポート
-- ⚠️ **文書化された相違点** - API プレフィックス、ペイロード、既読状態、リアルタイム通信は同一ではない
-
-### デプロイ特性
-
-- ⚡ **単一バイナリ** - UI とヘルプを埋め込み
-- ⚡ **言語ランタイム不要** - 配布バイナリは Go、Bun、Node.js を必要としない
-- ⚡ **明示的な同時実行制御** - Webhook は上限付き、または意図的に無制限に設定可能
-
-リポジトリには再現可能なプロジェクト間ベンチマークはありません。実際の負荷で
-起動時間、メモリ、スループットを測定してください。
+> [!IMPORTANT]
+> OwlMail は開発、テスト、CI、信頼できる内部ネットワーク向けです。公開本番
+> MTA、exactly-once queue、マルチテナントメールサービスではありません。
 
 ## 🚀 Quick Start
 
@@ -699,4 +697,4 @@ If this project helps you, please give it a Star ⭐!
 
 ---
 
-**OwlMail** - MailDev 移行手順を明示した Go 製メール開発・テストサーバー 🦉
+**OwlMail** — 開発、CI、自動化、AI Agent のためのセルフホスト型メールテストゲートウェイ。🦉

--- a/README.ja.md
+++ b/README.ja.md
@@ -55,7 +55,11 @@ REST API と OpenAPI、自動化は永続イベント、AI Agent は境界が明
 - **移行パス** — MailDev / MailCatcher REST facade は既定で無効であり、
   Socket.IO や完全互換を主張しません。
 
-- **ローカルツール** — 組み込み `/webhooks` editor でルールを作成し、従来\n  プログラムは [sendmail ガイド](./docs/ja/Sendmail.md)を参照できます。ソースと\n  ブラウザテストは Bun を使用しますが、配布バイナリの実行には不要です。\n\n## 🆕 OwlMail 0.8.0
+- **ローカルツール** — 組み込み `/webhooks` editor でルールを作成し、従来
+  プログラムは [sendmail ガイド](./docs/ja/Sendmail.md)を参照できます。ソースと
+  ブラウザテストは Bun を使用しますが、配布バイナリの実行には不要です。
+
+## 🆕 OwlMail 0.8.0
 
 `v0.8.0` は現在の安定版です。永続 Relay job、階層化 YAML/JSON 設定、任意の
 SQLite index、Prometheus metrics、構造化 log、MailCatcher REST facade、MCP

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,8 +1,9 @@
 # OwlMail
 
-> 🦉 MailDev 스타일 워크플로와 OwlMail 전용 API를 제공하는 Go 이메일 개발·테스트 서버
+> 🦉 개발자, CI 파이프라인, 자동화 및 코딩 Agent를 위한 셀프 호스팅 AI 네이티브 이메일 테스트 게이트웨이.
 
 [![Go Version](https://img.shields.io/badge/Go-1.27.0+-00ADD8?style=flat&logo=go)](https://go.dev/)
+[![Latest Release](https://img.shields.io/github/v/release/soulteary/owlmail)](https://github.com/soulteary/owlmail/releases)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![MailDev Workflows](https://img.shields.io/badge/MailDev-Workflow%20Compatibility-blue.svg)](./docs/ko/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 [![Go Report Card](.github/goreportcard.svg)](.github/goreportcard-report.md)
@@ -13,10 +14,18 @@
 
 ---
 
-OwlMail은 개발 및 테스트 환경을 위한 SMTP 서버와 Web UI입니다. 일반적인
-[MailDev](https://github.com/maildev/maildev) 워크플로를 지원하지만 API 응답과
-WebSocket 프로토콜은 OwlMail 고유 형식입니다. API 또는 Socket.IO 클라이언트를
-마이그레이션하기 전에 문서화된 차이를 확인하세요.
+OwlMail은 애플리케이션 이메일이 실제 받은 편지함에 도착하기 전에 캡처하여
+결정적이고 검사 가능한 테스트 데이터로 변환합니다. 개발자는 Web UI, 테스트는
+버전이 지정된 REST API와 OpenAPI, 자동화는 지속 이벤트, AI Agent는 경계가
+명확한 읽기 전용 MCP를 사용할 수 있습니다.
+
+| 사용자 | 인터페이스 | 일반적인 워크플로 |
+|---|---|---|
+| 개발자 | Web UI 및 브라우저 알림 | HTML, 텍스트, Header, 원본, 링크 및 첨부 검사 |
+| 테스트와 CI | REST API, OpenAPI 3.1 및 WebSocket | 가입, 비밀번호 재설정 및 알림 이메일 검증 |
+| 자동화 | 서명된 Webhook 및 선택적 Redis Streams | 커밋된 이메일을 복구 가능한 이벤트로 변환 |
+| AI 코딩 Agent | Streamable HTTP 또는 stdio 기반 읽기 전용 MCP | 파괴적 권한 없이 이메일 검색, 조회 및 대기 |
+| SMTP 운영 | 수동 및 자동 Relay | 명시적 TLS와 재시도 정책으로 테스트 이메일 전달 |
 
 ![](.github/assets/owlmail-banner.jpg)
 
@@ -28,49 +37,38 @@ WebSocket 프로토콜은 OwlMail 고유 형식입니다. API 또는 Socket.IO �
 
 ![데모 비디오](.github/assets/realtime.gif)
 
-## ✨ Features
+## ✨ OwlMail을 선택하는 이유
 
-### Core Features
+- **결정적 캡처** — EML, 메타데이터 및 첨부를 staging한 뒤 원자적 commit이
+  완료되어야 API와 이벤트 소비자에게 공개됩니다.
+- **통합 테스트 지원** — `/api/v1`, OpenAPI 3.1, 네이티브 WebSocket,
+  health/readiness, 검색, 필터 및 내보내기를 제공합니다.
+- **AI 네이티브, AI 비의존** — 기본 비활성 MCP는 7개의 폐쇄형 읽기 전용 Tool,
+  제한된 Resource, Prompt 및 이벤트 기반 `wait_for_email`을 제공하며 OwlMail
+  자체는 LLM이 필요하지 않습니다.
+- **지속 가능한 자동화** — 로컬 Webhook outbox, 선택적 Redis Streams, HMAC,
+  안정적인 전달 ID, 제한된 재시도 및 graceful drain.
+- **명확한 운영 경계** — SMTP 용량 제한, 영속성, 선택적 S3 첨부, SQLite index,
+  Prometheus metrics 및 JSON log.
+- **제어된 전달** — 영속 비동기 Relay job은 불변 snapshot, 스트리밍 DATA,
+  명시적 TLS mode 및 상태 조회를 사용합니다.
+- **마이그레이션 경로** — 기본 비활성 MailDev 및 MailCatcher REST facade를
+  제공하지만 Socket.IO 또는 완전한 동등성을 주장하지 않습니다.
 
-- ✅ **SMTP Server** - Receives and stores all sent emails (default port 1025)
-- ✅ **Web Interface** - View and manage emails through a browser (default port 1080)
-- ✅ **Email Persistence** - Emails saved as `.eml` files, supports loading from directory
-- ✅ **Email Relay** - Supports forwarding emails to real SMTP servers
-- ✅ **Auto Relay** - Supports automatically forwarding all emails with rule filtering
-- ✅ **Webhook Forwarding** - Sends matching new emails to HTTP webhooks with custom message templates
-- ✅ **인바운드 SMTP 인증** - 필수 PLAIN/LOGIN 인증과 설정이 필요 없는 NO AUTH 테스트 모드 지원
-- ✅ **TLS/STARTTLS** - Supports encrypted connections
-- ✅ **SMTPS** - Supports direct TLS connection on port 465 when SMTP TLS is enabled
+- **로컬 도구** — 내장 `/webhooks` 편집기에서 규칙을 만들고 기존 프로그램은\n  [sendmail 가이드](./docs/ko/Sendmail.md)를 사용할 수 있습니다. 소스 및 브라우저\n  테스트는 Bun을 사용하지만 배포 바이너리에는 런타임이 필요하지 않습니다.\n\n## 🆕 OwlMail 0.8.0
 
-### Enhanced Features
+`v0.8.0`은 현재 안정 버전입니다. 영속 Relay job, 계층형 YAML/JSON 설정, 선택적
+SQLite index, Prometheus metrics, 구조화 log, MailCatcher REST facade, MCP
+stdio bridge, 확장된 Web inbox 및 더 엄격한 검증을 추가했습니다.
 
-- 🆕 **Batch Operations** - Batch delete, batch mark as read
-- 🆕 **브라우저 알림** - 새 이메일에 대한 선택적 실시간 알림
-- 🆕 **Email Statistics** - Get email statistics
-- 🆕 **Email Preview** - Lightweight email preview API
-- 🆕 **Email Export** - Export emails as ZIP files
-- 🆕 **Configuration Management API** - Complete configuration management (GET/PUT/PATCH)
-- 🆕 **Powerful Search** - Full-text search, date range filtering, sorting
-- 🆕 **Improved RESTful API** - More standardized API design (`/api/v1/*`)
-- 🆕 **내장 도움말** - 받은 편지함 또는 `/help`에서 여는 로컬 이중 언어 가이드
-- 🆕 **Webhook 구성 도구** - `/webhooks`에서 전달 규칙을 생성, 가져오기, 검증, 복사 및 다운로드하는 내장 로컬 편집기
-- 🆕 **sendmail 호환 CLI** - [`owlmail sendmail`](./docs/ko/Sendmail.md)은 PHP, Cron 및 기존 프로그램의 메일을 일반 SMTP 경계를 통해 전달
+아래 예제는 `ghcr.io/soulteary/owlmail:0.8.0`으로 고정됩니다.
+재현 가능한 CI에서는 전체 버전 또는
+`ghcr.io/soulteary/owlmail@sha256:<digest>`를 사용하세요.
+[0.8.0 릴리스 노트](./docs/en/Release-0.8.0.md)를 참고하세요.
 
-### Compatibility
-
-- ✅ **MailDev 스타일 워크플로 경로** - 일반적인 이메일, 릴레이, 설정 및 상태 확인 흐름
-- ✅ **선택된 MailDev 환경 변수 별칭** - 지원되는 `MAILDEV_*` 이름은 설정 표에 명시
-- ✅ **자동 릴레이 규칙** - MailDev 스타일 JSON allow/deny 규칙 지원
-- ⚠️ **문서화된 차이** - API 접두사, 페이로드, 읽음 상태 및 실시간 프로토콜이 동일하지 않음
-
-### 배포 특성
-
-- ⚡ **단일 바이너리** - UI와 도움말이 내장됨
-- ⚡ **언어 런타임 불필요** - 배포 바이너리는 Go, Bun 또는 Node.js가 필요하지 않음
-- ⚡ **명시적 동시성 제어** - Webhook 전달은 제한하거나 의도적으로 무제한 설정 가능
-
-저장소에는 재현 가능한 프로젝트 간 벤치마크가 없습니다. 실제 부하로 시작 시간,
-메모리 및 처리량을 측정하세요.
+> [!IMPORTANT]
+> OwlMail은 개발, 테스트, CI 및 신뢰할 수 있는 내부 네트워크용입니다. 공개 운영
+> MTA, exactly-once queue 또는 멀티 테넌트 이메일 서비스가 아닙니다.
 
 ## 🚀 Quick Start
 
@@ -699,4 +697,4 @@ If this project helps you, please give it a Star ⭐!
 
 ---
 
-**OwlMail** - MailDev 마이그레이션 경로가 문서화된 Go 이메일 개발·테스트 서버 🦉
+**OwlMail** — 개발, CI, 자동화 및 AI Agent를 위한 셀프 호스팅 이메일 테스트 게이트웨이. 🦉

--- a/README.ko.md
+++ b/README.ko.md
@@ -55,7 +55,11 @@ OwlMail은 애플리케이션 이메일이 실제 받은 편지함에 도착하�
 - **마이그레이션 경로** — 기본 비활성 MailDev 및 MailCatcher REST facade를
   제공하지만 Socket.IO 또는 완전한 동등성을 주장하지 않습니다.
 
-- **로컬 도구** — 내장 `/webhooks` 편집기에서 규칙을 만들고 기존 프로그램은\n  [sendmail 가이드](./docs/ko/Sendmail.md)를 사용할 수 있습니다. 소스 및 브라우저\n  테스트는 Bun을 사용하지만 배포 바이너리에는 런타임이 필요하지 않습니다.\n\n## 🆕 OwlMail 0.8.0
+- **로컬 도구** — 내장 `/webhooks` 편집기에서 규칙을 만들고 기존 프로그램은
+  [sendmail 가이드](./docs/ko/Sendmail.md)를 사용할 수 있습니다. 소스 및 브라우저
+  테스트는 Bun을 사용하지만 배포 바이너리에는 런타임이 필요하지 않습니다.
+
+## 🆕 OwlMail 0.8.0
 
 `v0.8.0`은 현재 안정 버전입니다. 영속 Relay job, 계층형 YAML/JSON 설정, 선택적
 SQLite index, Prometheus metrics, 구조화 log, MailCatcher REST facade, MCP

--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ fits each workflow:
 - **Migration paths** — Default-off MailDev and MailCatcher REST facades support
   selected existing workflows without claiming Socket.IO or exact equivalence.
 
-- **Local tooling** — Build Webhook rules in the embedded `/webhooks` editor and\n  use the [sendmail guide](./docs/en/Sendmail.md) for legacy programs. Source and\n  browser tests use Bun; the deployed binary needs no Go, Bun, or Node.js runtime.\n\n## 🆕 OwlMail 0.8.0
+- **Local tooling** — Build Webhook rules in the embedded `/webhooks` editor and
+  use the [sendmail guide](./docs/en/Sendmail.md) for legacy programs. Source and
+  browser tests use Bun; the deployed binary needs no Go, Bun, or Node.js runtime.
+
+## 🆕 OwlMail 0.8.0
 
 `v0.8.0` is the current stable release. It brings persistent Relay jobs, layered
 YAML/JSON configuration, optional SQLite indexing, Prometheus metrics, structured

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # OwlMail
 
-> 🦉 A Go mail development and testing server with MailDev-style workflow compatibility and OwlMail-specific APIs
+> 🦉 A self-hosted, AI-native email testing gateway for developers, CI pipelines, automation, and coding agents.
 
 [![Go Version](https://img.shields.io/badge/Go-1.27.0+-00ADD8?style=flat&logo=go)](https://go.dev/)
+[![Latest Release](https://img.shields.io/github/v/release/soulteary/owlmail)](https://github.com/soulteary/owlmail/releases)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![MailDev Workflows](https://img.shields.io/badge/MailDev-Workflow%20Compatibility-blue.svg)](./docs/en/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 [![Go Report Card](.github/goreportcard.svg)](.github/goreportcard-report.md)
@@ -13,11 +14,22 @@
 
 ---
 
-OwlMail is an SMTP server and web interface for development and testing
-environments. It supports common [MailDev](https://github.com/maildev/maildev)
-workflows while providing its own versioned API, native WebSocket protocol,
-webhooks, and browser notifications. Review the documented compatibility
-boundary before migrating API or Socket.IO clients.
+OwlMail captures application email before it reaches a real inbox and turns it
+into deterministic, inspectable test data. Developers can review messages in
+the Web UI, test suites can use the versioned REST API and OpenAPI contract,
+automation systems can consume durable events, and AI agents can wait for and
+inspect delivery through a bounded, read-only MCP interface.
+
+Capture once, then verify the same committed message through the interface that
+fits each workflow:
+
+| Consumer | Interface | Typical workflow |
+|---|---|---|
+| Developers | Web UI and browser notifications | Inspect HTML, text, headers, source, links, and attachments |
+| Test suites and CI | REST API, OpenAPI 3.1, and WebSocket | Verify registration, password-reset, and notification mail |
+| Automation | Signed Webhooks and optional Redis Streams | Convert committed email into restart-safe downstream events |
+| AI coding agents | Read-only MCP over Streamable HTTP or stdio | Search, retrieve, and wait for email without destructive access |
+| SMTP operators | Manual and automatic Relay | Forward selected test mail under explicit TLS and retry policies |
 
 ![](.github/assets/owlmail-banner.jpg)
 
@@ -29,51 +41,42 @@ boundary before migrating API or Socket.IO clients.
 
 ![Demo Video](.github/assets/realtime.gif)
 
-## ✨ Features
+## ✨ Why OwlMail
 
-### Core Features
+- **Deterministic capture** — EML, metadata, and attachments are staged before
+  one atomic commit makes a message visible to APIs and event consumers.
+- **Integration-test ready** — Versioned `/api/v1` routes, OpenAPI 3.1, native
+  WebSocket events, health/readiness probes, search, filtering, and exports.
+- **AI-native, not AI-dependent** — The default-off MCP service exposes seven
+  closed-world read-only tools, bounded resources, prompts, and event-driven
+  `wait_for_email`; OwlMail itself does not require an LLM.
+- **Durable automation** — Local Webhook outbox, optional Redis Streams, HMAC
+  signatures, stable delivery IDs, retry limits, and graceful drain.
+- **Operationally explicit** — SMTP capacity limits, persistence, optional S3
+  attachments, SQLite indexing, Prometheus metrics, JSON logs, and recovery.
+- **Controlled delivery** — Persistent asynchronous Relay jobs use immutable
+  configuration snapshots, streaming DATA, explicit TLS modes, and status lookup.
+- **Migration paths** — Default-off MailDev and MailCatcher REST facades support
+  selected existing workflows without claiming Socket.IO or exact equivalence.
 
-- ✅ **SMTP Server** - Receives and stores all sent emails (default port 1025)
-- ✅ **Web Interface** - View and manage emails through a browser (default port 1080)
-- ✅ **Email Persistence** - Emails saved as `.eml` files, supports loading from directory
-- ✅ **S3-compatible Attachments** - Optional object storage for decoded attachments; local storage remains the default
-- ✅ **Email Relay** - Supports forwarding emails to real SMTP servers
-- ✅ **Auto Relay** - Supports automatically forwarding all emails with rule filtering
-- ✅ **Webhook Forwarding** - Sends matching new emails to generic HTTP webhooks with custom payload templates
-- ✅ **Inbound SMTP Authentication** - Required PLAIN/LOGIN authentication with a zero-config NO AUTH mode for testing
-- ✅ **TLS/STARTTLS** - Supports encrypted connections
-- ✅ **SMTPS** - Supports direct TLS connection on port 465 when SMTP TLS is enabled
+- **Local tooling** — Build Webhook rules in the embedded `/webhooks` editor and\n  use the [sendmail guide](./docs/en/Sendmail.md) for legacy programs. Source and\n  browser tests use Bun; the deployed binary needs no Go, Bun, or Node.js runtime.\n\n## 🆕 OwlMail 0.8.0
 
-### Enhanced Features
+`v0.8.0` is the current stable release. It brings persistent Relay jobs, layered
+YAML/JSON configuration, optional SQLite indexing, Prometheus metrics, structured
+logging, the MailCatcher REST facade, the MCP stdio bridge, expanded Web inbox
+navigation, stricter API validation, SMTP capacity controls, and hardened
+attachment downloads.
 
-- 🆕 **Batch Operations** - Batch delete, batch mark as read
-- 🆕 **Browser Notifications** - Optional live notifications for newly received email
-- 🆕 **Email Statistics** - Get email statistics
-- 🆕 **Email Preview** - Lightweight email preview API
-- 🆕 **Email Export** - Export emails as ZIP files
-- 🆕 **Configuration Management API** - Complete configuration management (GET/PUT/PATCH)
-- 🆕 **Powerful Search** - Full-text search, date range filtering, sorting
-- 🆕 **Improved RESTful API** - More standardized API design (`/api/v1/*`)
-- 🆕 **Built-in Help** - Local bilingual guide available from the inbox or at `/help`
-- 🆕 **Webhook Configurator** - Embedded local editor at `/webhooks` for building, importing, validating, copying, and downloading forwarding rules
-- 🆕 **Sendmail-compatible CLI** - [`owlmail sendmail`](./docs/en/Sendmail.md) lets PHP, cron, and legacy programs submit through the normal SMTP security and capacity boundary
+All installation examples below pin `ghcr.io/soulteary/owlmail:0.8.0`.
+For repeatable CI and production-like test environments, prefer the exact
+version or `ghcr.io/soulteary/owlmail@sha256:<digest>` over moving tags.
+See [the 0.8.0 release notes](./docs/en/Release-0.8.0.md) and
+[CHANGELOG.md](./CHANGELOG.md) for the complete contract.
 
-### Compatibility
-
-- ✅ **MailDev-style Workflow Routes** - Common email, relay, configuration, and health workflows have OwlMail routes
-- ✅ **Selected MailDev Environment Aliases** - Supported `MAILDEV_*` names are listed in the configuration table
-- ✅ **Auto Relay Rules** - Supports MailDev-style JSON allow/deny rules
-- ⚠️ **Documented Differences** - API prefixes and payloads, read side effects, and live-event protocols are not identical
-
-### Deployment Characteristics
-
-- ⚡ **Single Binary** - Compiled executable with the UI and help assets embedded
-- ⚡ **No Language Runtime** - The deployed binary does not require Go, Bun, or Node.js
-- ⚡ **Explicit Concurrency Controls** - Webhook delivery can be bounded or intentionally unlimited
-
-The repository does not publish a reproducible cross-project benchmark. Measure
-startup, memory, and throughput with your own mail volume, storage, TLS, and
-webhook targets before making capacity claims.
+> [!IMPORTANT]
+> OwlMail is built for development, testing, CI, and trusted internal networks.
+> It is not a public production MTA, an exactly-once queue, or a multi-tenant
+> mail service.
 
 ## 🚀 Quick Start
 
@@ -837,4 +840,4 @@ If this project helps you, please give it a Star ⭐!
 
 ---
 
-**OwlMail** - A Go mail development and testing server with documented MailDev migration paths 🦉
+**OwlMail** — one self-hosted email test gateway for developers, CI, automation, and AI agents. 🦉

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,8 +1,9 @@
 # OwlMail
 
-> 🦉 一个用 Go 实现的邮件开发测试服务，支持常见 MailDev 工作流并提供 OwlMail 专属 API
+> 🦉 面向开发者、CI 流水线、自动化系统与 AI Agent 的自托管 AI 原生邮件测试网关。
 
 [![Go Version](https://img.shields.io/badge/Go-1.27.0+-00ADD8?style=flat&logo=go)](https://go.dev/)
+[![Latest Release](https://img.shields.io/github/v/release/soulteary/owlmail)](https://github.com/soulteary/owlmail/releases)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![MailDev Workflows](https://img.shields.io/badge/MailDev-Workflow%20Compatibility-blue.svg)](./docs/zh-CN/OwlMail%20×%20MailDev%20-%20Full%20Feature%20&%20API%20Comparison%20and%20Migration%20White%20Paper.md)
 [![Go Report Card](.github/goreportcard.svg)](.github/goreportcard-report.md)
@@ -13,10 +14,20 @@
 
 ---
 
-OwlMail 是面向开发和测试环境的 SMTP 服务器与 Web 界面，支持常见
-[MailDev](https://github.com/maildev/maildev) 工作流，并提供自己的版本化 API、
-原生 WebSocket、Webhook 和浏览器通知。迁移 API 或 Socket.IO 客户端前，请先
-核对文档中的兼容边界。
+OwlMail 在应用邮件进入真实邮箱前将其捕获，并转换为确定、可检查的测试数据。
+开发者可以通过 Web UI 查看邮件，测试套件可以使用版本化 REST API 和 OpenAPI
+合约，自动化系统可以消费持久事件，AI Agent 则可以通过有明确边界的只读 MCP
+等待并检查邮件投递。
+
+只需捕获一次，即可通过适合不同工作流的接口验证同一封已完整提交的邮件：
+
+| 使用者 | 接口 | 典型工作流 |
+|---|---|---|
+| 开发者 | Web UI、浏览器通知 | 检查 HTML、纯文本、Header、源码、链接与附件 |
+| 测试套件与 CI | REST API、OpenAPI 3.1、WebSocket | 验证注册、密码重置和通知邮件 |
+| 自动化系统 | 签名 Webhook、可选 Redis Streams | 将已提交邮件转换为可跨重启恢复的下游事件 |
+| AI 编码 Agent | 基于 Streamable HTTP 或 stdio 的只读 MCP | 搜索、获取和等待邮件，不开放破坏性操作 |
+| SMTP 运维方 | 手动与自动 Relay | 按明确的 TLS 与重试策略转发选定测试邮件 |
 
 ![](.github/assets/owlmail-banner.jpg)
 
@@ -28,50 +39,39 @@ OwlMail 是面向开发和测试环境的 SMTP 服务器与 Web 界面，支持�
 
 ![演示视频](.github/assets/realtime.gif)
 
-## ✨ 特性
+## ✨ 为什么选择 OwlMail
 
-### 核心功能
+- **确定性捕获** —— EML、元数据和附件先进入 staging，原子提交后才会对 API
+  与事件消费者可见。
+- **面向集成测试** —— 提供版本化 `/api/v1`、OpenAPI 3.1、原生 WebSocket、
+  健康与就绪检查、搜索、过滤及导出。
+- **AI 原生但不依赖 AI** —— 默认关闭的 MCP 提供七个封闭集合的只读工具、
+  有界 Resources、Prompts 和事件驱动的 `wait_for_email`；运行 OwlMail 不需要 LLM。
+- **持久化自动化** —— 本地 Webhook outbox、可选 Redis Streams、HMAC 签名、
+  稳定投递 ID、有限重试和优雅排空。
+- **明确的运维边界** —— SMTP 容量限制、持久化、可选 S3 附件、SQLite 索引、
+  Prometheus Metrics、JSON 日志与故障恢复。
+- **受控投递** —— 持久化异步 Relay 任务使用不可变配置快照、流式 DATA、
+  明确 TLS 模式与状态查询。
+- **清晰迁移路径** —— 默认关闭的 MailDev 与 MailCatcher REST facade 支持
+  部分现有工作流，但不宣称 Socket.IO 或完全等价兼容。
 
-- ✅ **SMTP 服务器** - 接收和存储所有发送的邮件（默认端口 1025）
-- ✅ **Web 界面** - 通过浏览器查看和管理邮件（默认端口 1080）
-- ✅ **邮件持久化** - 邮件保存为 `.eml` 文件，支持从目录加载
-- ✅ **S3 兼容附件存储** - 可选使用对象存储保存解析后的附件，默认仍为本地存储
-- ✅ **邮件转发** - 支持将邮件转发到真实的 SMTP 服务器
-- ✅ **自动中继** - 支持自动转发所有邮件，带规则过滤
-- ✅ **Webhook 消息转发** - 按规则把新邮件转换为自定义消息并发送到通用 HTTP Webhook
-- ✅ **入站 SMTP 认证** - 支持强制 PLAIN/LOGIN 认证，并保留零配置的 NO AUTH 测试模式
-- ✅ **TLS/STARTTLS** - 支持加密连接
-- ✅ **SMTPS** - 启用 SMTP TLS 时支持端口 465 的直接 TLS 连接
+- **本地工具** —— 使用内嵌的 `/webhooks` 编辑器生成 Webhook 规则，并通过\n  [sendmail 指南](./docs/zh-CN/Sendmail.md)接入传统程序。源码和浏览器测试使用 Bun；\n  部署后的二进制不需要 Go、Bun 或 Node.js 运行时。\n\n## 🆕 OwlMail 0.8.0
 
-### 增强功能
+`v0.8.0` 是当前稳定版本，新增持久化 Relay 任务、分层 YAML/JSON 配置、可选
+SQLite 索引、Prometheus Metrics、结构化日志、MailCatcher REST facade、MCP
+stdio 桥接、更完整的 Web 收件箱导航、更严格的 API 校验、SMTP 容量控制及附件
+下载安全加固。
 
-- 🆕 **批量操作** - 批量删除、批量标记已读
-- 🆕 **浏览器通知** - 可按需开启新邮件实时通知
-- 🆕 **邮件统计** - 获取邮件统计信息
-- 🆕 **邮件预览** - 轻量级邮件预览 API
-- 🆕 **邮件导出** - 导出邮件为 ZIP 文件
-- 🆕 **配置管理 API** - 完整的配置管理（GET/PUT/PATCH）
-- 🆕 **强大的搜索** - 全文搜索、日期范围过滤、排序
-- 🆕 **改进的 RESTful API** - 更规范的 API 设计（`/api/v1/*`）
-- 🆕 **内置帮助** - 可从收件箱或 `/help` 打开本地中英文指南
-- 🆕 **Webhook 配置器** - 在 `/webhooks` 使用内置本地编辑器生成、导入、校验、复制和下载转发规则
-- 🆕 **Sendmail 兼容 CLI** - [`owlmail sendmail`](./docs/zh-CN/Sendmail.md) 让 PHP、Cron 和传统程序通过正常 SMTP 安全与容量边界投递
+以下安装示例统一固定为 `ghcr.io/soulteary/owlmail:0.8.0`。需要可重复的 CI
+或接近生产的测试环境时，应使用完整版本号或
+`ghcr.io/soulteary/owlmail@sha256:<digest>`，不要依赖移动标签。
+完整内容参阅 [0.8.0 发布说明](./docs/zh-CN/Release-0.8.0.md)和
+[CHANGELOG.md](./CHANGELOG.md)。
 
-### 兼容性
-
-- ✅ **MailDev 风格工作流路由** - 覆盖常用邮件、转发、配置与健康检查流程
-- ✅ **部分 MailDev 环境变量别名** - 支持范围以配置表中的 `MAILDEV_*` 为准
-- ✅ **自动中继规则** - 支持 MailDev 风格 JSON allow/deny 规则
-- ⚠️ **明确记录差异** - API 前缀与载荷、已读副作用、实时协议并不相同
-
-### 部署特性
-
-- ⚡ **单一二进制** - UI 与帮助资源均内嵌到可执行文件
-- ⚡ **无需语言运行时** - 部署后的二进制不依赖 Go、Bun 或 Node.js
-- ⚡ **明确的并发控制** - Webhook 投递可设置上限，也可显式使用无限并发
-
-仓库目前没有发布可复现的跨项目基准。请按实际邮件量、存储、TLS 和 Webhook
-目标测量启动时间、内存与吞吐，不应直接把实现语言当作容量结论。
+> [!IMPORTANT]
+> OwlMail 面向开发、测试、CI 与可信内部网络，不是公网生产 MTA、
+> exactly-once 消息队列或多租户邮件服务。
 
 ## 🚀 快速开始
 
@@ -800,4 +800,4 @@ OwlMail/
 
 ---
 
-**OwlMail** - 用 Go 实现、提供明确 MailDev 迁移路径的邮件开发测试服务 🦉
+**OwlMail** —— 为开发者、CI、自动化系统与 AI Agent 提供统一的自托管邮件测试网关。🦉

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -56,7 +56,11 @@ OwlMail 在应用邮件进入真实邮箱前将其捕获，并转换为确定、
 - **清晰迁移路径** —— 默认关闭的 MailDev 与 MailCatcher REST facade 支持
   部分现有工作流，但不宣称 Socket.IO 或完全等价兼容。
 
-- **本地工具** —— 使用内嵌的 `/webhooks` 编辑器生成 Webhook 规则，并通过\n  [sendmail 指南](./docs/zh-CN/Sendmail.md)接入传统程序。源码和浏览器测试使用 Bun；\n  部署后的二进制不需要 Go、Bun 或 Node.js 运行时。\n\n## 🆕 OwlMail 0.8.0
+- **本地工具** —— 使用内嵌的 `/webhooks` 编辑器生成 Webhook 规则，并通过
+  [sendmail 指南](./docs/zh-CN/Sendmail.md)接入传统程序。源码和浏览器测试使用 Bun；
+  部署后的二进制不需要 Go、Bun 或 Node.js 运行时。
+
+## 🆕 OwlMail 0.8.0
 
 `v0.8.0` 是当前稳定版本，新增持久化 Relay 任务、分层 YAML/JSON 配置、可选
 SQLite 索引、Prometheus Metrics、结构化日志、MailCatcher REST facade、MCP


### PR DESCRIPTION
## Summary

- reposition OwlMail as a self-hosted, AI-native email testing gateway for developers, CI pipelines, automation systems, and coding agents
- describe the human, test-suite, event-automation, MCP, and SMTP Relay workflows before the detailed feature reference
- use the published `v0.8.0` release and `ghcr.io/soulteary/owlmail:0.8.0` consistently, with digest pinning guidance for reproducible CI
- update English, Simplified Chinese, German, French, Italian, Japanese, and Korean README introductions and closing descriptions
- keep MailDev and MailCatcher compatibility as migration paths rather than the project's primary identity
- explicitly retain the trusted-network boundary: OwlMail is not a public production MTA, exactly-once queue, or multi-tenant mail service

## Validation

- the commit changes only the seven root README files
- every locale retains all 71 configuration-table rows required by the documentation contract
- every locale retains the required OpenAPI, Sendmail, Webhook configurator, Bun runtime-boundary, NO AUTH, and 0.8.0 release markers
- Markdown code fences remain balanced
- localized release links resolve to the available English or Simplified Chinese 0.8.0 release notes

## Release context

This documentation targets the published OwlMail 0.8.0 feature set, including persistent Relay jobs, layered YAML/JSON configuration, optional SQLite indexing, Prometheus metrics, structured logging, the MailCatcher REST facade, MCP stdio, expanded inbox navigation, stricter API validation, SMTP capacity controls, and hardened attachment downloads.