### PR TITLE
docs(mcp): document optional prompt inputs

### DIFF
--- a/docs/en/MCP-Reference.md
+++ b/docs/en/MCP-Reference.md
@@ -43,11 +43,16 @@ is larger. The result includes `returned_bytes`, full `size`, and `truncated`.
 
 ## Prompts
 
-| Prompt | Required input | Purpose |
-|---|---|---|
-| `registration_verification_email` | `recipient` | Wait, inspect, and extract a verification value without mutation |
-| `password_reset_email` | `recipient` | Wait, inspect, and extract a reset value without mutation |
-| `wait_for_delivery` | none | Wait for an optional recipient, subject, or text match |
+| Prompt | Required input | Optional input | Purpose |
+|---|---|---|---|
+| `registration_verification_email` | `recipient` | `subject`, `timeout_seconds` | Wait, inspect, and extract a verification value without mutation |
+| `password_reset_email` | `recipient` | `subject`, `timeout_seconds` | Wait, inspect, and extract a reset value without mutation |
+| `wait_for_delivery` | none | `recipient`, `subject`, `text`, `timeout_seconds` | Wait for an optional recipient, subject, or text match |
+
+`subject` and `text` are substring matches. `timeout_seconds` must be an integer
+from 1 through the effective service maximum, which is the smaller of the
+configured wait timeout and MCP session timeout. When it is omitted, the prompt
+uses the smaller of 30 seconds and that effective maximum.
 
 All prompts compose the read-only tools. They do not grant capabilities beyond
 the tool list.

--- a/docs/zh-CN/MCP-Reference.md
+++ b/docs/zh-CN/MCP-Reference.md
@@ -42,11 +42,15 @@ HTTP 会话在 `-mcp-session-timeout` 后过期，默认 `30m`；关闭最多等
 
 ## Prompts
 
-| Prompt | 必填输入 | 用途 |
-|---|---|---|
-| `registration_verification_email` | `recipient` | 等待、检查并提取验证值，不修改邮件 |
-| `password_reset_email` | `recipient` | 等待、检查并提取重置值，不修改邮件 |
-| `wait_for_delivery` | 无 | 按可选收件人、主题或文本等待投递 |
+| Prompt | 必填输入 | 可选输入 | 用途 |
+|---|---|---|---|
+| `registration_verification_email` | `recipient` | `subject`、`timeout_seconds` | 等待、检查并提取验证值，不修改邮件 |
+| `password_reset_email` | `recipient` | `subject`、`timeout_seconds` | 等待、检查并提取重置值，不修改邮件 |
+| `wait_for_delivery` | 无 | `recipient`、`subject`、`text`、`timeout_seconds` | 按可选收件人、主题或文本等待投递 |
+
+`subject` 与 `text` 使用子串匹配。`timeout_seconds` 必须是 1 到服务有效上限之间的
+整数；有效上限取配置的等待超时与 MCP 会话超时中的较小值。省略时，Prompt 使用
+30 秒与该有效上限中的较小值。
 
 所有 Prompt 只组合上述只读工具，不会增加权限。
 


### PR DESCRIPTION
## Summary

- distinguish required and optional inputs for every built-in MCP prompt
- document `subject`, `text`, and `timeout_seconds` where supported by the implementation
- explain substring matching and the effective timeout bound
- keep the English and Simplified Chinese references synchronized

## Validation

- documentation tests: 16 passed
- `git diff --check`