### PR TITLE
fix(docs): document concrete MCP HTTP methods

### DIFF
--- a/docs/en/API-Reference.md
+++ b/docs/en/API-Reference.md
@@ -218,7 +218,9 @@ enabled. They follow the configured base pathname and Web Basic Auth policy.
 | Method and path | Purpose |
 |---|---|
 | `GET /metrics` | Prometheus metrics when `-metrics-enabled` is set |
-| `ALL /mcp` | Streamable HTTP MCP transport when `-mcp-enabled` is set; the transport validates the allowed HTTP methods |
+| `GET /mcp` | Open the optional standalone SSE stream for the MCP Streamable HTTP transport |
+| `POST /mcp` | Send MCP JSON-RPC messages over the Streamable HTTP transport |
+| `DELETE /mcp` | Terminate an MCP Streamable HTTP session |
 
 Malformed WebSocket upgrade headers or handshake keys return a plain-text
 `400` response before a WebSocket connection is established.

--- a/docs/zh-CN/API-Reference.md
+++ b/docs/zh-CN/API-Reference.md
@@ -199,7 +199,9 @@ curl -u admin:secret http://localhost:1080/api/v1/openapi.yaml
 | 方法与路径 | 用途 |
 |---|---|
 | `GET /metrics` | 设置 `-metrics-enabled` 后提供 Prometheus 指标 |
-| `ALL /mcp` | 设置 `-mcp-enabled` 后提供 Streamable HTTP MCP Transport；由 Transport 校验允许的 HTTP 方法 |
+| `GET /mcp` | 打开 MCP Streamable HTTP Transport 可选的独立 SSE 流 |
+| `POST /mcp` | 通过 Streamable HTTP Transport 发送 MCP JSON-RPC 消息 |
+| `DELETE /mcp` | 终止 MCP Streamable HTTP 会话 |
 
 WebSocket upgrade header 或握手 key 格式错误时，会在建立 WebSocket 连接前返回
 纯文本 `400`。

--- a/tests/docs/markdown.test.js
+++ b/tests/docs/markdown.test.js
@@ -236,6 +236,9 @@ function extractAPIRoutes() {
     source.slice(source.indexOf("api.setupImprovedAPIRoutes(app)"), source.indexOf("// Browser UI and local help.")),
   ];
   const routes = [];
+  const allMethodContracts = new Map([
+    ["/mcp", ["GET", "POST", "DELETE"]],
+  ]);
 
   for (const section of sections) {
     const prefixes = new Map([["app", ""]]);
@@ -247,7 +250,10 @@ function extractAPIRoutes() {
     for (const match of section.matchAll(/(\w+)\.(Get|Post|Put|Patch|Delete|All)\((?:api\.route\()?"([^"]*)"/g)) {
       const [, group, method, route] = match;
       assert.ok(prefixes.has(group), `unknown API route group ${group}`);
-      routes.push(`${method.toUpperCase()} ${prefixes.get(group)}${route}`);
+      const fullRoute = `${prefixes.get(group)}${route}`;
+      const methods = method === "All" ? allMethodContracts.get(fullRoute) : [method.toUpperCase()];
+      assert.ok(methods, `missing public HTTP method contract for All ${fullRoute}`);
+      for (const publicMethod of methods) routes.push(`${publicMethod} ${fullRoute}`);
     }
   }
 


### PR DESCRIPTION
## Summary

- replace the framework-only `ALL /mcp` notation with the concrete `GET`, `POST`, and `DELETE` methods supported by the MCP Streamable HTTP transport
- map Fiber `.All(...)` registrations to an explicit public method contract in the documentation test
- make any future `.All(...)` route fail the contract test until its actual public methods are declared
- update the English and Chinese API references

## Validation

- complete documentation contract suite executed with a Node test harness
- `git diff --check`

Follow-up to the review on #120, which was merged before that review completed.