### PR TITLE
docs: move security policies into .github

### DIFF
--- a/.github/SECURITY.de.md
+++ b/.github/SECURITY.de.md
@@ -1,14 +1,18 @@
 # Sicherheitsrichtlinie
 
+## Languages / 语言 / Sprachen / Langues / Lingue / 言語 / 언어
+
+[English](SECURITY.md) | [简体中文](SECURITY.zh-CN.md) | [Deutsch](SECURITY.de.md) | [Français](SECURITY.fr.md) | [Italiano](SECURITY.it.md) | [日本語](SECURITY.ja.md) | [한국어](SECURITY.ko.md)
+
 ## Unterstützte Versionen
 
 Wir bieten derzeit Sicherheitsupdates für die folgenden Versionen:
 
 | Version | Unterstützt |
 |---------|-------------|
+| 0.9.x | ✅ Ja |
 | 0.8.x | ✅ Ja |
-| 0.7.x | ✅ Ja |
-| 0.6.x und älter | ❌ Nein |
+| 0.7.x und älter | ❌ Nein |
 
 ## Meldung einer Sicherheitslücke
 

--- a/.github/SECURITY.fr.md
+++ b/.github/SECURITY.fr.md
@@ -1,14 +1,18 @@
 # Politique de Sécurité
 
+## Languages / 语言 / Sprachen / Langues / Lingue / 言語 / 언어
+
+[English](SECURITY.md) | [简体中文](SECURITY.zh-CN.md) | [Deutsch](SECURITY.de.md) | [Français](SECURITY.fr.md) | [Italiano](SECURITY.it.md) | [日本語](SECURITY.ja.md) | [한국어](SECURITY.ko.md)
+
 ## Versions Prise en Charge
 
 Nous fournissons actuellement des mises à jour de sécurité pour les versions suivantes :
 
 | Version | Prise en charge |
 |---------|-----------------|
+| 0.9.x | ✅ Oui |
 | 0.8.x | ✅ Oui |
-| 0.7.x | ✅ Oui |
-| 0.6.x et antérieures | ❌ Non |
+| 0.7.x et antérieures | ❌ Non |
 
 ## Signaler une Vulnérabilité
 

--- a/.github/SECURITY.it.md
+++ b/.github/SECURITY.it.md
@@ -1,14 +1,18 @@
 # Politica di Sicurezza
 
+## Languages / 语言 / Sprachen / Langues / Lingue / 言語 / 언어
+
+[English](SECURITY.md) | [简体中文](SECURITY.zh-CN.md) | [Deutsch](SECURITY.de.md) | [Français](SECURITY.fr.md) | [Italiano](SECURITY.it.md) | [日本語](SECURITY.ja.md) | [한국어](SECURITY.ko.md)
+
 ## Versioni Supportate
 
 Attualmente forniamo aggiornamenti di sicurezza per le seguenti versioni:
 
 | Versione | Supportata |
 |----------|------------|
+| 0.9.x | ✅ Sì |
 | 0.8.x | ✅ Sì |
-| 0.7.x | ✅ Sì |
-| 0.6.x e precedenti | ❌ No |
+| 0.7.x e precedenti | ❌ No |
 
 ## Segnalazione di una Vulnerabilità
 

--- a/.github/SECURITY.ja.md
+++ b/.github/SECURITY.ja.md
@@ -1,14 +1,18 @@
 # セキュリティポリシー
 
+## Languages / 语言 / Sprachen / Langues / Lingue / 言語 / 언어
+
+[English](SECURITY.md) | [简体中文](SECURITY.zh-CN.md) | [Deutsch](SECURITY.de.md) | [Français](SECURITY.fr.md) | [Italiano](SECURITY.it.md) | [日本語](SECURITY.ja.md) | [한국어](SECURITY.ko.md)
+
 ## サポートされているバージョン
 
 現在、以下のバージョンに対してセキュリティアップデートを提供しています：
 
 | バージョン | サポート |
 |-----------|---------|
+| 0.9.x | ✅ はい |
 | 0.8.x | ✅ はい |
-| 0.7.x | ✅ はい |
-| 0.6.x 以前 | ❌ いいえ |
+| 0.7.x 以前 | ❌ いいえ |
 
 ## 脆弱性の報告
 

--- a/.github/SECURITY.ko.md
+++ b/.github/SECURITY.ko.md
@@ -1,14 +1,18 @@
 # 보안 정책
 
+## Languages / 语言 / Sprachen / Langues / Lingue / 言語 / 언어
+
+[English](SECURITY.md) | [简体中文](SECURITY.zh-CN.md) | [Deutsch](SECURITY.de.md) | [Français](SECURITY.fr.md) | [Italiano](SECURITY.it.md) | [日本語](SECURITY.ja.md) | [한국어](SECURITY.ko.md)
+
 ## 지원되는 버전
 
 현재 다음 버전에 대한 보안 업데이트를 제공합니다:
 
 | 버전 | 지원 여부 |
 |------|----------|
+| 0.9.x | ✅ 예 |
 | 0.8.x | ✅ 예 |
-| 0.7.x | ✅ 예 |
-| 0.6.x 이하 | ❌ 아니오 |
+| 0.7.x 이하 | ❌ 아니오 |
 
 ## 취약점 보고
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,14 +1,18 @@
 # Security Policy
 
+## Languages / 语言 / Sprachen / Langues / Lingue / 言語 / 언어
+
+[English](SECURITY.md) | [简体中文](SECURITY.zh-CN.md) | [Deutsch](SECURITY.de.md) | [Français](SECURITY.fr.md) | [Italiano](SECURITY.it.md) | [日本語](SECURITY.ja.md) | [한국어](SECURITY.ko.md)
+
 ## Supported Versions
 
 We currently provide security updates for the following versions:
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.9.x | ✅ Yes |
 | 0.8.x | ✅ Yes |
-| 0.7.x | ✅ Yes |
-| 0.6.x and older | ❌ No |
+| 0.7.x and older | ❌ No |
 
 ## Reporting a Vulnerability
 

--- a/.github/SECURITY.zh-CN.md
+++ b/.github/SECURITY.zh-CN.md
@@ -1,14 +1,18 @@
 # 安全策略
 
+## Languages / 语言 / Sprachen / Langues / Lingue / 言語 / 언어
+
+[English](SECURITY.md) | [简体中文](SECURITY.zh-CN.md) | [Deutsch](SECURITY.de.md) | [Français](SECURITY.fr.md) | [Italiano](SECURITY.it.md) | [日本語](SECURITY.ja.md) | [한국어](SECURITY.ko.md)
+
 ## 支持的版本
 
 我们目前支持以下版本的安全更新：
 
 | 版本 | 支持状态 |
 | ---- | -------- |
+| 0.9.x | ✅ 支持 |
 | 0.8.x | ✅ 支持 |
-| 0.7.x | ✅ 支持 |
-| 0.6.x 及更早版本 | ❌ 不支持 |
+| 0.7.x 及更早版本 | ❌ 不支持 |
 
 ## 报告安全漏洞
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to OwlMail are documented in this file. The format follows
 
 ## [Unreleased]
 
+### Changed
+
+- Security policies now live with the other GitHub community health files in
+  `.github`, provide navigation across all seven translations, and document
+  support for the current `0.9.x` and previous `0.8.x` release series.
+
 ## [0.9.0] - 2026-09-03
 
 ### Added

--- a/docs/en/Security-Model.md
+++ b/docs/en/Security-Model.md
@@ -65,7 +65,7 @@ errors are bounded and do not expose raw downstream errors through status.
 - Separate test data from production accounts and infrastructure.
 - Pin the release image by manifest digest for sensitive CI.
 - Back up the complete mail directory before upgrades.
-- Review [SECURITY.md](../../SECURITY.md) before reporting a vulnerability; use
+- Review [SECURITY.md](../../.github/SECURITY.md) before reporting a vulnerability; use
   a private advisory or the documented security email, not a public Issue.
 
 Configuration details are in [Operations](./Operations.md); exact API auth and

--- a/docs/zh-CN/Security-Model.md
+++ b/docs/zh-CN/Security-Model.md
@@ -54,7 +54,7 @@ Agent 必须把邮件内容视为数据而非指令。邮件内嵌的 Prompt 不
 - 测试数据与生产账户、生产基础设施隔离。
 - 安全敏感 CI 按 manifest digest 固定发布镜像。
 - 升级前备份完整邮件目录。
-- 漏洞报告前阅读 [SECURITY.zh-CN.md](../../SECURITY.zh-CN.md)，通过私有 Advisory
+- 漏洞报告前阅读 [SECURITY.zh-CN.md](../../.github/SECURITY.zh-CN.md)，通过私有 Advisory
   或安全邮箱提交，不要创建公开 Issue。
 
 配置细节见[运维与排障](./Operations.md)，API 认证与 Origin 行为见

--- a/tests/docs/markdown.test.js
+++ b/tests/docs/markdown.test.js
@@ -17,6 +17,15 @@ const translatedReadmes = [
   "README.ja.md",
   "README.ko.md",
 ];
+const securityFiles = [
+  "SECURITY.md",
+  "SECURITY.zh-CN.md",
+  "SECURITY.de.md",
+  "SECURITY.fr.md",
+  "SECURITY.it.md",
+  "SECURITY.ja.md",
+  "SECURITY.ko.md",
+];
 
 test("current documentation version is a semantic version", () => {
   assert.match(
@@ -804,6 +813,17 @@ test("GitHub community files match repository features and supported conventions
     assert.ok(pullRequest.includes(command), `pull request template is missing ${command}`);
   }
 
+  for (const security of securityFiles) {
+    assert.ok(!fs.existsSync(path.join(root, security)), `${security} should not remain in the repository root`);
+    const markdown = fs.readFileSync(path.join(root, ".github", security), "utf8");
+    for (const translatedSecurity of securityFiles) {
+      assert.ok(markdown.includes(`](${translatedSecurity})`), `${security} does not link ${translatedSecurity}`);
+    }
+    for (const marker of ["0.9.x", "0.8.x", "0.7.x"]) {
+      assert.ok(markdown.includes(marker), `${security} is missing ${marker}`);
+    }
+  }
+
   for (const locale of ["de", "fr", "it", "ja", "ko"]) {
     const contributing = fs.readFileSync(path.join(root, `.github/CONTRIBUTING.${locale}.md`), "utf8");
     const conduct = fs.readFileSync(path.join(root, `.github/CODE_OF_CONDUCT.${locale}.md`), "utf8");
@@ -812,15 +832,9 @@ test("GitHub community files match repository features and supported conventions
     assert.ok(contributing.includes("CONTRIBUTING.md"), `${locale} contribution summary lacks canonical link`);
     assert.ok(conduct.includes("CODE_OF_CONDUCT.md"), `${locale} conduct summary lacks canonical link`);
 
-    const security = fs.readFileSync(path.join(root, `SECURITY.${locale}.md`), "utf8");
-    for (const marker of ["0.8.x", "0.7.x", "0.6.x", "srcdoc", 'referrerpolicy="no-referrer"', "CSP", "CID"]) {
+    const security = fs.readFileSync(path.join(root, `.github/SECURITY.${locale}.md`), "utf8");
+    for (const marker of ["srcdoc", 'referrerpolicy="no-referrer"', "CSP", "CID"]) {
       assert.ok(security.includes(marker), `SECURITY.${locale}.md is missing ${marker}`);
-    }
-  }
-  for (const security of ["SECURITY.md", "SECURITY.zh-CN.md"]) {
-    const markdown = fs.readFileSync(path.join(root, security), "utf8");
-    for (const marker of ["0.8.x", "0.7.x", "0.6.x"]) {
-      assert.ok(markdown.includes(marker), `${security} is missing ${marker}`);
     }
   }
 });


### PR DESCRIPTION
## Summary

- move the canonical and six translated security policies from the repository root into `.github`, alongside the other community health files
- add direct navigation between all seven security-policy translations
- update the supported-version matrix for the current `0.9.x` and previous `0.8.x` release series
- update the English and Chinese security-model references to the new locations
- strengthen documentation tests so security policies cannot drift back to the root and every translation must link to every other translation
- record the documentation change under `Unreleased`

GitHub recognizes `.github/SECURITY.md` as the repository security policy, so the platform Security policy and Community Standards entry points remain intact.

## Validation

- `bun test ./tests/web ./tests/docs` — 105 passed
- `git diff --check`
- the existing repository-wide Markdown test verified balanced fences, every local file target, and every Markdown anchor