### PR TITLE
fix(testing): clean up Python example failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
 
+      - name: Test Python integration example helpers
+        run: python3 -m unittest examples.testing.python.email_cleanup_test
+
       - name: Build coverage report
         run: |
           go tool cover -html=coverage.out -o coverage.html

--- a/examples/testing/python/email_cleanup_test.py
+++ b/examples/testing/python/email_cleanup_test.py
@@ -1,0 +1,64 @@
+import io
+import json
+import types
+import unittest
+from unittest import mock
+
+from examples.testing.python import email_test as example
+
+
+class Response(io.StringIO):
+    def __init__(self, body="", status=200):
+        super().__init__(body)
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+
+class SMTPClient:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return None
+
+    def send_message(self, message):
+        return None
+
+
+class CleanupTest(unittest.TestCase):
+    def test_cleanup_runs_after_an_assertion_failure(self):
+        requests = []
+
+        def urlopen(request, timeout):
+            requests.append(request)
+            if hasattr(request, "get_method") and request.get_method() == "DELETE":
+                return Response(status=204)
+            if str(request).endswith("/api/v1/emails/captured-id"):
+                return Response(json.dumps({"subject": "wrong subject", "text": ""}))
+            return Response(json.dumps({
+                "emails": [{"id": "captured-id", "subject": "OwlMail integration run"}],
+            }))
+
+        result = unittest.TestResult()
+        case = example.OwlMailIntegrationTest("test_captured_email")
+        with (
+            mock.patch("examples.testing.python.email_test.smtplib.SMTP", return_value=SMTPClient()),
+            mock.patch("examples.testing.python.email_test.urllib.request.urlopen", side_effect=urlopen),
+            mock.patch("examples.testing.python.email_test.uuid.uuid4", return_value=types.SimpleNamespace(hex="run")),
+        ):
+            case.run(result)
+
+        self.assertEqual(len(result.failures), 1)
+        self.assertTrue(
+            any(hasattr(request, "get_method") and request.get_method() == "DELETE" for request in requests),
+            "cleanup DELETE was not attempted after the assertion failure",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/testing/python/email_test.py
+++ b/examples/testing/python/email_test.py
@@ -9,6 +9,15 @@ import uuid
 from email.message import EmailMessage
 
 
+def delete_email(api_base, email_id):
+    cleanup = urllib.request.Request(
+        f"{api_base}/api/v1/emails/{email_id}", method="DELETE"
+    )
+    with urllib.request.urlopen(cleanup, timeout=5) as response:
+        if response.status >= 300:
+            raise RuntimeError(f"cleanup failed with HTTP status {response.status}")
+
+
 class OwlMailIntegrationTest(unittest.TestCase):
     def test_captured_email(self):
         smtp_host = os.getenv("TEST_SMTP_HOST", "127.0.0.1")
@@ -44,18 +53,13 @@ class OwlMailIntegrationTest(unittest.TestCase):
         self.assertIsNotNone(found, f"timed out waiting for {recipient}")
 
         email_id = urllib.parse.quote(found["id"], safe="")
+        self.addCleanup(delete_email, api_base, email_id)
         with urllib.request.urlopen(
             f"{api_base}/api/v1/emails/{email_id}", timeout=5
         ) as response:
             detail = json.load(response)
         self.assertEqual(detail["subject"], subject)
         self.assertIn(token, detail["text"])
-
-        cleanup = urllib.request.Request(
-            f"{api_base}/api/v1/emails/{email_id}", method="DELETE"
-        )
-        with urllib.request.urlopen(cleanup, timeout=5) as response:
-            self.assertLess(response.status, 300)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- register per-message deletion with `unittest.TestCase.addCleanup` immediately after resolving the captured ID
- keep cleanup active when detail retrieval or content assertions fail
- add a failure-path test that verifies DELETE is attempted after an assertion failure
- run the Python helper test in CI

## Validation

- `python3 -m unittest examples.testing.python.email_cleanup_test`
- `python3 -m py_compile examples/testing/python/email_test.py examples/testing/python/email_cleanup_test.py`
- `go test -race ./...`
- integration example against the published OwlMail 0.8.0 binary