### PR TITLE
test(docs): cover every machine-facing API route

### DIFF
--- a/docs/en/API-Reference.md
+++ b/docs/en/API-Reference.md
@@ -210,6 +210,16 @@ MailDev facade continues to wait for its relay attempt.
 | `GET /api/v1/openapi.json` | base-path-aware OpenAPI 3.1 JSON contract |
 | `GET /api/v1/openapi.yaml` | base-path-aware OpenAPI 3.1 YAML contract |
 
+### Optional service endpoints
+
+These endpoints are registered only when their corresponding feature is
+enabled. They follow the configured base pathname and Web Basic Auth policy.
+
+| Method and path | Purpose |
+|---|---|
+| `GET /metrics` | Prometheus metrics when `-metrics-enabled` is set |
+| `ALL /mcp` | Streamable HTTP MCP transport when `-mcp-enabled` is set; the transport validates the allowed HTTP methods |
+
 Malformed WebSocket upgrade headers or handshake keys return a plain-text
 `400` response before a WebSocket connection is established.
 
@@ -418,7 +428,7 @@ follows OwlMail's base path and Web Basic Auth policy.
 | `GET /messages/:id.plain` | plain-text body |
 | `GET /messages/:id.source` | RFC 822 source |
 | `GET /messages/:id.eml` | downloadable RFC 822 message |
-| `GET /messages/:id/parts/:cid` | attachment or inline MIME part by content ID |
+| `GET /messages/:id/parts/*` | attachment or inline MIME part selected by the wildcard content ID path |
 | `DELETE /messages/:id` | delete one message |
 
 This is a REST migration aid. It does not emulate MailCatcher's WebSocket bus

--- a/docs/zh-CN/API-Reference.md
+++ b/docs/zh-CN/API-Reference.md
@@ -191,6 +191,16 @@ curl -u admin:secret http://localhost:1080/api/v1/openapi.yaml
 | `GET /api/v1/openapi.json` | 支持 base path 的 OpenAPI 3.1 JSON 合约 |
 | `GET /api/v1/openapi.yaml` | 支持 base path 的 OpenAPI 3.1 YAML 合约 |
 
+### 可选服务端点
+
+以下端点只在对应功能启用时注册，并跟随配置的基础路径和 Web Basic Auth
+策略。
+
+| 方法与路径 | 用途 |
+|---|---|
+| `GET /metrics` | 设置 `-metrics-enabled` 后提供 Prometheus 指标 |
+| `ALL /mcp` | 设置 `-mcp-enabled` 后提供 Streamable HTTP MCP Transport；由 Transport 校验允许的 HTTP 方法 |
+
 WebSocket upgrade header 或握手 key 格式错误时，会在建立 WebSocket 连接前返回
 纯文本 `400`。
 
@@ -366,7 +376,7 @@ Auth 策略。
 | `GET /messages/:id.plain` | 返回纯文本正文 |
 | `GET /messages/:id.source` | 返回 RFC 822 源码 |
 | `GET /messages/:id.eml` | 下载 RFC 822 邮件 |
-| `GET /messages/:id/parts/:cid` | 按内容 ID 返回附件或内联 MIME 部分 |
+| `GET /messages/:id/parts/*` | 使用通配内容 ID 路径返回附件或内联 MIME 部分 |
 | `DELETE /messages/:id` | 删除单封消息 |
 
 这是 REST 迁移辅助层，不模拟 MailCatcher 的 WebSocket 总线或整数 ID 分配；客户端应将

--- a/tests/docs/markdown.test.js
+++ b/tests/docs/markdown.test.js
@@ -224,10 +224,16 @@ function extractAPIRoutes() {
     path.join(root, "internal/api/api_maildev_compat.go"),
     "utf8",
   );
+  const mailCatcherCompatSource = fs.readFileSync(
+    path.join(root, "internal/api/api_mailcatcher_compat.go"),
+    "utf8",
+  );
   const sections = [
     source.slice(source.indexOf("func (api *API) setupImprovedAPIRoutes"), source.indexOf("// Start starts the API server")),
     source.slice(source.indexOf("func (api *API) setupMailDevCompatibleRoutes")),
     mailDevCompatSource.slice(mailDevCompatSource.indexOf("func (api *API) setupMailDevRESTCompatRoutes")),
+    mailCatcherCompatSource.slice(mailCatcherCompatSource.indexOf("func (api *API) setupMailCatcherRESTCompatRoutes")),
+    source.slice(source.indexOf("api.setupImprovedAPIRoutes(app)"), source.indexOf("// Browser UI and local help.")),
   ];
   const routes = [];
 
@@ -238,7 +244,7 @@ function extractAPIRoutes() {
       assert.ok(prefixes.has(parent), `unknown API route group ${parent}`);
       prefixes.set(name, prefixes.get(parent) + segment);
     }
-    for (const match of section.matchAll(/(\w+)\.(Get|Post|Put|Patch|Delete)\((?:api\.route\()?"([^"]*)"/g)) {
+    for (const match of section.matchAll(/(\w+)\.(Get|Post|Put|Patch|Delete|All)\((?:api\.route\()?"([^"]*)"/g)) {
       const [, group, method, route] = match;
       assert.ok(prefixes.has(group), `unknown API route group ${group}`);
       routes.push(`${method.toUpperCase()} ${prefixes.get(group)}${route}`);
@@ -398,7 +404,7 @@ test("security-sensitive SMTP authentication modes remain explicit", () => {
   }
 });
 
-test("English and Chinese API references cover every registered API route", () => {
+test("English and Chinese API references cover every registered machine-facing route", () => {
   const routes = extractAPIRoutes();
   assert.ok(routes.length > 0, "no API routes found");
 


### PR DESCRIPTION
## Summary

- include the optional MailCatcher compatibility surface in route extraction
- include standalone `/metrics` and all-method `/mcp` registrations
- teach the route extractor about Fiber `.All(...)` registrations
- document both optional service endpoints in English and Chinese
- align the MailCatcher wildcard attachment path with the registered route

## Validation

- complete documentation contract suite executed with a Node test harness
- `git diff --check`

This fixes the incomplete API route coverage identified in audit item 6.