### PR TITLE
fix(testing): make integration example cleanup reliable

### DIFF
--- a/examples/testing/README.md
+++ b/examples/testing/README.md
@@ -41,6 +41,9 @@ node examples/testing/javascript/email-test.mjs
 
 The examples intentionally avoid clearing the mailbox. Each creates a unique
 recipient, filters by the complete address, and removes only the returned ID.
+If SMTP accepted the message but polling failed before returning its ID,
+cleanup searches again using that unique recipient and exact subject rather
+than deleting unrelated messages.
 See [Integration testing](../../docs/en/Integration-Testing.md) and the
 [testing recipes](../../docs/en/Testing-Recipes.md) for production test-suite
 patterns.

--- a/examples/testing/README.zh-CN.md
+++ b/examples/testing/README.zh-CN.md
@@ -38,6 +38,8 @@ node examples/testing/javascript/email-test.mjs
 ```
 
 示例不会清空邮箱。每次运行都会创建唯一收件人、按完整地址过滤，并只删除返回 ID。
+如果 SMTP 已接受邮件，但轮询请求在返回 ID 前失败，清理逻辑会使用该唯一收件人和精确
+主题重新查询，而不会删除无关邮件。
 完整模式见[集成测试](../../docs/zh-CN/Integration-Testing.md)与
 [测试配方](../../docs/zh-CN/Testing-Recipes.md)。
 

--- a/examples/testing/go/email_test.go
+++ b/examples/testing/go/email_test.go
@@ -38,7 +38,7 @@ func joinSMTPAddress(host, port string) string {
 	return net.JoinHostPort(host, port)
 }
 
-func sendSMTPMessage(address, from string, recipients []string, message []byte, timeout time.Duration) error {
+func sendSMTPMessage(address, from string, recipients []string, message []byte, timeout time.Duration, onAccepted func()) error {
 	host, _, err := net.SplitHostPort(address)
 	if err != nil {
 		return fmt.Errorf("parse SMTP address: %w", err)
@@ -78,6 +78,7 @@ func sendSMTPMessage(address, from string, recipients []string, message []byte, 
 	if err := writer.Close(); err != nil {
 		return fmt.Errorf("finish SMTP DATA: %w", err)
 	}
+	onAccepted()
 	if err := client.Quit(); err != nil {
 		return fmt.Errorf("quit SMTP session: %w", err)
 	}
@@ -98,6 +99,9 @@ func deleteEmail(client *http.Client, messageURL string) (err error) {
 		return fmt.Errorf("delete email: %w", err)
 	}
 	defer func() {
+		if _, drainErr := io.Copy(io.Discard, io.LimitReader(response.Body, 64<<10)); drainErr != nil {
+			err = errors.Join(err, fmt.Errorf("drain cleanup response: %w", drainErr))
+		}
 		if closeErr := response.Body.Close(); closeErr != nil {
 			err = errors.Join(err, fmt.Errorf("close cleanup response: %w", closeErr))
 		}
@@ -106,6 +110,57 @@ func deleteEmail(client *http.Client, messageURL string) (err error) {
 		return fmt.Errorf("delete email: unexpected status %d", response.StatusCode)
 	}
 	return nil
+}
+
+func findMatchingEmailIDs(client *http.Client, apiBase, recipient, subject string) (ids []string, err error) {
+	endpoint := apiBase + "/api/v1/emails?to=" + url.QueryEscape(recipient) + "&limit=10"
+	response, err := client.Get(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("list emails: %w", err)
+	}
+	defer func() {
+		if _, drainErr := io.Copy(io.Discard, io.LimitReader(response.Body, 64<<10)); drainErr != nil {
+			err = errors.Join(err, fmt.Errorf("drain email list response: %w", drainErr))
+		}
+		if closeErr := response.Body.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close email list response: %w", closeErr))
+		}
+	}()
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("list emails: unexpected status %d", response.StatusCode)
+	}
+	var page emailPage
+	if err := json.NewDecoder(response.Body).Decode(&page); err != nil {
+		return nil, fmt.Errorf("decode email list: %w", err)
+	}
+	for _, item := range page.Emails {
+		if item.Subject == subject {
+			ids = append(ids, item.ID)
+		}
+	}
+	return ids, nil
+}
+
+func cleanupCapturedEmail(client *http.Client, apiBase, recipient, subject, knownID string) error {
+	ids := []string{knownID}
+	if knownID == "" {
+		var err error
+		ids, err = findMatchingEmailIDs(client, apiBase, recipient, subject)
+		if err != nil {
+			return err
+		}
+	}
+	if len(ids) == 0 {
+		return fmt.Errorf("cleanup could not locate the accepted message for %s", recipient)
+	}
+	var cleanupErr error
+	for _, id := range ids {
+		messageURL := apiBase + "/api/v1/emails/" + url.PathEscape(id)
+		if err := deleteEmail(client, messageURL); err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
+		}
+	}
+	return cleanupErr
 }
 
 func TestCapturedEmail(t *testing.T) {
@@ -122,6 +177,17 @@ func TestCapturedEmail(t *testing.T) {
 	recipient := "signup+" + runID + "@example.test"
 	subject := "OwlMail integration " + runID
 	token := "token-" + runID
+	client := &http.Client{Timeout: 5 * time.Second}
+	accepted := false
+	var id string
+	t.Cleanup(func() {
+		if !accepted {
+			return
+		}
+		if err := cleanupCapturedEmail(client, apiBase, recipient, subject, id); err != nil {
+			t.Errorf("cleanup captured email: %v", err)
+		}
+	})
 	message := strings.Join([]string{
 		"From: sender@example.test",
 		"To: " + recipient,
@@ -136,34 +202,19 @@ func TestCapturedEmail(t *testing.T) {
 		[]string{recipient},
 		[]byte(message),
 		5*time.Second,
+		func() { accepted = true },
 	); err != nil {
 		t.Fatalf("send test email: %v", err)
 	}
 
-	client := &http.Client{Timeout: 5 * time.Second}
 	deadline := time.Now().Add(15 * time.Second)
-	var id string
 	for time.Now().Before(deadline) {
-		endpoint := apiBase + "/api/v1/emails?to=" + url.QueryEscape(recipient) + "&limit=10"
-		response, err := client.Get(endpoint)
+		ids, err := findMatchingEmailIDs(client, apiBase, recipient, subject)
 		if err != nil {
-			t.Fatalf("list emails: %v", err)
+			t.Fatalf("find email: %v", err)
 		}
-		var page emailPage
-		err = json.NewDecoder(response.Body).Decode(&page)
-		if closeErr := response.Body.Close(); closeErr != nil {
-			t.Fatalf("close email list response: %v", closeErr)
-		}
-		if err != nil || response.StatusCode != http.StatusOK {
-			t.Fatalf("decode email list: status=%d err=%v", response.StatusCode, err)
-		}
-		for _, item := range page.Emails {
-			if item.Subject == subject {
-				id = item.ID
-				break
-			}
-		}
-		if id != "" {
+		if len(ids) != 0 {
+			id = ids[0]
 			break
 		}
 		time.Sleep(200 * time.Millisecond)
@@ -173,11 +224,6 @@ func TestCapturedEmail(t *testing.T) {
 	}
 
 	messageURL := apiBase + "/api/v1/emails/" + url.PathEscape(id)
-	t.Cleanup(func() {
-		if err := deleteEmail(client, messageURL); err != nil {
-			t.Errorf("cleanup captured email: %v", err)
-		}
-	})
 	response, err := client.Get(messageURL)
 	if err != nil {
 		t.Fatalf("get email: %v", err)
@@ -224,6 +270,18 @@ type closeErrorBody struct{}
 
 func (closeErrorBody) Read([]byte) (int, error) { return 0, io.EOF }
 func (closeErrorBody) Close() error             { return errors.New("close failed") }
+
+type trackingBody struct {
+	reader *strings.Reader
+	reads  int
+}
+
+func (body *trackingBody) Read(buffer []byte) (int, error) {
+	body.reads++
+	return body.reader.Read(buffer)
+}
+
+func (*trackingBody) Close() error { return nil }
 
 func TestDeleteEmailReportsCleanupFailures(t *testing.T) {
 	tests := map[string]struct {
@@ -304,5 +362,51 @@ func TestDeleteEmailReportsCleanupFailures(t *testing.T) {
 				t.Fatalf("deleteEmail() error = %v, want substring %q", err, test.wantError)
 			}
 		})
+	}
+}
+
+func TestDeleteEmailDrainsNonSuccessResponse(t *testing.T) {
+	body := &trackingBody{reader: strings.NewReader("cleanup failure details")}
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusInternalServerError, Body: body}, nil
+	})}
+
+	err := deleteEmail(client, "http://owlmail.test/api/v1/emails/id")
+	if err == nil || !strings.Contains(err.Error(), "unexpected status 500") {
+		t.Fatalf("deleteEmail() error = %v", err)
+	}
+	if body.reads == 0 || body.reader.Len() != 0 {
+		t.Fatalf("error response body was not drained: reads=%d remaining=%d", body.reads, body.reader.Len())
+	}
+}
+
+func TestCleanupCapturedEmailFindsUnknownID(t *testing.T) {
+	var deletedPath string
+	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		switch request.Method {
+		case http.MethodGet:
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"emails":[{"id":"other-id","subject":"other"},{"id":"captured-id","subject":"subject"}]}`)),
+			}, nil
+		case http.MethodDelete:
+			deletedPath = request.URL.Path
+			return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+		default:
+			return nil, fmt.Errorf("unexpected method %s", request.Method)
+		}
+	})}
+
+	if err := cleanupCapturedEmail(
+		client,
+		"http://owlmail.test",
+		"recipient@example.test",
+		"subject",
+		"",
+	); err != nil {
+		t.Fatalf("cleanupCapturedEmail() error = %v", err)
+	}
+	if deletedPath != "/api/v1/emails/captured-id" {
+		t.Fatalf("deleted path = %q", deletedPath)
 	}
 }

--- a/examples/testing/javascript/api.mjs
+++ b/examples/testing/javascript/api.mjs
@@ -1,0 +1,76 @@
+const defaultTimeoutMs = 5_000;
+
+export function normalizeAPIBase(value) {
+  return value.replace(/\/+$/, "");
+}
+
+async function withTimeout(dependencies, operation) {
+  const fetchImpl = dependencies.fetchImpl || globalThis.fetch;
+  const timeoutMs = dependencies.timeoutMs || defaultTimeoutMs;
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(new Error(`HTTP request exceeded ${timeoutMs} ms`)),
+    timeoutMs,
+  );
+  try {
+    return await operation(fetchImpl, controller.signal);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function requestJSON(apiBase, path, options = {}, dependencies = {}) {
+  return withTimeout(dependencies, async (fetchImpl, signal) => {
+    const response = await fetchImpl(`${apiBase}${path}`, { ...options, signal });
+    const body = response.ok ? await response.json() : null;
+    if (!response.ok && response.body) await response.body.cancel();
+    return { response, body };
+  });
+}
+
+export async function requestStatus(apiBase, path, options = {}, dependencies = {}) {
+  return withTimeout(dependencies, async (fetchImpl, signal) => {
+    const response = await fetchImpl(
+      `${apiBase}${path}`,
+      { ...options, redirect: "manual", signal },
+    );
+    if (response.body) await response.body.cancel();
+    return response;
+  });
+}
+
+export async function findMatchingMessages(apiBase, recipient, subject, dependencies = {}) {
+  const query = new URLSearchParams({ to: recipient, limit: "10" });
+  const { response, body: page } = await requestJSON(
+    apiBase,
+    `/api/v1/emails?${query}`,
+    {},
+    dependencies,
+  );
+  if (!response.ok) throw new Error(`list failed: ${response.status}`);
+  return page.emails.filter((email) => email.subject === subject);
+}
+
+export async function cleanupCapturedEmail(
+  apiBase,
+  recipient,
+  subject,
+  knownID,
+  dependencies = {},
+) {
+  const ids = knownID
+    ? [knownID]
+    : (await findMatchingMessages(apiBase, recipient, subject, dependencies)).map((email) => email.id);
+  if (ids.length === 0) {
+    throw new Error(`cleanup could not locate the accepted message for ${recipient}`);
+  }
+  for (const id of ids) {
+    const response = await requestStatus(
+      apiBase,
+      `/api/v1/emails/${encodeURIComponent(id)}`,
+      { method: "DELETE" },
+      dependencies,
+    );
+    if (!response.ok) throw new Error(`cleanup failed: ${response.status}`);
+  }
+}

--- a/examples/testing/javascript/email-test.mjs
+++ b/examples/testing/javascript/email-test.mjs
@@ -1,10 +1,16 @@
 import assert from "node:assert/strict";
 import net from "node:net";
+import {
+  cleanupCapturedEmail,
+  findMatchingMessages,
+  normalizeAPIBase,
+  requestJSON,
+} from "./api.mjs";
 import { withCleanup } from "./cleanup.mjs";
 
 const smtpHost = process.env.TEST_SMTP_HOST || "127.0.0.1";
 const smtpPort = Number(process.env.TEST_SMTP_PORT || "1025");
-const apiBase = (process.env.TEST_MAIL_API || "http://127.0.0.1:1080").replace(/\/$/, "");
+const apiBase = normalizeAPIBase(process.env.TEST_MAIL_API || "http://127.0.0.1:1080");
 const runID = `${Date.now()}-${process.pid}`;
 const recipient = `signup+${runID}@example.test`;
 const subject = `OwlMail integration ${runID}`;
@@ -46,37 +52,7 @@ function lineReader(socket) {
   });
 }
 
-async function requestJSON(path, options = {}) {
-  const controller = new AbortController();
-  const timer = setTimeout(
-    () => controller.abort(new Error(`HTTP request exceeded ${ioTimeoutMs} ms`)),
-    ioTimeoutMs,
-  );
-  try {
-    const response = await fetch(`${apiBase}${path}`, { ...options, signal: controller.signal });
-    const body = response.ok ? await response.json() : null;
-    return { response, body };
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-async function requestStatus(path, options = {}) {
-  const controller = new AbortController();
-  const timer = setTimeout(
-    () => controller.abort(new Error(`HTTP request exceeded ${ioTimeoutMs} ms`)),
-    ioTimeoutMs,
-  );
-  try {
-    const response = await fetch(`${apiBase}${path}`, { ...options, signal: controller.signal });
-    await response.arrayBuffer();
-    return response;
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-async function sendMessage() {
+async function sendMessage(onAccepted) {
   const socket = net.createConnection({ host: smtpHost, port: smtpPort });
   const abortSMTP = () => {
     socket.destroy(new Error(`SMTP operation exceeded ${ioTimeoutMs} ms`));
@@ -118,6 +94,7 @@ async function sendMessage() {
       "",
     ].join("\r\n"));
     await reply(250);
+    onAccepted();
     await command("QUIT", 221);
   } finally {
     clearTimeout(deadline);
@@ -128,29 +105,32 @@ async function sendMessage() {
 async function waitForMessage() {
   const deadline = Date.now() + 15_000;
   while (Date.now() < deadline) {
-    const query = new URLSearchParams({ to: recipient, limit: "10" });
-    const { response, body: page } = await requestJSON(`/api/v1/emails?${query}`);
-    assert.equal(response.ok, true, `list failed: ${response.status}`);
-    const match = page.emails.find((email) => email.subject === subject);
+    const match = (await findMatchingMessages(apiBase, recipient, subject))[0];
     if (match) return match;
     await new Promise((resolve) => setTimeout(resolve, 200));
   }
   throw new Error(`timed out waiting for ${recipient}`);
 }
 
-await sendMessage();
-const summary = await waitForMessage();
-const messagePath = `/api/v1/emails/${encodeURIComponent(summary.id)}`;
+let accepted = false;
+let messageID = "";
 await withCleanup(
   async () => {
-    const { response: detailResponse, body: detail } = await requestJSON(messagePath);
+    await sendMessage(() => {
+      accepted = true;
+    });
+    const summary = await waitForMessage();
+    messageID = summary.id;
+    const messagePath = `/api/v1/emails/${encodeURIComponent(messageID)}`;
+    const { response: detailResponse, body: detail } = await requestJSON(apiBase, messagePath);
     assert.equal(detailResponse.ok, true, `detail failed: ${detailResponse.status}`);
     assert.equal(detail.subject, subject);
     assert.match(detail.text, new RegExp(token));
-    console.log(`verified OwlMail message ${summary.id}`);
+    console.log(`verified OwlMail message ${messageID}`);
   },
   async () => {
-    const deleteResponse = await requestStatus(messagePath, { method: "DELETE" });
-    assert.equal(deleteResponse.ok, true, `cleanup failed: ${deleteResponse.status}`);
+    if (accepted) {
+      await cleanupCapturedEmail(apiBase, recipient, subject, messageID);
+    }
   },
 );

--- a/examples/testing/python/email_cleanup_test.py
+++ b/examples/testing/python/email_cleanup_test.py
@@ -2,6 +2,7 @@ import io
 import json
 import types
 import unittest
+import urllib.error
 from unittest import mock
 
 from examples.testing.python import email_test as example
@@ -31,6 +32,65 @@ class SMTPClient:
 
 
 class CleanupTest(unittest.TestCase):
+    def test_delete_email_reports_non_success_status(self):
+        with mock.patch(
+            "examples.testing.python.email_test.urllib.request.urlopen",
+            return_value=Response(status=500),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "cleanup failed with HTTP status 500"):
+                example.delete_email("http://owlmail.test", "captured/id")
+
+    def test_delete_email_reports_transport_failure(self):
+        failure = urllib.error.URLError("connection lost")
+        with mock.patch(
+            "examples.testing.python.email_test.urllib.request.urlopen",
+            side_effect=failure,
+        ):
+            with self.assertRaises(urllib.error.URLError):
+                example.delete_email("http://owlmail.test", "captured-id")
+
+    def test_delete_email_does_not_accept_a_redirect(self):
+        redirect = urllib.error.HTTPError(
+            "http://owlmail.test/login", 302, "Found", {}, None
+        )
+        with mock.patch(
+            "examples.testing.python.email_test.urllib.request.urlopen",
+            side_effect=redirect,
+        ):
+            with self.assertRaises(urllib.error.HTTPError) as raised:
+                example.delete_email("http://owlmail.test", "captured-id")
+        self.assertEqual(raised.exception.code, 302)
+
+    def test_cleanup_discovers_an_accepted_message_without_a_known_id(self):
+        requests = []
+
+        def urlopen(request, timeout):
+            requests.append(request)
+            if hasattr(request, "get_method") and request.get_method() == "DELETE":
+                return Response(status=204)
+            return Response(json.dumps({
+                "emails": [
+                    {"id": "other-id", "subject": "other"},
+                    {"id": "captured/id", "subject": "subject"},
+                ],
+            }))
+
+        with mock.patch(
+            "examples.testing.python.email_test.urllib.request.urlopen",
+            side_effect=urlopen,
+        ):
+            example.cleanup_captured_email(
+                "http://owlmail.test",
+                "recipient@example.test",
+                "subject",
+                {"id": None},
+            )
+
+        self.assertEqual(len(requests), 2)
+        self.assertIn("to=recipient%40example.test", requests[0])
+        self.assertEqual(requests[1].get_method(), "DELETE")
+        self.assertTrue(requests[1].full_url.endswith("/captured%2Fid"))
+
     def test_cleanup_runs_after_an_assertion_failure(self):
         requests = []
 

--- a/examples/testing/python/email_test.py
+++ b/examples/testing/python/email_test.py
@@ -10,12 +10,38 @@ from email.message import EmailMessage
 
 
 def delete_email(api_base, email_id):
+    encoded_id = urllib.parse.quote(email_id, safe="")
     cleanup = urllib.request.Request(
-        f"{api_base}/api/v1/emails/{email_id}", method="DELETE"
+        f"{api_base}/api/v1/emails/{encoded_id}", method="DELETE"
     )
     with urllib.request.urlopen(cleanup, timeout=5) as response:
         if response.status >= 300:
             raise RuntimeError(f"cleanup failed with HTTP status {response.status}")
+
+
+def find_matching_email_ids(api_base, recipient, subject):
+    query = urllib.parse.urlencode({"to": recipient, "limit": 10})
+    with urllib.request.urlopen(
+        f"{api_base}/api/v1/emails?{query}", timeout=5
+    ) as response:
+        if response.status >= 300:
+            raise RuntimeError(f"list failed with HTTP status {response.status}")
+        page = json.load(response)
+    return [
+        item["id"] for item in page["emails"] if item["subject"] == subject
+    ]
+
+
+def cleanup_captured_email(api_base, recipient, subject, state):
+    email_ids = [state["id"]] if state["id"] else find_matching_email_ids(
+        api_base, recipient, subject
+    )
+    if not email_ids:
+        raise RuntimeError(
+            f"cleanup could not locate the accepted message for {recipient}"
+        )
+    for email_id in email_ids:
+        delete_email(api_base, email_id)
 
 
 class OwlMailIntegrationTest(unittest.TestCase):
@@ -33,8 +59,16 @@ class OwlMailIntegrationTest(unittest.TestCase):
         message["To"] = recipient
         message["Subject"] = subject
         message.set_content(f"Verification token: {token}")
+        cleanup_state = {"id": None}
         with smtplib.SMTP(smtp_host, smtp_port, timeout=5) as client:
             client.send_message(message)
+            self.addCleanup(
+                cleanup_captured_email,
+                api_base,
+                recipient,
+                subject,
+                cleanup_state,
+            )
 
         query = urllib.parse.urlencode({"to": recipient, "limit": 10})
         deadline = time.monotonic() + 15
@@ -52,8 +86,8 @@ class OwlMailIntegrationTest(unittest.TestCase):
             time.sleep(0.2)
         self.assertIsNotNone(found, f"timed out waiting for {recipient}")
 
+        cleanup_state["id"] = found["id"]
         email_id = urllib.parse.quote(found["id"], safe="")
-        self.addCleanup(delete_email, api_base, email_id)
         with urllib.request.urlopen(
             f"{api_base}/api/v1/emails/{email_id}", timeout=5
         ) as response:

--- a/tests/docs/integration-example-http.test.js
+++ b/tests/docs/integration-example-http.test.js
@@ -1,0 +1,68 @@
+const assert = require("node:assert/strict");
+const { test } = require("bun:test");
+
+test("JavaScript integration example removes every trailing API slash", async () => {
+  const { normalizeAPIBase } = await import("../../examples/testing/javascript/api.mjs");
+  assert.equal(normalizeAPIBase("http://owlmail.test///"), "http://owlmail.test");
+});
+
+test("JavaScript cleanup rejects redirects without buffering the response", async () => {
+  const { cleanupCapturedEmail } = await import("../../examples/testing/javascript/api.mjs");
+  let cancelled = false;
+  let options;
+  const fetchImpl = async (_url, requestOptions) => {
+    options = requestOptions;
+    return {
+      body: { cancel: async () => { cancelled = true; } },
+      ok: false,
+      status: 302,
+    };
+  };
+
+  await assert.rejects(
+    cleanupCapturedEmail(
+      "http://owlmail.test",
+      "recipient@example.test",
+      "subject",
+      "captured-id",
+      { fetchImpl },
+    ),
+    /cleanup failed: 302/,
+  );
+  assert.equal(options.method, "DELETE");
+  assert.equal(options.redirect, "manual");
+  assert.equal(cancelled, true);
+});
+
+test("JavaScript cleanup discovers an accepted message when its ID was not returned", async () => {
+  const { cleanupCapturedEmail } = await import("../../examples/testing/javascript/api.mjs");
+  const requests = [];
+  const fetchImpl = async (url, options) => {
+    requests.push({ url, options });
+    if (!options.method) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          emails: [
+            { id: "other-id", subject: "other" },
+            { id: "captured-id", subject: "subject" },
+          ],
+        }),
+      };
+    }
+    return { body: null, ok: true, status: 204 };
+  };
+
+  await cleanupCapturedEmail(
+    "http://owlmail.test",
+    "recipient@example.test",
+    "subject",
+    "",
+    { fetchImpl },
+  );
+  assert.equal(requests.length, 2);
+  assert.match(requests[0].url, /to=recipient%40example\.test/);
+  assert.equal(requests[1].url, "http://owlmail.test/api/v1/emails/captured-id");
+  assert.equal(requests[1].options.method, "DELETE");
+});

--- a/tests/docs/markdown.test.js
+++ b/tests/docs/markdown.test.js
@@ -870,7 +870,8 @@ test("0.8.0 examples are pinned, private by default, persistent, and bounded", (
 
   const javascript = fs.readFileSync(path.join(root, "examples/testing/javascript/email-test.mjs"), "utf8");
   assert.ok(javascript.includes("socket.setTimeout"));
-  assert.ok(javascript.includes("AbortController"));
+  const javascriptAPI = fs.readFileSync(path.join(root, "examples/testing/javascript/api.mjs"), "utf8");
+  assert.ok(javascriptAPI.includes("AbortController"));
   const goExample = fs.readFileSync(path.join(root, "examples/testing/go/email_test.go"), "utf8");
   assert.ok(goExample.includes("net.Dialer{Timeout:"));
   assert.ok(goExample.includes("SetDeadline"));


### PR DESCRIPTION
## Summary

- normalize JavaScript API bases with any number of trailing slashes
- reject cleanup redirects and cancel response streams instead of buffering complete bodies
- expand Python cleanup coverage for HTTP, redirect, transport, and fallback lookup failures
- drain bounded Go cleanup response bodies before closing them
- register cleanup as soon as SMTP accepts a message and re-query by the unique recipient plus exact subject when polling fails before returning an ID
- document the fallback cleanup boundary in both example guides

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `python3 -m unittest examples.testing.python.email_cleanup_test -v`
- live OwlMail smoke run of JavaScript, Python, and Go examples
- live JavaScript smoke run with `TEST_MAIL_API` containing three trailing slashes
- Node validation for manual redirect rejection and response cancellation

This covers audit items 1, 2, 3, 4, 5, and 8 as one lifecycle-focused change.