### PR TITLE
ci: avoid full checks for badge-only pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [ main, develop ]
+    paths-ignore:
+      - '.github/goreportcard.svg'
   pull_request:
     branches: [ main, develop ]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ All notable changes to OwlMail are documented in this file. The format follows
   mail directory, pin the 0.8.0 source and Go installs, and use executable CI
   commands with bounded network waits.
 - The Go Report Card workflow no longer replaces its stable documentation page
-  with line-number output or suppresses CI on badge-only commits.
+  with line-number output. The CI push trigger explicitly excludes the generated
+  badge so future token changes cannot repeat the full test, lint, vet, and build
+  jobs, while pull request validation remains unchanged.
 - Relay persistence documentation now states that it requires a configured mail
   directory and applies to native asynchronous relay jobs.
 

--- a/tests/docs/markdown.test.js
+++ b/tests/docs/markdown.test.js
@@ -813,6 +813,13 @@ test("release history and generated reports avoid stale documentation", () => {
   assert.ok(workflow.includes('version: "v1.0.0"'));
   assert.ok(workflow.includes("git add .github/goreportcard.svg"));
   assert.ok(!workflow.includes("[skip ci]"));
+
+  const ciWorkflow = fs.readFileSync(path.join(root, ".github/workflows/ci.yml"), "utf8");
+  const pushTrigger = ciWorkflow.slice(ciWorkflow.indexOf("  push:"), ciWorkflow.indexOf("  pull_request:"));
+  const pullRequestTrigger = ciWorkflow.slice(ciWorkflow.indexOf("  pull_request:"), ciWorkflow.indexOf("\nconcurrency:"));
+  assert.ok(pushTrigger.includes("paths-ignore:"));
+  assert.ok(pushTrigger.includes("'.github/goreportcard.svg'"));
+  assert.ok(!pullRequestTrigger.includes("paths-ignore:"));
 });
 
 test("0.8.0 examples are pinned, private by default, persistent, and bounded", () => {


### PR DESCRIPTION
## Summary

- explicitly ignore `.github/goreportcard.svg` in the CI workflow's push trigger
- keep pull request validation unchanged, including badge-only PRs
- avoid adding a PAT or GitHub App credential: the current repository `GITHUB_TOKEN` already suppresses downstream workflow events
- preserve the path filter as defense in depth if the badge workflow later changes authentication
- add a documentation contract test that distinguishes push and pull-request behavior

## Validation

- parsed the resulting workflow YAML
- ran the complete documentation contract suite with a Node test harness
- rebased onto the latest `main`
- `git diff --check`

This completes audit item 7 without reintroducing `[skip ci]` or expanding workflow permissions.