### PR TITLE
ci: skip builds for Go Report Card badge commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,11 +6,13 @@ on:
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
+      - '.github/goreportcard.svg'
   pull_request:
     branches: [ main ]
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
+      - '.github/goreportcard.svg'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
+      - '.github/goreportcard.svg'
   workflow_dispatch:
 
 concurrency:

--- a/tests/docs/workflow-paths.test.js
+++ b/tests/docs/workflow-paths.test.js
@@ -1,0 +1,30 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("bun:test");
+
+const root = path.resolve(__dirname, "../..");
+
+function triggerBlock(workflow, event, nextEvent) {
+  const start = workflow.indexOf(`  ${event}:`);
+  assert.notEqual(start, -1, `missing ${event} trigger`);
+  const end = nextEvent === undefined ? workflow.length : workflow.indexOf(`  ${nextEvent}:`, start + 1);
+  return workflow.slice(start, end === -1 ? workflow.length : end);
+}
+
+test("badge-only commits do not rebuild binaries or container images", () => {
+  const build = fs.readFileSync(path.join(root, ".github/workflows/build.yml"), "utf8");
+  const docker = fs.readFileSync(path.join(root, ".github/workflows/docker.yml"), "utf8");
+
+  for (const [name, workflow] of [["Build", build], ["Docker", docker]]) {
+    const push = triggerBlock(workflow, "push", name === "Build" ? "pull_request" : "workflow_dispatch");
+    assert.match(
+      push,
+      /^\s+- ['"]?\.github\/goreportcard\.svg['"]?$/m,
+      `${name} push trigger does not ignore the generated badge`,
+    );
+  }
+
+  const pullRequest = triggerBlock(build, "pull_request", "workflow_dispatch");
+  assert.match(pullRequest, /^\s+- ['"]?\.github\/goreportcard\.svg['"]?$/m);
+});


### PR DESCRIPTION
## Summary

- exclude `.github/goreportcard.svg` from binary snapshot builds
- exclude the generated badge from container image builds and pushes
- retain normal CI and CodeQL verification for badge commits
- add workflow-trigger regression coverage

This prevents a changed grade badge from rebuilding identical binaries and replacing `main`/`latest` container images with a badge-only revision.

## Validation

- documentation/workflow tests: 17 passed
- `git diff --check`