### PR TITLE
fix(testing): preserve JavaScript verification errors

### DIFF
--- a/examples/testing/javascript/cleanup.mjs
+++ b/examples/testing/javascript/cleanup.mjs
@@ -1,0 +1,22 @@
+export async function withCleanup(operation, cleanup) {
+  let primaryError;
+  try {
+    return await operation();
+  } catch (error) {
+    primaryError = error;
+    throw error;
+  } finally {
+    try {
+      await cleanup();
+    } catch (cleanupError) {
+      if (primaryError) {
+        throw new AggregateError(
+          [primaryError, cleanupError],
+          "email verification and cleanup both failed",
+          { cause: primaryError },
+        );
+      }
+      throw cleanupError;
+    }
+  }
+}

--- a/examples/testing/javascript/email-test.mjs
+++ b/examples/testing/javascript/email-test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import net from "node:net";
+import { withCleanup } from "./cleanup.mjs";
 
 const smtpHost = process.env.TEST_SMTP_HOST || "127.0.0.1";
 const smtpPort = Number(process.env.TEST_SMTP_PORT || "1025");
@@ -140,13 +141,16 @@ async function waitForMessage() {
 await sendMessage();
 const summary = await waitForMessage();
 const messagePath = `/api/v1/emails/${encodeURIComponent(summary.id)}`;
-try {
-  const { response: detailResponse, body: detail } = await requestJSON(messagePath);
-  assert.equal(detailResponse.ok, true, `detail failed: ${detailResponse.status}`);
-  assert.equal(detail.subject, subject);
-  assert.match(detail.text, new RegExp(token));
-  console.log(`verified OwlMail message ${summary.id}`);
-} finally {
-  const deleteResponse = await requestStatus(messagePath, { method: "DELETE" });
-  assert.equal(deleteResponse.ok, true, `cleanup failed: ${deleteResponse.status}`);
-}
+await withCleanup(
+  async () => {
+    const { response: detailResponse, body: detail } = await requestJSON(messagePath);
+    assert.equal(detailResponse.ok, true, `detail failed: ${detailResponse.status}`);
+    assert.equal(detail.subject, subject);
+    assert.match(detail.text, new RegExp(token));
+    console.log(`verified OwlMail message ${summary.id}`);
+  },
+  async () => {
+    const deleteResponse = await requestStatus(messagePath, { method: "DELETE" });
+    assert.equal(deleteResponse.ok, true, `cleanup failed: ${deleteResponse.status}`);
+  },
+);

--- a/tests/docs/integration-example-cleanup.test.js
+++ b/tests/docs/integration-example-cleanup.test.js
@@ -1,0 +1,37 @@
+const assert = require("node:assert/strict");
+const { test } = require("bun:test");
+
+test("JavaScript integration cleanup preserves the primary error", async () => {
+  const { withCleanup } = await import("../../examples/testing/javascript/cleanup.mjs");
+  const primaryError = new Error("verification failed");
+  const cleanupError = new Error("cleanup failed");
+
+  await assert.rejects(
+    withCleanup(
+      async () => {
+        throw primaryError;
+      },
+      async () => {
+        throw cleanupError;
+      },
+    ),
+    (error) => {
+      assert.ok(error instanceof AggregateError);
+      assert.equal(error.cause, primaryError);
+      assert.deepEqual(error.errors, [primaryError, cleanupError]);
+      return true;
+    },
+  );
+});
+
+test("JavaScript integration cleanup still reports a cleanup-only error", async () => {
+  const { withCleanup } = await import("../../examples/testing/javascript/cleanup.mjs");
+  const cleanupError = new Error("cleanup failed");
+
+  await assert.rejects(
+    withCleanup(async () => "verified", async () => {
+      throw cleanupError;
+    }),
+    cleanupError,
+  );
+});


### PR DESCRIPTION
## Summary

- isolate the integration example's cleanup orchestration in a small reusable helper
- preserve both the verification error and cleanup error with `AggregateError`
- continue reporting cleanup-only failures directly
- add tests for combined and cleanup-only failure paths

## Validation

- `node --check examples/testing/javascript/email-test.mjs`
- `node --check examples/testing/javascript/cleanup.mjs`
- documentation/example tests: 18 passed
- integration example against the published OwlMail 0.8.0 binary