### PR TITLE
fix(testing): report Go integration cleanup failures

### DIFF
--- a/examples/testing/go/email_test.go
+++ b/examples/testing/go/email_test.go
@@ -2,7 +2,9 @@ package testingexample
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/smtp"
@@ -82,6 +84,30 @@ func sendSMTPMessage(address, from string, recipients []string, message []byte, 
 	return nil
 }
 
+func deleteEmail(client *http.Client, messageURL string) (err error) {
+	request, err := http.NewRequest(http.MethodDelete, messageURL, nil)
+	if err != nil {
+		return fmt.Errorf("create cleanup request: %w", err)
+	}
+	cleanupClient := *client
+	cleanupClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	response, err := cleanupClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("delete email: %w", err)
+	}
+	defer func() {
+		if closeErr := response.Body.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close cleanup response: %w", closeErr))
+		}
+	}()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("delete email: unexpected status %d", response.StatusCode)
+	}
+	return nil
+}
+
 func TestCapturedEmail(t *testing.T) {
 	if os.Getenv("OWLMAIL_RUN_INTEGRATION_TEST") != "1" {
 		t.Skip("set OWLMAIL_RUN_INTEGRATION_TEST=1 to run against a live OwlMail instance")
@@ -148,11 +174,8 @@ func TestCapturedEmail(t *testing.T) {
 
 	messageURL := apiBase + "/api/v1/emails/" + url.PathEscape(id)
 	t.Cleanup(func() {
-		request, _ := http.NewRequest(http.MethodDelete, messageURL, nil)
-		if response, err := client.Do(request); err == nil {
-			if closeErr := response.Body.Close(); closeErr != nil {
-				t.Errorf("close cleanup response: %v", closeErr)
-			}
+		if err := deleteEmail(client, messageURL); err != nil {
+			t.Errorf("cleanup captured email: %v", err)
 		}
 	})
 	response, err := client.Get(messageURL)
@@ -186,6 +209,99 @@ func TestSMTPAddressSupportsHostnamesAndIPAddresses(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			if got := joinSMTPAddress(test.host, "1025"); got != test.want {
 				t.Fatalf("joinSMTPAddress(%q, %q) = %q, want %q", test.host, "1025", got, test.want)
+			}
+		})
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
+type closeErrorBody struct{}
+
+func (closeErrorBody) Read([]byte) (int, error) { return 0, io.EOF }
+func (closeErrorBody) Close() error             { return errors.New("close failed") }
+
+func TestDeleteEmailReportsCleanupFailures(t *testing.T) {
+	tests := map[string]struct {
+		messageURL string
+		transport  roundTripFunc
+		wantError  string
+	}{
+		"invalid URL": {
+			messageURL: "://invalid",
+			wantError:  "create cleanup request",
+		},
+		"transport failure": {
+			messageURL: "http://owlmail.test/api/v1/emails/id",
+			transport: func(*http.Request) (*http.Response, error) {
+				return nil, errors.New("connection lost")
+			},
+			wantError: "connection lost",
+		},
+		"non-success status": {
+			messageURL: "http://owlmail.test/api/v1/emails/id",
+			transport: func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Body:       io.NopCloser(strings.NewReader("")),
+				}, nil
+			},
+			wantError: "unexpected status 500",
+		},
+		"redirect": {
+			messageURL: "http://owlmail.test/api/v1/emails/id",
+			transport: func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusFound,
+					Header:     http.Header{"Location": []string{"/login"}},
+					Body:       io.NopCloser(strings.NewReader("")),
+				}, nil
+			},
+			wantError: "unexpected status 302",
+		},
+		"response close failure": {
+			messageURL: "http://owlmail.test/api/v1/emails/id",
+			transport: func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNoContent,
+					Body:       closeErrorBody{},
+				}, nil
+			},
+			wantError: "close cleanup response: close failed",
+		},
+		"success": {
+			messageURL: "http://owlmail.test/api/v1/emails/id",
+			transport: func(request *http.Request) (*http.Response, error) {
+				if request.Method != http.MethodDelete {
+					return nil, fmt.Errorf("method = %s", request.Method)
+				}
+				return &http.Response{
+					StatusCode: http.StatusNoContent,
+					Body:       io.NopCloser(strings.NewReader("")),
+				}, nil
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := &http.Client{}
+			if test.transport != nil {
+				client.Transport = test.transport
+			}
+			err := deleteEmail(client, test.messageURL)
+			if test.wantError == "" {
+				if err != nil {
+					t.Fatalf("deleteEmail() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("deleteEmail() error = %v, want substring %q", err, test.wantError)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- move captured-email deletion into an error-returning helper
- report request construction, transport, non-2xx response, and body-close failures
- keep cleanup registered with `t.Cleanup` so it runs after assertion failures
- add focused tests for every cleanup outcome

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- integration example against the published OwlMail 0.8.0 binary