### PR TITLE
docs: keep security language links valid

### DIFF
--- a/.github/SECURITY.de.md
+++ b/.github/SECURITY.de.md
@@ -2,7 +2,7 @@
 
 ## Languages / 语言 / Sprachen / Langues / Lingue / 言語 / 언어
 
-[English](SECURITY.md) | [简体中文](SECURITY.zh-CN.md) | [Deutsch](SECURITY.de.md) | [Français](SECURITY.fr.md) | [Italiano](SECURITY.it.md) | [日本語](SECURITY.ja.md) | [한국어](SECURITY.ko.md)
+[English](https://github.com/soulteary/owlmail/security/policy) | [简体中文](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.zh-CN.md) | [Deutsch](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.de.md) | [Français](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.fr.md) | [Italiano](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.it.md) | [日本語](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.ja.md) | [한국어](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.ko.md)
 
 ## Unterstützte Versionen
 

--- a/.github/SECURITY.fr.md
+++ b/.github/SECURITY.fr.md
@@ -2,7 +2,7 @@
 
 ## Languages / 语言 / Sprachen / Langues / Lingue / 言語 / 언어
 
-[English](SECURITY.md) | [简体中文](SECURITY.zh-CN.md) | [Deutsch](SECURITY.de.md) | [Français](SECURITY.fr.md) | [Italiano](SECURITY.it.md) | [日本語](SECURITY.ja.md) | [한국어](SECURITY.ko.md)
+[English](https://github.com/soulteary/owlmail/security/policy) | [简体中文](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.zh-CN.md) | [Deutsch](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.de.md) | [Français](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.fr.md) | [Italiano](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.it.md) | [日本語](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.ja.md) | [한국어](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.ko.md)
 
 ## Versions Prise en Charge
 

--- a/.github/SECURITY.it.md
+++ b/.github/SECURITY.it.md
@@ -2,7 +2,7 @@
 
 ## Languages / 语言 / Sprachen / Langues / Lingue / 言語 / 언어
 
-[English](SECURITY.md) | [简体中文](SECURITY.zh-CN.md) | [Deutsch](SECURITY.de.md) | [Français](SECURITY.fr.md) | [Italiano](SECURITY.it.md) | [日本語](SECURITY.ja.md) | [한국어](SECURITY.ko.md)
+[English](https://github.com/soulteary/owlmail/security/policy) | [简体中文](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.zh-CN.md) | [Deutsch](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.de.md) | [Français](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.fr.md) | [Italiano](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.it.md) | [日本語](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.ja.md) | [한국어](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.ko.md)
 
 ## Versioni Supportate
 

--- a/.github/SECURITY.ja.md
+++ b/.github/SECURITY.ja.md
@@ -2,7 +2,7 @@
 
 ## Languages / 语言 / Sprachen / Langues / Lingue / 言語 / 언어
 
-[English](SECURITY.md) | [简体中文](SECURITY.zh-CN.md) | [Deutsch](SECURITY.de.md) | [Français](SECURITY.fr.md) | [Italiano](SECURITY.it.md) | [日本語](SECURITY.ja.md) | [한국어](SECURITY.ko.md)
+[English](https://github.com/soulteary/owlmail/security/policy) | [简体中文](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.zh-CN.md) | [Deutsch](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.de.md) | [Français](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.fr.md) | [Italiano](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.it.md) | [日本語](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.ja.md) | [한국어](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.ko.md)
 
 ## サポートされているバージョン
 

--- a/.github/SECURITY.ko.md
+++ b/.github/SECURITY.ko.md
@@ -2,7 +2,7 @@
 
 ## Languages / 语言 / Sprachen / Langues / Lingue / 言語 / 언어
 
-[English](SECURITY.md) | [简体中文](SECURITY.zh-CN.md) | [Deutsch](SECURITY.de.md) | [Français](SECURITY.fr.md) | [Italiano](SECURITY.it.md) | [日本語](SECURITY.ja.md) | [한국어](SECURITY.ko.md)
+[English](https://github.com/soulteary/owlmail/security/policy) | [简体中文](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.zh-CN.md) | [Deutsch](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.de.md) | [Français](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.fr.md) | [Italiano](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.it.md) | [日本語](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.ja.md) | [한국어](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.ko.md)
 
 ## 지원되는 버전
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Languages / 语言 / Sprachen / Langues / Lingue / 言語 / 언어
 
-[English](SECURITY.md) | [简体中文](SECURITY.zh-CN.md) | [Deutsch](SECURITY.de.md) | [Français](SECURITY.fr.md) | [Italiano](SECURITY.it.md) | [日本語](SECURITY.ja.md) | [한국어](SECURITY.ko.md)
+[English](https://github.com/soulteary/owlmail/security/policy) | [简体中文](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.zh-CN.md) | [Deutsch](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.de.md) | [Français](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.fr.md) | [Italiano](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.it.md) | [日本語](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.ja.md) | [한국어](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.ko.md)
 
 ## Supported Versions
 

--- a/.github/SECURITY.zh-CN.md
+++ b/.github/SECURITY.zh-CN.md
@@ -2,7 +2,7 @@
 
 ## Languages / 语言 / Sprachen / Langues / Lingue / 言語 / 언어
 
-[English](SECURITY.md) | [简体中文](SECURITY.zh-CN.md) | [Deutsch](SECURITY.de.md) | [Français](SECURITY.fr.md) | [Italiano](SECURITY.it.md) | [日本語](SECURITY.ja.md) | [한국어](SECURITY.ko.md)
+[English](https://github.com/soulteary/owlmail/security/policy) | [简体中文](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.zh-CN.md) | [Deutsch](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.de.md) | [Français](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.fr.md) | [Italiano](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.it.md) | [日本語](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.ja.md) | [한국어](https://github.com/soulteary/owlmail/blob/main/.github/SECURITY.ko.md)
 
 ## 支持的版本
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ All notable changes to OwlMail are documented in this file. The format follows
 ### Changed
 
 - Security policies now live with the other GitHub community health files in
-  `.github`, provide navigation across all seven translations, and document
-  support for the current `0.9.x` and previous `0.8.x` release series.
+  `.github`, provide navigation across all seven translations from both file
+  views and GitHub's Security policy view, and document support for the current
+  `0.9.x` and previous `0.8.x` release series.
 
 ## [0.9.0] - 2026-09-03
 

--- a/tests/docs/markdown.test.js
+++ b/tests/docs/markdown.test.js
@@ -26,6 +26,8 @@ const securityFiles = [
   "SECURITY.ja.md",
   "SECURITY.ko.md",
 ];
+const securityPolicyURL = "https://github.com/soulteary/owlmail/security/policy";
+const securityTranslationBaseURL = "https://github.com/soulteary/owlmail/blob/main/.github/";
 
 test("current documentation version is a semantic version", () => {
   assert.match(
@@ -817,10 +819,20 @@ test("GitHub community files match repository features and supported conventions
     assert.ok(!fs.existsSync(path.join(root, security)), `${security} should not remain in the repository root`);
     const markdown = fs.readFileSync(path.join(root, ".github", security), "utf8");
     for (const translatedSecurity of securityFiles) {
-      assert.ok(markdown.includes(`](${translatedSecurity})`), `${security} does not link ${translatedSecurity}`);
+      const destination = translatedSecurity === "SECURITY.md"
+        ? securityPolicyURL
+        : `${securityTranslationBaseURL}${translatedSecurity}`;
+      assert.ok(markdown.includes(`](${destination})`), `${security} does not link ${destination}`);
     }
     for (const marker of ["0.9.x", "0.8.x", "0.7.x"]) {
       assert.ok(markdown.includes(marker), `${security} is missing ${marker}`);
+    }
+  }
+
+  for (const readme of translatedReadmes) {
+    const markdown = fs.readFileSync(path.join(root, readme), "utf8");
+    for (const translatedReadme of translatedReadmes) {
+      assert.ok(markdown.includes(`](${translatedReadme})`), `${readme} does not link ${translatedReadme}`);
     }
   }
 


### PR DESCRIPTION
## Summary

- replace relative security-policy language links with stable GitHub destinations
- keep English on GitHub's canonical Security policy view and point translations at their files under `.github`
- verify every root README continues to link to all seven README translations
- add regression coverage for both README navigation and Security policy special-view navigation
- clarify the `Unreleased` changelog entry

## Root cause

GitHub renders `.github/SECURITY.md` at `/security/policy`, but resolves a relative link such as `SECURITY.zh-CN.md` to `blob/main/SECURITY.zh-CN.md` at the repository root. After PR #126 moved the files, those generated links returned “File not found.”

## Validation

- opened all seven README destinations and all seven corrected Security policy destinations on GitHub
- `bun test ./tests/web ./tests/docs` — 105 passed
- `git diff --check`
- repository-wide Markdown file and anchor validation passed